### PR TITLE
Anvilize sample app + use AppComponentFactory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,6 +191,11 @@ subprojects {
       sourceCompatibility = JavaVersion.VERSION_11
       targetCompatibility = JavaVersion.VERSION_11
     }
+
+    lint {
+      // https://issuetracker.google.com/issues/243267012
+      disable += "Instantiatable"
+    }
   }
 
   // Android library config

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -13,7 +13,7 @@ android {
   namespace = "com.slack.circuit.sample"
 
   defaultConfig {
-    minSdk = 24
+    minSdk = 28
     targetSdk = 33
     versionCode = 1
     versionName = "1"

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   kotlin("kapt")
   kotlin("plugin.parcelize")
   alias(libs.plugins.moshiGradlePlugin)
+  alias(libs.plugins.anvil)
 }
 
 android {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
   -->
 
 <manifest package="com.slack.circuit.sample"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -24,6 +25,8 @@
         android:name=".StarApp"
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/StarTheme"
+        android:appComponentFactory="com.slack.circuit.sample.di.StarAppComponentFactory"
+        tools:replace="android:appComponentFactory"
         >
         <activity
             android:name=".MainActivity"

--- a/sample/src/main/kotlin/com/slack/circuit/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/MainActivity.kt
@@ -15,24 +15,30 @@
  */
 package com.slack.circuit.sample
 
+import android.app.Activity
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.slack.circuit.Navigator
-import com.slack.circuit.sample.di.StarViewModelProviderFactory
+import com.slack.circuit.sample.di.ActivityKey
+import com.slack.circuit.sample.di.AppScope
 import com.slack.circuit.sample.petlist.PetListScreen
 import com.slack.circuit.sample.ui.StarTheme
+import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
-class MainActivity : AppCompatActivity() {
-
-  @Inject lateinit var viewModelProviderFactory: ViewModelProvider.Factory
-  @Inject lateinit var navigatorFactory: Navigator.Factory<*>
+@ContributesMultibinding(AppScope::class, boundType = Activity::class)
+@ActivityKey(MainActivity::class)
+class MainActivity
+@Inject
+constructor(
+  private val viewModelProviderFactory: ViewModelProvider.Factory,
+  private val navigatorFactory: Navigator.Factory<*>
+) : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    (application as StarApp).appComponent().inject(this)
 
     val navigator =
       navigatorFactory.create(

--- a/sample/src/main/kotlin/com/slack/circuit/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/MainActivity.kt
@@ -20,14 +20,14 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.slack.circuit.Navigator
-import com.slack.circuit.sample.di.CircuitViewModelProviderFactory
+import com.slack.circuit.sample.di.StarViewModelProviderFactory
 import com.slack.circuit.sample.petlist.PetListScreen
 import com.slack.circuit.sample.ui.StarTheme
 import javax.inject.Inject
 
 class MainActivity : AppCompatActivity() {
 
-  @Inject lateinit var viewModelProviderFactory: CircuitViewModelProviderFactory
+  @Inject lateinit var viewModelProviderFactory: ViewModelProvider.Factory
   @Inject lateinit var navigatorFactory: Navigator.Factory<*>
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/sample/src/main/kotlin/com/slack/circuit/sample/StarApp.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/StarApp.kt
@@ -20,12 +20,7 @@ import com.slack.circuit.sample.di.AppComponent
 
 class StarApp : Application() {
 
-  private lateinit var appComponent: AppComponent
-
-  override fun onCreate() {
-    super.onCreate()
-    appComponent = AppComponent.create()
-  }
+  private val appComponent by lazy { AppComponent.create() }
 
   fun appComponent() = appComponent
 }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/data/DataModule.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/data/DataModule.kt
@@ -15,31 +15,34 @@
  */
 package com.slack.circuit.sample.data
 
+import com.slack.circuit.sample.di.AppScope
+import com.slack.circuit.sample.di.SingleIn
+import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
-import javax.inject.Singleton
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.create
 
+@ContributesTo(AppScope::class)
 @Module
 object DataModule {
   @Provides
-  @Singleton
+  @SingleIn(AppScope::class)
   fun provideMoshi(): Moshi {
     return Moshi.Builder().build()
   }
 
   @Provides
-  @Singleton
+  @SingleIn(AppScope::class)
   fun provideOkHttpClient(): OkHttpClient {
     return OkHttpClient.Builder().build()
   }
 
   @Provides
-  @Singleton
+  @SingleIn(AppScope::class)
   fun providePetfinderApi(moshi: Moshi, okHttpClient: OkHttpClient): PetfinderApi {
     val baseRetrofit =
       Retrofit.Builder()

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/ActivityKey.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/ActivityKey.kt
@@ -16,14 +16,10 @@
 package com.slack.circuit.sample.di
 
 import android.app.Activity
-import androidx.lifecycle.ViewModel
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Module
-import dagger.multibindings.Multibinds
+import dagger.MapKey
+import kotlin.reflect.KClass
 
-@ContributesTo(AppScope::class)
-@Module
-interface BaseUiModule {
-  @Multibinds fun provideViewModelProviders(): Map<Class<out ViewModel>, ViewModel>
-  @Multibinds fun provideActivityProviders(): Map<Class<out Activity>, Activity>
-}
+/**
+ * A Dagger multi-binding key used for registering a [Activity] into the top level dagger graphs.
+ */
+@MapKey annotation class ActivityKey(val value: KClass<out Activity>)

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/AppComponent.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/AppComponent.kt
@@ -15,10 +15,11 @@
  */
 package com.slack.circuit.sample.di
 
-import com.slack.circuit.sample.MainActivity
+import android.app.Activity
 import com.slack.circuit.sample.data.DataModule
 import com.squareup.anvil.annotations.MergeComponent
 import dagger.Component
+import javax.inject.Provider
 
 @MergeComponent(
   scope = AppScope::class,
@@ -31,7 +32,7 @@ import dagger.Component
 )
 @SingleIn(AppScope::class)
 interface AppComponent {
-  fun inject(mainActivity: MainActivity)
+  val activityProviders: Map<Class<out Activity>, @JvmSuppressWildcards Provider<Activity>>
 
   @Component.Factory
   interface Factory {

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/BaseUiModule.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/BaseUiModule.kt
@@ -16,11 +16,12 @@
 package com.slack.circuit.sample.di
 
 import androidx.lifecycle.ViewModel
+import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.multibindings.Multibinds
 
+@ContributesTo(AppScope::class)
 @Module
 interface BaseUiModule {
-
   @Multibinds fun provideViewModelProviders(): Map<Class<out ViewModel>, ViewModel>
 }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/CircuitModule.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/CircuitModule.kt
@@ -21,12 +21,14 @@ import com.slack.circuit.NavigatorImpl
 import com.slack.circuit.PresenterFactory
 import com.slack.circuit.ScreenViewFactory
 import com.slack.circuit.backstack.BackStackRecordLocalProviderViewModel
+import com.squareup.anvil.annotations.ContributesTo
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
 import dagger.multibindings.Multibinds
 
+@ContributesTo(AppScope::class)
 @Module
 interface CircuitModule {
   @Multibinds fun presenterFactories(): Set<PresenterFactory>

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/Scopes.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/Scopes.kt
@@ -15,30 +15,9 @@
  */
 package com.slack.circuit.sample.di
 
-import com.slack.circuit.sample.MainActivity
-import com.slack.circuit.sample.data.DataModule
-import com.squareup.anvil.annotations.MergeComponent
-import dagger.Component
+import javax.inject.Scope
+import kotlin.reflect.KClass
 
-@MergeComponent(
-  scope = AppScope::class,
-  modules =
-    [
-      BaseUiModule::class,
-      CircuitModule::class,
-      DataModule::class,
-    ]
-)
-@SingleIn(AppScope::class)
-interface AppComponent {
-  fun inject(mainActivity: MainActivity)
+@Scope annotation class SingleIn(val scope: KClass<*>)
 
-  @Component.Factory
-  interface Factory {
-    fun create(): AppComponent
-  }
-
-  companion object {
-    fun create(): AppComponent = DaggerAppComponent.factory().create()
-  }
-}
+class AppScope private constructor()

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/StarAppComponentFactory.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/StarAppComponentFactory.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.sample.di
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import androidx.annotation.Keep
+import androidx.core.app.AppComponentFactory
+import com.slack.circuit.sample.StarApp
+import javax.inject.Provider
+
+@Keep
+class StarAppComponentFactory : AppComponentFactory() {
+
+  private lateinit var activityProviders: Map<Class<out Activity>, Provider<Activity>>
+
+  private inline fun <reified T> getInstance(
+    cl: ClassLoader,
+    className: String,
+    providers: Map<Class<out T>, @JvmSuppressWildcards Provider<T>>,
+  ): T? {
+    val clazz = Class.forName(className, false, cl).asSubclass(T::class.java)
+    val modelProvider = providers[clazz] ?: return null
+    @Suppress("UNCHECKED_CAST") return modelProvider.get() as T
+  }
+
+  override fun instantiateActivityCompat(
+    cl: ClassLoader,
+    className: String,
+    intent: Intent?
+  ): Activity {
+    return getInstance(cl, className, activityProviders)
+      ?: super.instantiateActivityCompat(cl, className, intent)
+  }
+
+  override fun instantiateApplicationCompat(cl: ClassLoader, className: String): Application {
+    val app = super.instantiateApplicationCompat(cl, className)
+    activityProviders = (app as StarApp).appComponent().activityProviders
+    return app
+  }
+}

--- a/sample/src/main/kotlin/com/slack/circuit/sample/di/StarViewModelProviderFactory.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/di/StarViewModelProviderFactory.kt
@@ -17,11 +17,13 @@ package com.slack.circuit.sample.di
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import javax.inject.Provider
 
 /** A factory that will provide [ViewModels][ViewModel] using their Dagger provider. */
-class CircuitViewModelProviderFactory
+@ContributesBinding(AppScope::class)
+class StarViewModelProviderFactory
 @Inject
 constructor(
   private val modelProviders: Map<Class<out ViewModel>, @JvmSuppressWildcards Provider<ViewModel>>

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
@@ -35,14 +35,13 @@ import com.slack.circuit.Screen
 import com.slack.circuit.ScreenView
 import com.slack.circuit.ScreenViewFactory
 import com.slack.circuit.StateRenderer
+import com.slack.circuit.sample.di.AppScope
 import com.slack.circuit.sample.repo.PetRepository
 import com.slack.circuit.ui
-import dagger.Binds
-import dagger.Module
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.multibindings.IntoSet
 import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 
@@ -57,6 +56,7 @@ data class PetDetailScreen(val petId: Long) : Screen {
   ) : Parcelable
 }
 
+@ContributesMultibinding(AppScope::class)
 class PetDetailScreenPresenterFactory
 @Inject
 constructor(private val petDetailPresenterFactory: PetDetailPresenter.Factory) : PresenterFactory {
@@ -95,14 +95,7 @@ constructor(
   }
 }
 
-@Module
-interface PetDetailModule {
-  @Binds @IntoSet fun PetDetailScreenFactory.bindPetDetailScreenFactory(): ScreenViewFactory
-  @Binds
-  @IntoSet
-  fun PetDetailScreenPresenterFactory.bindPetDetailScreenPresenterFactory(): PresenterFactory
-}
-
+@ContributesMultibinding(AppScope::class)
 class PetDetailScreenFactory @Inject constructor() : ScreenViewFactory {
   override fun createView(screen: Screen, container: ContentContainer): ScreenView? {
     if (screen is PetDetailScreen) return ScreenView(container, petDetailUi())

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
@@ -47,15 +47,14 @@ import com.slack.circuit.ScreenView
 import com.slack.circuit.ScreenViewFactory
 import com.slack.circuit.StateRenderer
 import com.slack.circuit.sample.data.Animal
+import com.slack.circuit.sample.di.AppScope
 import com.slack.circuit.sample.petdetail.PetDetailScreen
 import com.slack.circuit.sample.repo.PetRepository
 import com.slack.circuit.ui
-import dagger.Binds
-import dagger.Module
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.multibindings.IntoSet
 import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 
@@ -78,6 +77,7 @@ object PetListScreen : Screen {
   }
 }
 
+@ContributesMultibinding(AppScope::class)
 class PetListScreenPresenterFactory
 @Inject
 constructor(private val petListPresenterFactory: PetListPresenter.Factory) : PresenterFactory {
@@ -126,14 +126,7 @@ constructor(
   }
 }
 
-@Module
-interface PetListModule {
-  @Binds @IntoSet fun PetListScreenFactory.bindPetListScreenFactory(): ScreenViewFactory
-  @Binds
-  @IntoSet
-  fun PetListScreenPresenterFactory.bindPetListScreenPresenterFactory(): PresenterFactory
-}
-
+@ContributesMultibinding(AppScope::class)
 class PetListScreenFactory @Inject constructor() : ScreenViewFactory {
   override fun createView(screen: Screen, container: ContentContainer): ScreenView? {
     if (screen is PetListScreen) {

--- a/sample/src/main/kotlin/com/slack/circuit/sample/repo/PetRepository.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/repo/PetRepository.kt
@@ -17,15 +17,16 @@ package com.slack.circuit.sample.repo
 
 import com.slack.circuit.sample.data.Animal
 import com.slack.circuit.sample.data.PetfinderApi
+import com.slack.circuit.sample.di.AppScope
+import com.slack.circuit.sample.di.SingleIn
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-@Singleton
+@SingleIn(AppScope::class)
 class PetRepository @Inject constructor(private val petFinderApi: PetfinderApi) {
   private var animals: MutableStateFlow<List<Animal>> = MutableStateFlow(emptyList())
   private var fetched = false


### PR DESCRIPTION
Resolves #3 + raises min SDK in the sample to 28 so we can use AppComponentFactory for activity injection. Still can't fully escape accessing an app component from the application instance but ¯\_(ツ)_/¯ 