### PR TITLE
Remove Parcelable requirement for UiState

### DIFF
--- a/circuit/src/main/kotlin/com/slack/circuit/Circuit+Navigator.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Circuit+Navigator.kt
@@ -15,7 +15,6 @@
  */
 package com.slack.circuit
 
-import android.os.Parcelable
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -130,10 +129,10 @@ internal fun BasicFactoryNavigator(
           val routeName = record.route
           val screen = record.screen
 
-          @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen, container) as Ui<Parcelable, Any>?
+          @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen, container) as Ui<Any, Any>?
 
           @Suppress("UNCHECKED_CAST")
-          val presenter = circuit.presenter(screen, navigator) as Presenter<Parcelable, Any>?
+          val presenter = circuit.presenter(screen, navigator) as Presenter<Any, Any>?
 
           val currentRender: (@Composable (SaveableBackStack.Record) -> Unit) =
             if (presenter != null && ui != null) {

--- a/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
@@ -15,7 +15,6 @@
  */
 package com.slack.circuit
 
-import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -25,7 +24,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
  *
  * @see present for more thorough documentation.
  */
-interface Presenter<UiState, UiEvent : Any> where UiState : Any, UiState : Parcelable {
+interface Presenter<UiState : Any, UiEvent : Any> {
   /**
    * The primary [Composable] entry point to present a [UiState] and handle its [events]. In
    * production, a [Navigator] is used to automatically connect this with a corresponding [Ui] to

--- a/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
@@ -15,7 +15,6 @@
  */
 package com.slack.circuit
 
-import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,7 +51,7 @@ import kotlinx.coroutines.flow.Flow
  *
  * @see ui
  */
-interface Ui<UiState, UiEvent : Any> where UiState : Any, UiState : Parcelable {
+interface Ui<UiState : Any, UiEvent : Any> {
   @Composable fun Render(state: UiState, events: (UiEvent) -> Unit)
 }
 
@@ -65,9 +64,9 @@ interface Ui<UiState, UiEvent : Any> where UiState : Any, UiState : Parcelable {
  *
  * @see [Ui] for main docs.
  */
-inline fun <UiState, UiEvent : Any> ui(
+inline fun <UiState : Any, UiEvent : Any> ui(
   crossinline body: @Composable (state: UiState, events: (UiEvent) -> Unit) -> Unit
-): Ui<UiState, UiEvent> where UiState : Any, UiState : Parcelable {
+): Ui<UiState, UiEvent> {
   return object : Ui<UiState, UiEvent> {
     @Composable
     override fun Render(state: UiState, events: (UiEvent) -> Unit) {


### PR DESCRIPTION
Let's start without this for now and see if it comes up again as something we need outside of UI. My thinking here is that we should strongly push folks toward using the data layer as a source of truth, and only use rememberSaveable as needed.

One argument could definitely be "we're not using ViewModels though, where do we keep things on config changes?", and to that I'd argue that we should be able to derive state at any moment from the backing repository. Presenters in this case should just be state factories.

If the nice compose-first API is a factor, we could also explore offering more compose `State` APIs rather than coroutines.

Resolves #5, also sort of helps with #35 down the line.