### PR TITLE
Tinker with Paparazzi

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,7 @@ jobs:
         run: ./.github/checksum.sh checksum.txt
 
       - name: Check LFS files
-        run: |
-          # fail fast if files not checked in using git lfs
-          "$HOOKS_DIR"/pre-receive
-          git lfs install --local
-          git lfs pull
+        uses: actionsdesk/lfs-warning@v3.2
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Generate cache key
         run: ./.github/checksum.sh checksum.txt
 
+      - name: Check LFS files
+        run: |
+          # fail fast if files not checked in using git lfs
+          "$HOOKS_DIR"/pre-receive
+          git lfs install --local
+          git lfs pull
+
       - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         id: gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check
+          arguments: check verifyPaparazzi
 
       # TODO eventually also run instrumentation/UI tests?
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ plugins {
   alias(libs.plugins.versionsPlugin)
   alias(libs.plugins.dependencyAnalysis)
   alias(libs.plugins.moshiGradlePlugin) apply false
+  alias(libs.plugins.paparazzi) apply false
 }
 
 configure<DetektExtension> {
@@ -182,7 +183,9 @@ subprojects {
 
   // Common android config
   val commonAndroidConfig: CommonExtension<*, *, *, *>.() -> Unit = {
-    compileSdk = 33
+    // Due to paparazzi not supporting API 33 yet
+    // https://github.com/cashapp/paparazzi/issues/558
+    compileSdk = 32
 
     buildFeatures { compose = true }
     composeOptions { kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get() }

--- a/circuit/build.gradle.kts
+++ b/circuit/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
   id("com.android.library")
   kotlin("android")
+  kotlin("plugin.parcelize")
+  alias(libs.plugins.paparazzi)
 }
 
 if (hasProperty("SlackRepositoryUrl")) {
@@ -11,6 +13,13 @@ android {
   namespace = "com.slack.circuit.core"
 }
 
+tasks.withType<Test>().configureEach {
+  jvmArgs(
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+  )
+}
+
 dependencies {
   api(libs.androidx.compose.integration.viewModel)
   api(libs.androidx.compose.integration.activity)
@@ -18,4 +27,6 @@ dependencies {
   api(projects.backstack)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
+  testImplementation(libs.androidx.compose.ui.ui)
+  testImplementation(libs.androidx.compose.material.material3)
 }

--- a/circuit/src/test/kotlin/com/slack/circuit/core/SnapshotTests.kt
+++ b/circuit/src/test/kotlin/com/slack/circuit/core/SnapshotTests.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.slack.circuit.core
 
 import androidx.compose.material3.Text

--- a/circuit/src/test/kotlin/com/slack/circuit/core/SnapshotTests.kt
+++ b/circuit/src/test/kotlin/com/slack/circuit/core/SnapshotTests.kt
@@ -1,0 +1,59 @@
+package com.slack.circuit.core
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import app.cash.paparazzi.DeviceConfig.Companion.PIXEL_5
+import app.cash.paparazzi.Paparazzi
+import com.slack.circuit.Circuit
+import com.slack.circuit.CircuitContent
+import com.slack.circuit.CircuitProvider
+import com.slack.circuit.Presenter
+import com.slack.circuit.Screen
+import com.slack.circuit.ScreenView
+import com.slack.circuit.Ui
+import kotlinx.coroutines.flow.Flow
+import kotlinx.parcelize.Parcelize
+import org.junit.Rule
+import org.junit.Test
+
+class SnapshotTests {
+  @get:Rule
+  val paparazzi =
+    Paparazzi(
+      deviceConfig = PIXEL_5,
+      theme = "android:Theme.Material.Light.NoActionBar"
+      // ...see docs for more options
+      )
+
+  @Test
+  fun simpleCircuitContent() {
+    val state = mutableStateOf("State")
+    val presenter = StringPresenter(state)
+    val ui = StringUi()
+    val circuit =
+      Circuit.Builder()
+        .addPresenterFactory { _, _ -> presenter }
+        .addUiFactory { ScreenView(ui) }
+        .build()
+    paparazzi.snapshot { CircuitProvider(circuit) { CircuitContent(TestScreen) } }
+  }
+}
+
+@Parcelize private object TestScreen : Screen
+
+private class StringPresenter(val state: State<String>) : Presenter<String, String> {
+  @Composable
+  override fun present(events: Flow<String>): String {
+    return state.value
+  }
+}
+
+private class StringUi : Ui<String, String> {
+
+  @Composable
+  override fun Render(state: String, events: (String) -> Unit) {
+    Text(text = state)
+  }
+}

--- a/circuit/src/test/snapshots/images/com.slack.circuit.core_SnapshotTests_simpleCircuitContent.png
+++ b/circuit/src/test/snapshots/images/com.slack.circuit.core_SnapshotTests_simpleCircuitContent.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb2d78e32f29c9e654df12b9c9fda5436d588113438fd90540a1dddea5ed8e88
+size 8615

--- a/config/git/hooks/pre-receive
+++ b/config/git/hooks/pre-receive
@@ -1,0 +1,8 @@
+# compares files that match .gitattributes filter to those actually tracked by git-lfs
+diff <(git ls-files ':(attr:filter=lfs)' | sort) <(git lfs ls-files -n | sort) >/dev/null
+
+ret=$?
+if [[ $ret -ne 0 ]]; then
+  echo >&2 "This remote has detected files committed without using Git LFS. Run 'brew install git-lfs && git lfs install' to install it and re-commit your files.";
+  exit 1;
+fi

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ molecule = "0.4.0"
 moshi = "1.13.0"
 moshix = "0.18.3"
 okhttp = "5.0.0-alpha.10"
+paparazzi = "1.0.0"
 retrofit = "2.9.0"
 robolectric = "4.8.2"
 spotless = "6.9.0"
@@ -41,6 +42,7 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 moshiGradlePlugin = { id = "dev.zacsweers.moshix", version.ref = "moshix" }
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 versionsPlugin = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 


### PR DESCRIPTION
Some early explorations
- Mostly easy to set up and record baselines
- Can nicely enforce in CI that files are checked in via lfs
- Using circuit-core temporarily, not something we probably have much of a use for in circuit itself though. Maybe a multi-screen nav flow where we assert static screens at each step?

Some early limitations
- Only works in library modules - https://github.com/cashapp/paparazzi/issues/107
- Doesn't work on compile SDK 33 yet - https://github.com/cashapp/paparazzi/issues/558
- Requires extra config for JDK 16+ - https://github.com/cashapp/paparazzi/pull/566