### PR TITLE
Replace use of default return values with Robolectric

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ moshi = "1.13.0"
 moshix = "0.18.3"
 okhttp = "5.0.0-alpha.10"
 retrofit = "2.9.0"
+robolectric = "4.8.2"
 spotless = "6.9.0"
 turbine = "0.9.0"
 versionsPlugin = "0.42.0"
@@ -113,6 +114,7 @@ okio = "com.squareup.okio:okio:3.2.0"
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converters-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
 retrofit-converters-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
+robolectric = { module = "org.robolectric:robolectric", version.ref="robolectric" }
 truth = "com.google.truth:truth:1.1.3"
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -14,25 +14,24 @@ android {
 
   defaultConfig {
     minSdk = 28
-    targetSdk = 33
+    targetSdk = 32
     versionCode = 1
     versionName = "1"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     testApplicationId = "com.slack.circuit.sample.androidTest"
   }
 
-  testOptions {
-    unitTests.isReturnDefaultValues = true
-  }
+  testOptions { unitTests.isIncludeAndroidResources = true }
 }
 
 tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
     @Suppress("SuspiciousCollectionReassignment")
-    freeCompilerArgs += listOf(
-      "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-      "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
-    )
+    freeCompilerArgs +=
+      listOf(
+        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+      )
   }
 }
 
@@ -52,19 +51,14 @@ dependencies {
   implementation(libs.okio)
   implementation(libs.retrofit)
   implementation(libs.retrofit.converters.moshi)
-  
+
   implementation(libs.dagger)
 
+  testImplementation(libs.androidx.compose.ui.testing.junit)
   testImplementation(libs.coroutines.test)
   testImplementation(libs.junit)
   testImplementation(libs.molecule.runtime)
   testImplementation(libs.truth)
   testImplementation(libs.turbine)
-
-//  testImplementation(libs.robolectric)
-//  testImplementation("androidx.compose.ui:ui-test-junit4:1.0.5")
-//  testImplementation("androidx.test:core:1.4.0")
-//  testImplementation("androidx.test:core-ktx:1.4.0")
-//  testImplementation("androidx.test:monitor:1.4.0")
-//  testImplementation("app.cash.molecule:molecule-testing:0.4.0")
+  testImplementation(libs.robolectric)
 }

--- a/sample/src/test/kotlin/com/slack/circuit/sample/petdetail/PetDetailPresenterTest.kt
+++ b/sample/src/test/kotlin/com/slack/circuit/sample/petdetail/PetDetailPresenterTest.kt
@@ -24,7 +24,10 @@ import com.slack.circuit.sample.petlist.TestRepository
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class PetDetailPresenterTest {
   @Test
   fun `present - emit loading state then no animal state`() = runTest {

--- a/sample/src/test/kotlin/com/slack/circuit/sample/petlist/PetListPresenterTest.kt
+++ b/sample/src/test/kotlin/com/slack/circuit/sample/petlist/PetListPresenterTest.kt
@@ -33,7 +33,10 @@ import com.slack.circuit.sample.repo.PetRepository
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class PetListPresenterTest {
   private val navigator = FakeNavigator()
 


### PR DESCRIPTION
The previous [PR](https://github.com/slackhq/circuit/pull/23) enabled a build flag that had unmocked methods in the android.jar return default values (instead of throwing an exception). Replacing this flag with Robolectric so we have a more realistic Android environment when testing.

This is part of issue #9 