### PR TITLE
More sample app UI polish

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 accompanist = "0.26.0-alpha"
-androidx-activity = "1.5.1"
+androidx-activity = "1.6.0-beta01"
 androidx-appcompat = "1.4.2"
 androidx-lifecycle = "2.5.1"
 agp = "7.2.2"
@@ -87,6 +87,7 @@ androidx-compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "com
 androidx-compose-ui-unit = { module = "androidx.compose.ui:ui-unit", version.ref = "compose" }
 # Embed XML via view binding into Composables
 androidx-compose-ui-viewBinding = { module = "androidx.compose.ui:ui-viewbinding", version.ref = "compose" }
+androidx-palette = "androidx.palette:palette-ktx:1.0.0"
 
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
   implementation(libs.androidx.compose.integration.activity)
   implementation(libs.androidx.compose.material.material3)
   implementation(libs.androidx.appCompat)
+  implementation(libs.androidx.palette)
+  debugImplementation(libs.androidx.compose.ui.tooling)
   implementation(libs.bundles.androidx.activity)
   implementation(libs.coil)
   implementation(libs.coil.compose)

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         android:name=".StarApp"
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/StarTheme"
+        android:enableOnBackInvokedCallback="true"
         >
         <activity
             android:name=".MainActivity"

--- a/sample/src/main/kotlin/com/slack/circuit/sample/data/Petfinder.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/data/Petfinder.kt
@@ -66,6 +66,7 @@ data class Animal(
   val url: String,
   val type: String,
   val species: String,
+  val gender: String,
   val breeds: Breeds,
   val colors: Colors,
   val age: String,

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
@@ -16,16 +16,20 @@
 package com.slack.circuit.sample.petdetail
 
 import android.os.Parcelable
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import coil.compose.SubcomposeAsyncImage
 import com.slack.circuit.ContentContainer
 import com.slack.circuit.Navigator
@@ -114,16 +118,20 @@ private fun petDetailUi() = ui<PetDetailScreen.State, Unit> { state, _ -> render
 
 @Composable
 private fun renderImpl(state: PetDetailScreen.State) {
-  Scaffold { padding ->
+  Scaffold(
+    modifier = Modifier.systemBarsPadding(),
+  ) { padding ->
     LazyColumn(modifier = Modifier.padding(padding)) {
       item {
         SubcomposeAsyncImage(
+          modifier = Modifier.fillMaxWidth(),
           model = state.photoUrl,
           contentDescription = state.name,
+          contentScale = ContentScale.FillWidth,
           loading = { CircularProgressIndicator() }
         )
       }
-      item { Text(text = state.name) }
+      item { Text(text = state.name, style = MaterialTheme.typography.displayLarge) }
       item { Text(text = state.description) }
     }
   }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
@@ -15,29 +15,53 @@
  */
 package com.slack.circuit.sample.petlist
 
+import android.graphics.Bitmap
 import android.os.Parcelable
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.systemGesturesPadding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color as ComposeColor
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.capitalize
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import androidx.palette.graphics.Palette
+import androidx.palette.graphics.Palette.Swatch
+import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.request.ImageRequest
 import com.slack.circuit.ContentContainer
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
@@ -59,11 +83,15 @@ import dagger.multibindings.IntoSet
 import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 
+@Immutable
 @Parcelize
 data class PetListAnimal(
   val id: Long,
   val name: String,
-  val description: String,
+  val imageUrl: String,
+  val breed: String?,
+  val gender: String,
+  val age: String,
 ) : Parcelable
 
 @Parcelize
@@ -117,7 +145,15 @@ constructor(
   }
 
   private fun Animal.toPetListAnimal(): PetListAnimal {
-    return PetListAnimal(id = id, name = name, description = description)
+    return PetListAnimal(
+      id = id,
+      // Names are sometimes all caps
+      name = name.lowercase().capitalize(Locale.current),
+      imageUrl = photos[0].medium,
+      breed = breeds.primary,
+      gender = gender,
+      age = age
+    )
   }
 
   @AssistedFactory
@@ -149,7 +185,7 @@ private fun petListUi() =
 @Composable
 private fun RenderImpl(state: PetListScreen.State, events: (PetListScreen.Event) -> Unit) {
   Scaffold(
-    modifier = Modifier.systemBarsPadding().systemGesturesPadding().fillMaxWidth(),
+    modifier = Modifier.systemBarsPadding().fillMaxWidth(),
     topBar = {
       CenterAlignedTopAppBar(
         title = {
@@ -185,14 +221,82 @@ private fun PetList(
   animals: List<PetListAnimal>,
   events: (PetListScreen.Event) -> Unit
 ) {
-  LazyColumn(modifier) {
-    animals.forEach { animal ->
-      item { PetListItem(animal) { events(PetListScreen.Event.ClickAnimal(animal.id)) } }
+  LazyVerticalGrid(
+    columns = GridCells.Fixed(2),
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(16.dp),
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
+    contentPadding = PaddingValues(16.dp),
+  ) {
+    items(
+      count = animals.size,
+      key = { i -> animals[i].id },
+    ) { index ->
+      val animal = animals[index]
+      PetListItem(modifier, animal) { events(PetListScreen.Event.ClickAnimal(animal.id)) }
     }
   }
 }
 
 @Composable
-private fun PetListItem(animal: PetListAnimal, onClick: () -> Unit) {
-  Text(modifier = Modifier.clickable { onClick() }, text = animal.name)
+private fun PetListItem(modifier: Modifier, animal: PetListAnimal, onClick: () -> Unit) {
+  // Palette for extracted colors from the image
+  var paletteState by remember { mutableStateOf<Palette?>(null) }
+  val swatch = paletteState?.getSwatch()
+  val defaultColors = CardDefaults.cardColors()
+  val colors =
+    swatch?.let { s ->
+      CardDefaults.cardColors(
+        containerColor = Color(s.rgb),
+      )
+    }
+      ?: defaultColors
+
+  Card(
+    modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)).clickable { onClick() },
+    colors = colors,
+    shape = RoundedCornerShape(16.dp),
+  ) {
+    // Image
+    AsyncImage(
+      modifier = Modifier.fillMaxWidth(),
+      model =
+        ImageRequest.Builder(LocalContext.current)
+          .data(animal.imageUrl)
+          .crossfade(true)
+          // Default is hardware, which isn't usable in Palette
+          .bitmapConfig(Bitmap.Config.ARGB_8888)
+          .build(),
+      contentDescription = animal.name,
+      contentScale = ContentScale.FillWidth,
+      onState = { state ->
+        if (state is AsyncImagePainter.State.Success) {
+          Palette.Builder(state.result.drawable.toBitmap()).generate { palette ->
+            paletteState = palette
+          }
+        }
+      }
+    )
+    Column(modifier.padding(8.dp)) {
+      val textColor = swatch?.bodyTextColor?.let(::ComposeColor) ?: ComposeColor.Unspecified
+      // Name
+      Text(text = animal.name, style = MaterialTheme.typography.labelLarge, color = textColor)
+      // Type
+      animal.breed?.let {
+        Text(text = animal.breed, style = MaterialTheme.typography.bodyMedium, color = textColor)
+      }
+      // Gender, age
+      Text(
+        text = "${animal.gender} – ${animal.age}",
+        style = MaterialTheme.typography.bodySmall,
+        color = textColor
+      )
+    }
+  }
+}
+
+private fun Palette.getSwatch(): Swatch {
+  return vibrantSwatch
+    ?: lightVibrantSwatch ?: darkVibrantSwatch ?: lightMutedSwatch ?: mutedSwatch ?: darkMutedSwatch
+      ?: error("No usable swatch found")
 }


### PR DESCRIPTION
This does more polishing of the sample app UI (ref #6), focusing mostly on the list UI.

Highlights
- Lazy grid for all the adoptables
- Full list item UI with an image
- Uses Palette to extract colors from the pet image on load, then sets its content and text color accordingly
- Some minor touchups and toe-holds in other places for the future

https://user-images.githubusercontent.com/1361086/185845289-621988a4-9dd5-47d2-a240-ba9405525eb9.mp4


