### PR TITLE
Split out `Circuit` type from `Navigator`

### DIFF
--- a/circuit/build.gradle.kts
+++ b/circuit/build.gradle.kts
@@ -1,16 +1,10 @@
 plugins {
   id("com.android.library")
   kotlin("android")
-  id("com.squareup.anvil")
 }
 
 if (hasProperty("SlackRepositoryUrl")) {
   apply(plugin = "com.vanniktech.maven.publish")
-}
-
-anvil {
-  generateDaggerFactories.set(true)
-  generateDaggerFactoriesOnly.set(true)
 }
 
 android {
@@ -20,7 +14,6 @@ android {
 dependencies {
   api(libs.androidx.compose.integration.viewModel)
   api(libs.androidx.compose.integration.activity)
-  api(libs.dagger)
   api(libs.bundles.compose)
   api(projects.backstack)
   testImplementation(libs.junit)

--- a/circuit/src/main/kotlin/com/slack/circuit/Circuit+Navigator.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Circuit+Navigator.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import android.os.Parcelable
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import com.slack.circuit.backstack.BackStack
+import com.slack.circuit.backstack.NavigatorDefaults
+import com.slack.circuit.backstack.NavigatorRouteDecoration
+import com.slack.circuit.backstack.ProvidedValues
+import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.backstack.isAtRoot
+import com.slack.circuit.backstack.providedValuesForBackStack
+import com.slack.circuit.backstack.rememberSaveableBackStack
+
+/**
+ * Returns a new [Navigator] that is backed by this [Circuit] instance.
+ *
+ * @param contentContainer The [ContentContainer] to render into.
+ * @param onRootPop The [OnPopHandler] to handle root [Navigator.pop] calls.
+ */
+// TODO should we try to make a composable rememberNavigator() function here too?
+fun Circuit.navigator(contentContainer: ContentContainer, onRootPop: OnPopHandler?): Navigator {
+  return CircuitNavigator(this, contentContainer, onRootPop)
+}
+
+internal class CircuitNavigator(
+  val circuit: Circuit,
+  val contentContainer: ContentContainer,
+  val onRootPop: OnPopHandler?,
+) : Navigator {
+
+  override fun goTo(screen: Screen) {
+    // Headless? - MutableStateFlow and launch
+    // Testing - molecule to convert it to a Flow, then plumb into Turbine and treat it as a
+    // coroutines test. Don't ever use Dispatchers default/io in tests
+    contentContainer.render {
+      val backstack = rememberSaveableBackStack { push(screen) }
+      val goTo: (Screen) -> Unit = { screen -> backstack.push(screen) }
+      val navigator =
+        object : Navigator {
+          override fun goTo(screen: Screen) {
+            goTo(screen)
+          }
+
+          override fun pop(): Screen? {
+            return if (!backstack.isAtRoot) {
+              backstack.pop()?.screen
+            } else {
+              this@CircuitNavigator.pop()
+              null
+            }
+          }
+        }
+      FactoryNavigator(circuit, backstack, navigator, contentContainer)
+    }
+  }
+
+  override fun pop(): Screen? {
+    onRootPop?.onPop()
+    return null
+  }
+}
+
+@JvmInline
+private value class UiStateRenderer<UiState, UiEvent : Any>(val ui: Ui<UiState, UiEvent>) :
+  StateRenderer<UiState, UiEvent> where UiState : Any, UiState : Parcelable {
+  @Composable
+  override fun render(state: UiState, uiEvents: (UiEvent) -> Unit) {
+    ui.render(state, uiEvents)
+  }
+}
+
+@Composable
+internal fun <R : BackStack.Record> FactoryNavigator(
+  circuit: Circuit,
+  backStack: BackStack<R>,
+  navigator: Navigator,
+  container: ContentContainer,
+  modifier: Modifier = Modifier,
+  enableBackHandler: Boolean = true,
+  providedValues: Map<R, ProvidedValues> = providedValuesForBackStack(backStack),
+  decoration: NavigatorRouteDecoration = NavigatorDefaults.DefaultDecoration,
+  unavailableRoute: @Composable (String) -> Unit = NavigatorDefaults.UnavailableRoute,
+) {
+  BackHandler(enabled = enableBackHandler && !backStack.isAtRoot) { backStack.pop() }
+
+  BasicFactoryNavigator(
+    circuit = circuit,
+    backStack = backStack,
+    navigator = navigator,
+    container = container,
+    providedValues = providedValues,
+    modifier = modifier,
+    decoration = decoration,
+    unavailableRoute = unavailableRoute,
+  )
+}
+
+@Composable
+internal fun <R : BackStack.Record> BasicFactoryNavigator(
+  circuit: Circuit,
+  backStack: BackStack<R>,
+  navigator: Navigator,
+  container: ContentContainer,
+  providedValues: Map<R, ProvidedValues>,
+  modifier: Modifier = Modifier,
+  decoration: NavigatorRouteDecoration = NavigatorDefaults.EmptyDecoration,
+  unavailableRoute: @Composable (String) -> Unit = NavigatorDefaults.UnavailableRoute,
+) {
+  // TODO remember { mutableStatOf(circuit) } ?
+
+  val activeContentProviders = buildList {
+    for (record in backStack) {
+      val provider =
+        key(record.key) {
+          val routeName = record.route
+          // TODO fix this
+          val screen = (record as SaveableBackStack.Record).screen
+
+          @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen, container) as Ui<Parcelable, Any>?
+
+          @Suppress("UNCHECKED_CAST")
+          val presenter = circuit.presenter(screen, navigator) as Presenter<Parcelable, Any>?
+
+          val currentRender: (@Composable (R) -> Unit) =
+            if (presenter != null && ui != null) {
+              { presenter.present(UiStateRenderer(ui)) }
+            } else {
+              { unavailableRoute(routeName) }
+            }
+
+          val currentRouteContent by rememberUpdatedState(currentRender)
+          val currentRecord by rememberUpdatedState(record)
+          remember { movableContentOf { currentRouteContent(currentRecord) } }
+        }
+      add(record to provider)
+    }
+  }
+
+  if (backStack.size > 0) {
+    @Suppress("SpreadOperator")
+    decoration.DecoratedContent(activeContentProviders.first(), backStack.size, modifier) {
+      (record, provider) ->
+      val values = providedValues[record]?.provideValues()
+      val providedLocals = remember(values) { values?.toTypedArray() ?: emptyArray() }
+      CompositionLocalProvider(*providedLocals) { provider.invoke() }
+    }
+  }
+}

--- a/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Circuit adapts [presenterFactories][PresenterFactory] to their corresponding renderable
+ * [uiFactories][ScreenViewFactory] using [screens][Screen]. Create instances using [the Builder]
+ * [Builder] and create new [Navigator] instances from this using [Circuit.navigator].
+ *
+ * For example,
+ *
+ * ```kotlin
+ * val circuit = Circuit.Builder()
+ *     .addUiFactory(AddFavoritesScreenViewFactory()
+ *     .addPresenterFactory(AddFavoritesPresenterFactory()
+ *     .build()
+ *
+ * val navigator = circuit.navigator(AddFavoritesScreen())
+ * ```
+ */
+@Immutable
+class Circuit private constructor(builder: Builder) {
+  private val uiFactories: List<ScreenViewFactory> = builder.uiFactories.toList()
+  private val presenterFactories: List<PresenterFactory> = builder.presenterFactories.toList()
+
+  fun presenter(screen: Screen, navigator: Navigator): Presenter<*, *>? {
+    return nextPresenter(null, screen, navigator)
+  }
+
+  fun nextPresenter(
+    skipPast: PresenterFactory?,
+    screen: Screen,
+    navigator: Navigator
+  ): Presenter<*, *>? {
+    val start = presenterFactories.indexOf(skipPast) + 1
+    for (i in start until presenterFactories.size) {
+      val presenter = presenterFactories[i].create(screen, navigator)
+      if (presenter != null) {
+        return presenter
+      }
+    }
+
+    // TODO do we want to error instead? Maybe that's a `validateEagerly` thing?
+    return null
+  }
+
+  fun ui(screen: Screen, container: ContentContainer): Ui<*, *>? {
+    return nextUi(null, screen, container)
+  }
+
+  fun nextUi(skipPast: ScreenViewFactory?, screen: Screen, container: ContentContainer): Ui<*, *>? {
+    val start = uiFactories.indexOf(skipPast) + 1
+    for (i in start until uiFactories.size) {
+      val ui = uiFactories[i].createView(screen, container)
+      if (ui != null) {
+        return ui.ui
+      }
+    }
+
+    // TODO do we want to error instead? Maybe that's a `validateEagerly` thing?
+    return null
+  }
+
+  fun newBuilder() = Builder(this)
+
+  class Builder constructor() {
+    val uiFactories = mutableListOf<ScreenViewFactory>()
+    val presenterFactories = mutableListOf<PresenterFactory>()
+
+    internal constructor(circuit: Circuit) : this() {
+      uiFactories.addAll(circuit.uiFactories)
+      presenterFactories.addAll(circuit.presenterFactories)
+    }
+
+    fun addUiFactory(factory: ScreenViewFactory) = apply { uiFactories.add(factory) }
+
+    fun addPresenterFactory(factory: PresenterFactory) = apply { presenterFactories.add(factory) }
+
+    fun build(): Circuit {
+      return Circuit(this)
+    }
+  }
+}

--- a/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
@@ -89,7 +89,27 @@ class Circuit private constructor(builder: Builder) {
 
     fun addUiFactory(factory: ScreenViewFactory) = apply { uiFactories.add(factory) }
 
+    fun addUiFactory(vararg factory: ScreenViewFactory) = apply {
+      for (f in factory) {
+        uiFactories.add(f)
+      }
+    }
+
+    fun addUiFactories(factories: Iterable<ScreenViewFactory>) = apply {
+      uiFactories.addAll(factories)
+    }
+
     fun addPresenterFactory(factory: PresenterFactory) = apply { presenterFactories.add(factory) }
+
+    fun addPresenterFactory(vararg factory: PresenterFactory) = apply {
+      for (f in factory) {
+        presenterFactories.add(f)
+      }
+    }
+
+    fun addPresenterFactories(factories: Iterable<PresenterFactory>) = apply {
+      presenterFactories.addAll(factories)
+    }
 
     fun build(): Circuit {
       return Circuit(this)

--- a/circuit/src/main/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Navigator.kt
@@ -15,43 +15,29 @@
  */
 package com.slack.circuit
 
-import android.os.Parcelable
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.movableContentOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import com.slack.circuit.backstack.BackStack
-import com.slack.circuit.backstack.NavigatorDefaults
-import com.slack.circuit.backstack.NavigatorRouteDecoration
-import com.slack.circuit.backstack.ProvidedValues
-import com.slack.circuit.backstack.SaveableBackStack
-import com.slack.circuit.backstack.isAtRoot
-import com.slack.circuit.backstack.providedValuesForBackStack
-import com.slack.circuit.backstack.rememberSaveableBackStack
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 
 fun interface OnPopHandler {
   fun onPop()
 }
 
-/** TODO doc this */
+/** A basic navigation interface for navigating between [screens][Screen]. */
 interface Navigator {
   fun goTo(screen: Screen)
 
-  fun pop()
+  fun pop(): Screen?
+}
 
-  fun interface Factory<T : Navigator> {
-    fun create(renderer: ContentContainer, onRootPop: OnPopHandler?): T
+/** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
+fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
+  while (true) {
+    val screen = pop() ?: break
+    if (predicate(screen)) {
+      break
+    }
   }
 }
 
@@ -59,7 +45,7 @@ interface Navigator {
  * A simple rendering abstraction over a `@Composable () -> Unit`.
  *
  * This allows for any host container that can render composable functions to be used with a given
- * [Navigator.Factory.create] call, such as [ComponentActivity] and [ComposeView].
+ * [Circuit.navigator] call, such as [ComponentActivity] and [ComposeView].
  */
 fun interface ContentContainer {
   fun render(content: @Composable () -> Unit)
@@ -69,144 +55,4 @@ fun ComposeView.asContentContainer() = ContentContainer(::setContent)
 
 fun ComponentActivity.asContentContainer() = ContentContainer { content ->
   setContent(content = content)
-}
-
-class NavigatorImpl
-@AssistedInject
-constructor(
-  @Assisted val container: ContentContainer,
-  @Assisted val onRootPop: OnPopHandler?,
-  // TODO do we ever handle precedence/order here?
-  val presenterFactories: @JvmSuppressWildcards Set<PresenterFactory>,
-  val uiFactories: @JvmSuppressWildcards Set<ScreenViewFactory>,
-) : Navigator {
-
-  @AssistedFactory fun interface Factory : Navigator.Factory<NavigatorImpl>
-
-  override fun goTo(screen: Screen) {
-    // Headless? - MutableStateFlow and launch
-    // Testing - molecule to convert it to a Flow, then plumb into Turbine and treat it as a
-    // coroutines test. Don't ever use Dispatchers default/io in tests
-    container.render {
-      val backstack = rememberSaveableBackStack { push(screen) }
-      val goTo: (Screen) -> Unit = { screen -> backstack.push(screen) }
-      val navigator =
-        object : Navigator {
-          override fun goTo(screen: Screen) {
-            goTo(screen)
-          }
-
-          override fun pop() {
-            if (!backstack.isAtRoot) {
-              backstack.pop()
-            } else {
-              this@NavigatorImpl.pop()
-            }
-          }
-        }
-      FactoryNavigator(backstack, presenterFactories, uiFactories, navigator, container)
-    }
-  }
-
-  override fun pop() {
-    onRootPop?.onPop()
-  }
-}
-
-@JvmInline
-private value class UiStateRenderer<UiState, UiEvent : Any>(val ui: Ui<UiState, UiEvent>) :
-  StateRenderer<UiState, UiEvent> where UiState : Any, UiState : Parcelable {
-  @Composable
-  override fun render(state: UiState, uiEvents: (UiEvent) -> Unit) {
-    ui.render(state, uiEvents)
-  }
-}
-
-@Composable
-fun <R : BackStack.Record> FactoryNavigator(
-  backStack: BackStack<R>,
-  presenterFactories: Set<PresenterFactory>,
-  uiFactories: Set<ScreenViewFactory>,
-  navigator: Navigator,
-  container: ContentContainer,
-  modifier: Modifier = Modifier,
-  enableBackHandler: Boolean = true,
-  providedValues: Map<R, ProvidedValues> = providedValuesForBackStack(backStack),
-  decoration: NavigatorRouteDecoration = NavigatorDefaults.DefaultDecoration,
-  unavailableRoute: @Composable (String) -> Unit = NavigatorDefaults.UnavailableRoute,
-) {
-  BackHandler(enabled = enableBackHandler && !backStack.isAtRoot) { backStack.pop() }
-
-  BasicFactoryNavigator(
-    backStack = backStack,
-    presenterFactories = presenterFactories,
-    uiFactories = uiFactories,
-    navigator = navigator,
-    container = container,
-    providedValues = providedValues,
-    modifier = modifier,
-    decoration = decoration,
-    unavailableRoute = unavailableRoute,
-  )
-}
-
-@Composable
-fun <R : BackStack.Record> BasicFactoryNavigator(
-  backStack: BackStack<R>,
-  presenterFactories: Set<PresenterFactory>,
-  uiFactories: Set<ScreenViewFactory>,
-  navigator: Navigator,
-  container: ContentContainer,
-  providedValues: Map<R, ProvidedValues>,
-  modifier: Modifier = Modifier,
-  decoration: NavigatorRouteDecoration = NavigatorDefaults.EmptyDecoration,
-  unavailableRoute: @Composable (String) -> Unit = NavigatorDefaults.UnavailableRoute,
-) {
-  val currentPresenters by rememberUpdatedState(presenterFactories)
-  val currentUis by rememberUpdatedState(uiFactories)
-
-  val activeContentProviders = buildList {
-    for (record in backStack) {
-      val provider =
-        key(record.key) {
-          val routeName = record.route
-          // TODO fix this
-          val screen = (record as SaveableBackStack.Record).screen
-
-          @Suppress("UNCHECKED_CAST")
-          val ui =
-            currentUis.firstNotNullOfOrNull { it.createView(screen, container) }?.ui
-              as Ui<Parcelable, Any>?
-
-          @Suppress("UNCHECKED_CAST")
-          val presenter =
-            currentPresenters.firstNotNullOfOrNull {
-              // TODO fix exposition of navigator/backstack
-              it.create(screen, navigator)
-            } as Presenter<Parcelable, Any>?
-
-          val currentRender: (@Composable (R) -> Unit) =
-            if (presenter != null && ui != null) {
-              { presenter.present(UiStateRenderer(ui)) }
-            } else {
-              { unavailableRoute(routeName) }
-            }
-
-          val currentRouteContent by rememberUpdatedState(currentRender)
-          val currentRecord by rememberUpdatedState(record)
-          remember { movableContentOf { currentRouteContent(currentRecord) } }
-        }
-      add(record to provider)
-    }
-  }
-
-  if (backStack.size > 0) {
-    @Suppress("SpreadOperator")
-    decoration.DecoratedContent(activeContentProviders.first(), backStack.size, modifier) {
-      (record, provider) ->
-      val values = providedValues[record]?.provideValues()
-      val providedLocals = remember(values) { values?.toTypedArray() ?: emptyArray() }
-      CompositionLocalProvider(*providedLocals) { provider.invoke() }
-    }
-  }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   implementation(libs.okio)
   implementation(libs.retrofit)
   implementation(libs.retrofit.converters.moshi)
+  implementation(libs.dagger)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/MainActivity.kt
@@ -19,7 +19,8 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
-import com.slack.circuit.Navigator
+import com.slack.circuit.Circuit
+import com.slack.circuit.navigator
 import com.slack.circuit.sample.di.CircuitViewModelProviderFactory
 import com.slack.circuit.sample.petlist.PetListScreen
 import com.slack.circuit.sample.ui.StarTheme
@@ -28,14 +29,14 @@ import javax.inject.Inject
 class MainActivity : AppCompatActivity() {
 
   @Inject lateinit var viewModelProviderFactory: CircuitViewModelProviderFactory
-  @Inject lateinit var navigatorFactory: Navigator.Factory<*>
+  @Inject lateinit var circuit: Circuit
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     (application as StarApp).appComponent().inject(this)
 
     val navigator =
-      navigatorFactory.create(
+      circuit.navigator(
         { content -> setContent { StarTheme { content() } } },
         onBackPressedDispatcher::onBackPressed
       )

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/CircuitModule.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/CircuitModule.kt
@@ -16,8 +16,7 @@
 package com.slack.circuit.sample.di
 
 import androidx.lifecycle.ViewModel
-import com.slack.circuit.Navigator
-import com.slack.circuit.NavigatorImpl
+import com.slack.circuit.Circuit
 import com.slack.circuit.PresenterFactory
 import com.slack.circuit.ScreenViewFactory
 import com.slack.circuit.backstack.BackStackRecordLocalProviderViewModel
@@ -33,8 +32,6 @@ interface CircuitModule {
 
   @Multibinds fun viewFactories(): Set<ScreenViewFactory>
 
-  @Binds fun NavigatorImpl.Factory.bindNavigatorImpl(): Navigator.Factory<*>
-
   @ViewModelKey(BackStackRecordLocalProviderViewModel::class)
   @IntoMap
   @Binds
@@ -44,6 +41,23 @@ interface CircuitModule {
     @Provides
     fun provideBackStackRecordLocalProviderViewModel(): BackStackRecordLocalProviderViewModel {
       return BackStackRecordLocalProviderViewModel()
+    }
+
+    @Provides
+    fun provideCircuit(
+      presenterFactories: @JvmSuppressWildcards Set<PresenterFactory>,
+      uiFactories: @JvmSuppressWildcards Set<ScreenViewFactory>,
+    ): Circuit {
+      return Circuit.Builder()
+        .apply {
+          for (presenterFactory in presenterFactories) {
+            addPresenterFactory(presenterFactory)
+          }
+          for (uiFactory in uiFactories) {
+            addUiFactory(uiFactory)
+          }
+        }
+        .build()
     }
   }
 }


### PR DESCRIPTION
This splits out a new `Circuit` type from the existing navigation logic to better separate these concerns.

`Circuit` is responsible for managing UI factories and PresenterFactories (we still use `ScreenViewFactory` but saving cleanup of that for a later day), then there's a bridge `Circuit.navigator` function that creates a `CircuitNavigator` that drives navigation based on the underlying `Circuit` instance.

This should make it easier to hang up new local navigators in sub-UIs.

Resolves #20 along the way