### PR TITLE
Get things working

### DIFF
--- a/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
@@ -19,7 +19,6 @@ import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharedFlow
 
 /**
  * Presents a given [UiState] and handles its [events][UiEvent].
@@ -28,10 +27,9 @@ import kotlinx.coroutines.flow.SharedFlow
  */
 interface Presenter<UiState, UiEvent : Any> where UiState : Any, UiState : Parcelable {
   /**
-   * // TODO out of date - update!!
-   * The primary entry point to present a [Composable] [render] to connect this [Presenter] with a
-   * given [Ui], usually automatically handled by a [Navigator]. The structure of this function is
-   * based around two parameters:
+   * // TODO out of date - update!! The primary entry point to present a [Composable] [render] to
+   * connect this [Presenter] with a given [Ui], usually automatically handled by a [Navigator]. The
+   * structure of this function is based around two parameters:
    * 1. `state` - the current `UiState`.
    * 2. `uiEvents` - a callback to listen to UiEvent emissions from the corresponding [Ui].
    *

--- a/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
@@ -76,10 +76,8 @@ inline fun <UiState, UiEvent : Any> ui(
   }
 }
 
+@Suppress("NOTHING_TO_INLINE")
 @Composable
-// TODO inline
-fun <E : Any> collectEvents(events: Flow<E>, handler: (event: E) -> Unit) {
-  LaunchedEffect(events) {
-    events.collect(handler)
-  }
+inline fun <E : Any> collectEvents(events: Flow<E>, noinline handler: (event: E) -> Unit) {
+  LaunchedEffect(events) { events.collect(handler) }
 }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
@@ -42,9 +42,8 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.multibindings.IntoSet
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharedFlow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -87,7 +86,7 @@ constructor(
       )
     }
 
-//    LaunchedEffect(this) { /* nothing to do yet */ }
+    //    LaunchedEffect(this) { /* nothing to do yet */ }
 
     return state
   }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -96,13 +95,15 @@ constructor(
 ) : Presenter<PetListScreen.State, PetListScreen.Event> {
   @Composable
   override fun present(events: Flow<PetListScreen.Event>): PetListScreen.State {
-    val state = produceState<PetListScreen.State>(PetListScreen.State.Loading) {
-      val animals = petRepo.animalsStateFlow.value
-      value = when {
-        animals.isEmpty() -> PetListScreen.State.NoAnimals
-        else -> PetListScreen.State.Success(animals.map { it.toPetListAnimal() })
+    val state =
+      produceState<PetListScreen.State>(PetListScreen.State.Loading) {
+        val animals = petRepo.animalsStateFlow.value
+        value =
+          when {
+            animals.isEmpty() -> PetListScreen.State.NoAnimals
+            else -> PetListScreen.State.Success(animals.map { it.toPetListAnimal() })
+          }
       }
-    }
 
     collectEvents(events) { event ->
       when (event) {

--- a/sample/src/main/kotlin/com/slack/circuit/sample/repo/PetRepository.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/repo/PetRepository.kt
@@ -31,7 +31,8 @@ interface PetRepository {
 }
 
 @Singleton
-class PetRepositoryImpl @Inject constructor(private val petFinderApi: PetfinderApi): PetRepository {
+class PetRepositoryImpl @Inject constructor(private val petFinderApi: PetfinderApi) :
+  PetRepository {
   private val animals: MutableStateFlow<List<Animal>> = MutableStateFlow(emptyList())
   private var fetched = false
 

--- a/sample/src/test/kotlin/com/slack/circuit/sample/petlist/PetListPresenterTest.kt
+++ b/sample/src/test/kotlin/com/slack/circuit/sample/petlist/PetListPresenterTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.slack.circuit.sample.petlist
 
 import app.cash.molecule.RecompositionClock.Immediate
@@ -11,23 +26,18 @@ import com.slack.circuit.sample.data.Breeds
 import com.slack.circuit.sample.data.Colors
 import com.slack.circuit.sample.data.Link
 import com.slack.circuit.sample.data.Links
-import com.slack.circuit.sample.petdetail.PetDetailScreen
 import com.slack.circuit.sample.repo.PetRepository
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.fail
-import org.junit.Before
 import org.junit.Test
 
 class PetListPresenterTest {
-  private lateinit var navigator: TestNavigator
-
-  @Before
-  fun setup() {
-    navigator = TestNavigator()
-  }
+  private val navigator = TestNavigator()
 
   @Test
   fun `present - emit loading state then no animals state`() = runTest {
@@ -35,12 +45,11 @@ class PetListPresenterTest {
     val presenter = PetListPresenter(navigator, repository)
     val events = MutableSharedFlow<PetListScreen.Event>()
 
-    moleculeFlow(Immediate) {
-      presenter.present(events)
-    }.test {
-      assertThat(PetListScreen.State.Loading).isEqualTo(awaitItem())
-      assertThat(PetListScreen.State.NoAnimals).isEqualTo(awaitItem())
-    }
+    moleculeFlow(Immediate) { presenter.present(events) }
+      .test {
+        assertThat(PetListScreen.State.Loading).isEqualTo(awaitItem())
+        assertThat(PetListScreen.State.NoAnimals).isEqualTo(awaitItem())
+      }
   }
 
   @Test
@@ -49,64 +58,59 @@ class PetListPresenterTest {
     val presenter = PetListPresenter(navigator, repository)
     val events = MutableSharedFlow<PetListScreen.Event>()
 
-    moleculeFlow(Immediate) {
-      presenter.present(events)
-    }.test {
-      assertThat(PetListScreen.State.Loading).isEqualTo(awaitItem())
+    moleculeFlow(Immediate) { presenter.present(events) }
+      .test {
+        assertThat(PetListScreen.State.Loading).isEqualTo(awaitItem())
 
-      val animals = listOf(animal).map { it.toPetListAnimal() }
-      assertThat(PetListScreen.State.Success(animals)).isEqualTo(awaitItem())
-    }
+        val animals = listOf(animal).map { it.toPetListAnimal() }
+        assertThat(PetListScreen.State.Success(animals)).isEqualTo(awaitItem())
+      }
   }
 
   @Test
   fun `present - navigate to pet details screen`() = runTest {
     val repository = TestRepository(emptyList())
     val presenter = PetListPresenter(navigator, repository)
-    val events = MutableSharedFlow<PetListScreen.Event>()
+    val events = Channel<PetListScreen.Event>(Channel.BUFFERED)
 
-    moleculeFlow(Immediate) {
-      presenter.present(events)
-    }.test {
-      assertThat(PetListScreen.State.Loading).isEqualTo(awaitItem())
-      assertThat(PetListScreen.State.NoAnimals).isEqualTo(awaitItem())
+    moleculeFlow(Immediate) { presenter.present(events.receiveAsFlow()) }
+      .test {
+        assertThat(PetListScreen.State.Loading).isEqualTo(awaitItem())
+        assertThat(PetListScreen.State.NoAnimals).isEqualTo(awaitItem())
 
-      val clickAnimal = PetListScreen.Event.ClickAnimal(123L)
-      events.tryEmit(clickAnimal)
-
-      // TODO how do we watch for event triggered behaviour that does NOT result in the emission
-      // TODO of new state??
-      navigator.assertGoTo(PetDetailScreen(123L))
+        val clickAnimal = PetListScreen.Event.ClickAnimal(123L)
+        events.send(clickAnimal)
+      }
+    navigator.screens().test {
+      // Hangs forever waiting
+      //      assertThat(PetDetailScreen(123L)).isEqualTo(awaitItem())
     }
   }
 
   private companion object {
-    val animal = Animal(
-      id = 1L,
-      organizationId = "organizationId",
-      url = "url",
-      type = "type",
-      species = "species",
-      breeds = Breeds(),
-      colors = Colors(),
-      age = "age",
-      size = "size",
-      coat = "coat",
-      name = "name",
-      description = "description",
-      photos = emptyList(),
-      videos = emptyList(),
-      status = "status",
-      attributes = emptyMap(),
-      environment = emptyMap(),
-      tags = emptyList(),
-      publishedAt = "publishedAt",
-      links = Links(
-        self = Link("self"),
-        type = Link("type"),
-        organization = Link("organization")
+    val animal =
+      Animal(
+        id = 1L,
+        organizationId = "organizationId",
+        url = "url",
+        type = "type",
+        species = "species",
+        breeds = Breeds(),
+        colors = Colors(),
+        age = "age",
+        size = "size",
+        coat = "coat",
+        name = "name",
+        description = "description",
+        photos = emptyList(),
+        videos = emptyList(),
+        status = "status",
+        attributes = emptyMap(),
+        environment = emptyMap(),
+        tags = emptyList(),
+        publishedAt = "publishedAt",
+        links = Links(self = Link("self"), type = Link("type"), organization = Link("organization"))
       )
-    )
   }
 }
 
@@ -117,16 +121,20 @@ private class TestRepository(animals: List<Animal>) : PetRepository {
   override fun getAnimal(id: Long): Animal = TODO("Not yet implemented")
 }
 
+// TODO expose the backstack directly here somehow and assert the stack?
 private class TestNavigator : Navigator {
-  private var receivedGoToScreen: Screen? = null
+  private val screens = MutableSharedFlow<Screen>()
+  private val pops = MutableSharedFlow<Unit>()
 
   override fun goTo(screen: Screen) {
-    receivedGoToScreen = screen
+    screens.tryEmit(screen)
   }
 
-  override fun pop() = TODO("Not yet implemented")
-
-  fun assertGoTo(screen: Screen, lazyMessage: (() -> String)? = null) {
-    if (receivedGoToScreen != screen) fail(lazyMessage?.invoke())
+  override fun pop() {
+    pops.tryEmit(Unit)
   }
+
+  fun screens(): Flow<Screen> = screens
+
+  fun takePop(): Flow<Unit> = pops
 }

--- a/sample/src/test/kotlin/com/slack/circuit/sample/petlist/PetListPresenterTest.kt
+++ b/sample/src/test/kotlin/com/slack/circuit/sample/petlist/PetListPresenterTest.kt
@@ -29,11 +29,9 @@ import com.slack.circuit.sample.data.Link
 import com.slack.circuit.sample.data.Links
 import com.slack.circuit.sample.petdetail.PetDetailScreen
 import com.slack.circuit.sample.repo.PetRepository
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -72,15 +70,15 @@ class PetListPresenterTest {
   fun `present - navigate to pet details screen`() = runTest {
     val repository = TestRepository(emptyList())
     val presenter = PetListPresenter(navigator, repository)
-    val events = Channel<PetListScreen.Event>(Channel.BUFFERED)
+    val events = MutableSharedFlow<PetListScreen.Event>()
 
-    moleculeFlow(Immediate) { presenter.present(events.receiveAsFlow()) }
+    moleculeFlow(Immediate) { presenter.present(events) }
       .test {
         assertThat(PetListScreen.State.Loading).isEqualTo(awaitItem())
         assertThat(PetListScreen.State.NoAnimals).isEqualTo(awaitItem())
 
         val clickAnimal = PetListScreen.Event.ClickAnimal(123L)
-        events.send(clickAnimal)
+        events.emit(clickAnimal)
         assertThat(navigator.awaitNextScreen()).isEqualTo(PetDetailScreen(clickAnimal.petId))
       }
   }


### PR DESCRIPTION
This replaces the navigator in the test with a turbine-backed `FakeNavigator`. Moving all this into the test's `test { }` block appears to get everything working