### PR TITLE
KMP Prototype

### DIFF
--- a/circuit/build.gradle.kts
+++ b/circuit/build.gradle.kts
@@ -1,6 +1,8 @@
+import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+
 plugins {
   id("com.android.library")
-  kotlin("android")
+  kotlin("multiplatform")
 }
 
 if (hasProperty("SlackRepositoryUrl")) {
@@ -11,11 +13,46 @@ android {
   namespace = "com.slack.circuit.core"
 }
 
+kotlin {
+  //region KMP Targets
+  android {
+    publishLibraryVariants("release")
+  }
+  jvm()
+  //endregion
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(libs.compose.runtime)
+        api(libs.coroutines)
+      }
+    }
+    maybeCreate("androidMain").apply {
+      dependencies {
+        api(projects.backstack)
+      }
+    }
+    maybeCreate("commonTest").apply {
+      dependencies {
+        implementation(libs.kotlin.test)
+      }
+    }
+    val commonJvmTest = maybeCreate("commonJvmTest").apply {
+      dependencies {
+        implementation(libs.junit)
+        implementation(libs.truth)
+      }
+    }
+    maybeCreate("androidTest").apply {
+      dependsOn(commonJvmTest)
+    }
+    maybeCreate("jvmTest").apply {
+      dependsOn(commonJvmTest)
+    }
+  }
+}
+
 dependencies {
-  api(libs.androidx.compose.integration.viewModel)
-  api(libs.androidx.compose.integration.activity)
-  api(libs.bundles.compose)
-  api(projects.backstack)
-  testImplementation(libs.junit)
-  testImplementation(libs.truth)
+  add(PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.androidx.compose.compiler)
 }

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/AndroidNavigator.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/AndroidNavigator.kt
@@ -16,22 +16,8 @@
 package com.slack.circuit
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import com.slack.circuit.backstack.SaveableBackStack
-
-/** A basic navigation interface for navigating between [screens][Screen]. */
-@Stable
-interface Navigator {
-  fun goTo(screen: Screen)
-
-  fun pop(): Screen?
-
-  object NoOp : Navigator {
-    override fun goTo(screen: Screen) {}
-    override fun pop(): Screen? = null
-  }
-}
 
 /**
  * Returns a new [Navigator] for navigating within [CircuitContents][CircuitContent].
@@ -41,8 +27,12 @@ interface Navigator {
  * @param backstack The backing [SaveableBackStack] to navigate.
  * @param onRootPop The callback to handle root [Navigator.pop] calls.
  */
+// TODO can we make this common-friendly?
 @Composable
-fun rememberCircuitNavigator(backstack: SaveableBackStack, onRootPop: (() -> Unit)?): Navigator {
+public fun rememberCircuitNavigator(
+  backstack: SaveableBackStack,
+  onRootPop: (() -> Unit)?
+): Navigator {
   return remember { NavigatorImpl(backstack, onRootPop) }
 }
 
@@ -83,15 +73,5 @@ private class NavigatorImpl(
 
   override fun toString(): String {
     return "NavigatorImpl(backstack=$backstack, onRootPop=$onRootPop)"
-  }
-}
-
-/** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
-fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
-  while (true) {
-    val screen = pop() ?: break
-    if (predicate(screen)) {
-      break
-    }
   }
 }

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Backstack+Screen.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Backstack+Screen.kt
@@ -17,7 +17,7 @@ package com.slack.circuit
 
 import com.slack.circuit.backstack.SaveableBackStack
 
-fun SaveableBackStack.push(screen: Screen) {
+public fun SaveableBackStack.push(screen: Screen) {
   push(
     SaveableBackStack.Record(
       route = screen.javaClass.simpleName,
@@ -27,5 +27,5 @@ fun SaveableBackStack.push(screen: Screen) {
   )
 }
 
-val SaveableBackStack.Record.screen: Screen
+public val SaveableBackStack.Record.screen: Screen
   get() = args.getValue("screen") as Screen

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.kt
@@ -31,12 +31,9 @@ import com.slack.circuit.backstack.ProvidedValues
 import com.slack.circuit.backstack.SaveableBackStack
 import com.slack.circuit.backstack.isAtRoot
 import com.slack.circuit.backstack.providedValuesForBackStack
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
-import kotlinx.coroutines.flow.receiveAsFlow
 
 @Composable
-fun NavigableCircuitContent(
+public fun NavigableCircuitContent(
   navigator: Navigator,
   backstack: SaveableBackStack,
   modifier: Modifier = Modifier,
@@ -58,7 +55,7 @@ fun NavigableCircuitContent(
 }
 
 @Composable
-fun BasicNavigableCircuitContent(
+public fun BasicNavigableCircuitContent(
   navigator: Navigator,
   backstack: SaveableBackStack,
   providedValues: Map<out BackStack.Record, ProvidedValues>,
@@ -94,45 +91,4 @@ fun BasicNavigableCircuitContent(
       CompositionLocalProvider(*providedLocals) { provider.invoke() }
     }
   }
-}
-
-@Composable
-fun CircuitContent(
-  screen: Screen,
-  unavailableContent: (@Composable () -> Unit)? = null,
-) {
-  CircuitContent(screen, Navigator.NoOp, unavailableContent)
-}
-
-@Composable
-private fun CircuitContent(
-  screen: Screen,
-  navigator: Navigator,
-  unavailableContent: (@Composable () -> Unit)? = null,
-) {
-  val circuit = LocalCircuitOwner.current
-
-  @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen) as Ui<Any, Any>?
-
-  @Suppress("UNCHECKED_CAST")
-  val presenter = circuit.presenter(screen, navigator) as Presenter<Any, Any>?
-
-  if (ui != null && presenter != null) {
-    CircuitRender(presenter, ui)
-  } else if (unavailableContent != null) {
-    unavailableContent()
-  } else {
-    error("Could not render screen $screen")
-  }
-}
-
-@Composable
-private fun <UiState : Any, UiEvent : Any> CircuitRender(
-  presenter: Presenter<UiState, UiEvent>,
-  ui: Ui<UiState, UiEvent>,
-) {
-  val channel = remember(presenter, ui) { Channel<UiEvent>(BUFFERED) }
-  val eventsFlow = remember(channel) { channel.receiveAsFlow() }
-  val state = presenter.present(eventsFlow)
-  ui.Render(state) { event -> channel.trySend(event) }
 }

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import android.os.Parcelable
+
+public actual interface Screen : Parcelable

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Circuit.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Circuit.kt
@@ -47,7 +47,7 @@ import androidx.compose.runtime.Immutable
  * }
  * ```
  *
- * If using navigation, use [NavigableCircuitContent] instead.
+ * If using navigation, use `NavigableCircuitContent` instead.
  *
  * ```kotlin
  * val backstack = rememberSaveableBackStack { push(AddFavoritesScreen()) }
@@ -57,26 +57,27 @@ import androidx.compose.runtime.Immutable
  * }
  * ```
  *
- * @see rememberCircuitNavigator
+ * @see `rememberCircuitNavigator`
+ * @see `NavigableCircuitContent`
  * @see CircuitContent
- * @see NavigableCircuitContent
  */
 @Immutable
-class Circuit private constructor(builder: Builder) {
+public class Circuit private constructor(builder: Builder) {
   private val uiFactories: List<ScreenViewFactory> = builder.uiFactories.toList()
   private val presenterFactories: List<PresenterFactory> = builder.presenterFactories.toList()
 
-  fun presenter(screen: Screen, navigator: Navigator): Presenter<*, *>? {
+  public fun presenter(screen: Screen, navigator: Navigator): Presenter<*, *>? {
     return nextPresenter(null, screen, navigator)
   }
 
-  fun nextPresenter(
+  public fun nextPresenter(
     skipPast: PresenterFactory?,
     screen: Screen,
     navigator: Navigator
   ): Presenter<*, *>? {
     val start = presenterFactories.indexOf(skipPast) + 1
-    for (i in start until presenterFactories.size) {
+    // TODO use the normal range syntax in 1.7.20
+    (start until presenterFactories.size).forEach { i ->
       val presenter = presenterFactories[i].create(screen, navigator)
       if (presenter != null) {
         return presenter
@@ -86,13 +87,14 @@ class Circuit private constructor(builder: Builder) {
     return null
   }
 
-  fun ui(screen: Screen): Ui<*, *>? {
+  public fun ui(screen: Screen): Ui<*, *>? {
     return nextUi(null, screen)
   }
 
-  fun nextUi(skipPast: ScreenViewFactory?, screen: Screen): Ui<*, *>? {
+  public fun nextUi(skipPast: ScreenViewFactory?, screen: Screen): Ui<*, *>? {
     val start = uiFactories.indexOf(skipPast) + 1
-    for (i in start until uiFactories.size) {
+    // TODO use the normal range syntax in 1.7.20
+    (start until uiFactories.size).forEach { i ->
       val ui = uiFactories[i].createView(screen)
       if (ui != null) {
         return ui.ui
@@ -102,42 +104,46 @@ class Circuit private constructor(builder: Builder) {
     return null
   }
 
-  fun newBuilder() = Builder(this)
+  public fun newBuilder(): Builder = Builder(this)
 
-  class Builder constructor() {
-    val uiFactories = mutableListOf<ScreenViewFactory>()
-    val presenterFactories = mutableListOf<PresenterFactory>()
+  public class Builder constructor() {
+    public val uiFactories: MutableList<ScreenViewFactory> = mutableListOf()
+    public val presenterFactories: MutableList<PresenterFactory> = mutableListOf()
 
     internal constructor(circuit: Circuit) : this() {
       uiFactories.addAll(circuit.uiFactories)
       presenterFactories.addAll(circuit.presenterFactories)
     }
 
-    fun addUiFactory(factory: ScreenViewFactory) = apply { uiFactories.add(factory) }
+    public fun addUiFactory(factory: ScreenViewFactory): Builder = apply {
+      uiFactories.add(factory)
+    }
 
-    fun addUiFactory(vararg factory: ScreenViewFactory) = apply {
+    public fun addUiFactory(vararg factory: ScreenViewFactory): Builder = apply {
       for (f in factory) {
         uiFactories.add(f)
       }
     }
 
-    fun addUiFactories(factories: Iterable<ScreenViewFactory>) = apply {
+    public fun addUiFactories(factories: Iterable<ScreenViewFactory>): Builder = apply {
       uiFactories.addAll(factories)
     }
 
-    fun addPresenterFactory(factory: PresenterFactory) = apply { presenterFactories.add(factory) }
+    public fun addPresenterFactory(factory: PresenterFactory): Builder = apply {
+      presenterFactories.add(factory)
+    }
 
-    fun addPresenterFactory(vararg factory: PresenterFactory) = apply {
+    public fun addPresenterFactory(vararg factory: PresenterFactory): Builder = apply {
       for (f in factory) {
         presenterFactories.add(f)
       }
     }
 
-    fun addPresenterFactories(factories: Iterable<PresenterFactory>) = apply {
+    public fun addPresenterFactories(factories: Iterable<PresenterFactory>): Builder = apply {
       presenterFactories.addAll(factories)
     }
 
-    fun build(): Circuit {
+    public fun build(): Circuit {
       return Circuit(this)
     }
   }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.flow.receiveAsFlow
+
+@Composable
+public fun CircuitContent(
+  screen: Screen,
+  unavailableContent: (@Composable () -> Unit)? = null,
+) {
+  CircuitContent(screen, Navigator.NoOp, unavailableContent)
+}
+
+@Composable
+internal fun CircuitContent(
+  screen: Screen,
+  navigator: Navigator,
+  unavailableContent: (@Composable () -> Unit)? = null,
+) {
+  val circuit = LocalCircuitOwner.current
+
+  @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen) as Ui<Any, Any>?
+
+  @Suppress("UNCHECKED_CAST")
+  val presenter = circuit.presenter(screen, navigator) as Presenter<Any, Any>?
+
+  if (ui != null && presenter != null) {
+    CircuitRender(presenter, ui)
+  } else if (unavailableContent != null) {
+    unavailableContent()
+  } else {
+    error("Could not render screen $screen")
+  }
+}
+
+@Composable
+private fun <UiState : Any, UiEvent : Any> CircuitRender(
+  presenter: Presenter<UiState, UiEvent>,
+  ui: Ui<UiState, UiEvent>,
+) {
+  val channel = remember(presenter, ui) { Channel<UiEvent>(BUFFERED) }
+  val eventsFlow = remember(channel) { channel.receiveAsFlow() }
+  val state = presenter.present(eventsFlow)
+  ui.Render(state) { event -> channel.trySend(event) }
+}

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitProvider.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitProvider.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 
 /** Provides the given [circuit] as a [CompositionLocal] to all composables within [content]. */
 @Composable
-fun CircuitProvider(circuit: Circuit, content: @Composable () -> Unit) {
+public fun CircuitProvider(circuit: Circuit, content: @Composable () -> Unit) {
   CompositionLocalProvider(
     LocalCircuitOwner provides circuit,
   ) {
@@ -31,17 +31,17 @@ fun CircuitProvider(circuit: Circuit, content: @Composable () -> Unit) {
   }
 }
 
-object LocalCircuitOwner {
+public object LocalCircuitOwner {
   private val LocalCircuit = staticCompositionLocalOf<Circuit?> { null }
 
   /**
    * Returns current composition local value for the owner or errors if one has not been provided.
    */
-  val current: Circuit
+  public val current: Circuit
     @Composable get() = LocalCircuit.current ?: error("No circuit available")
 
   /** Associates a [LocalCircuit] key to a value in a call to [CompositionLocalProvider]. */
-  infix fun provides(circuit: Circuit): ProvidedValue<Circuit?> {
+  public infix fun provides(circuit: Circuit): ProvidedValue<Circuit?> {
     return LocalCircuit.provides(circuit)
   }
 }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Stable
+
+/** A basic navigation interface for navigating between [screens][Screen]. */
+@Stable
+public interface Navigator {
+  public fun goTo(screen: Screen)
+
+  public fun pop(): Screen?
+
+  public object NoOp : Navigator {
+    override fun goTo(screen: Screen) {}
+    override fun pop(): Screen? = null
+  }
+}
+
+/** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
+public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
+  while (true) {
+    val screen = pop() ?: break
+    if (predicate(screen)) {
+      break
+    }
+  }
+}

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Presenter.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Presenter.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
  *
  * @see present for more thorough documentation.
  */
-interface Presenter<UiState : Any, UiEvent : Any> {
+public interface Presenter<UiState : Any, UiEvent : Any> {
   /**
    * The primary [Composable] entry point to present a [UiState] and handle its [events]. In
    * production, a [Navigator] is used to automatically connect this with a corresponding [Ui] to
@@ -92,7 +92,7 @@ interface Presenter<UiState : Any, UiEvent : Any> {
    * }
    * ```
    */
-  @Composable fun present(events: Flow<UiEvent>): UiState
+  @Composable public fun present(events: Flow<UiEvent>): UiState
 }
 
 /**
@@ -148,10 +148,10 @@ interface Presenter<UiState : Any, UiEvent : Any> {
  * ```
  */
 // Diagram generated from asciiflow: https://shorturl.at/fgjtA
-fun interface PresenterFactory {
+public fun interface PresenterFactory {
   /**
    * Creates a [Presenter] for the given [screen] if it can handle it, or returns null if it cannot
    * handle the given [screen].
    */
-  fun create(screen: Screen, navigator: Navigator): Presenter<*, *>?
+  public fun create(screen: Screen, navigator: Navigator): Presenter<*, *>?
 }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
@@ -15,8 +15,6 @@
  */
 package com.slack.circuit
 
-import android.os.Parcelable
-
 /**
  * Represents an individual screen, used as a key for [PresenterFactory] and [ScreenViewFactory].
  *
@@ -43,4 +41,4 @@ import android.os.Parcelable
  * }
  * ```
  */
-interface Screen : Parcelable
+public expect interface Screen

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/ScreenViewFactory.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/ScreenViewFactory.kt
@@ -43,11 +43,11 @@ package com.slack.circuit
  *   ui<AddFavorites.State, AddFavorites.Event> { state, events -> RenderImpl(state, events) }
  * ```
  */
-fun interface ScreenViewFactory {
-  fun createView(screen: Screen): ScreenView?
+public fun interface ScreenViewFactory {
+  public fun createView(screen: Screen): ScreenView?
 }
 
-data class ScreenView(
+public data class ScreenView(
   val ui: Ui<*, *>,
 // TODO does this kind of thing eventually move to compose Modifier instead?
 //  val uiMetadata: UiMetadata = UiMetadata()

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Ui.kt
@@ -17,7 +17,6 @@ package com.slack.circuit
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -27,7 +26,7 @@ import kotlinx.coroutines.flow.Flow
  * This has two main benefits:
  * 1. Discouraging properties and general non-composable state that writing a class may invite.
  * 2. Ensuring separation of `RenderImpl` from the [Ui] instance allows for and encourages easy UI
- * previews via Compose's [@Preview][Preview] annotations.
+ * previews via Compose's `@Preview` annotations.
  *
  * Usage:
  * ```
@@ -51,8 +50,8 @@ import kotlinx.coroutines.flow.Flow
  *
  * @see ui
  */
-interface Ui<UiState : Any, UiEvent : Any> {
-  @Composable fun Render(state: UiState, events: (UiEvent) -> Unit)
+public interface Ui<UiState : Any, UiEvent : Any> {
+  @Composable public fun Render(state: UiState, events: (UiEvent) -> Unit)
 }
 
 /**
@@ -64,7 +63,7 @@ interface Ui<UiState : Any, UiEvent : Any> {
  *
  * @see [Ui] for main docs.
  */
-inline fun <UiState : Any, UiEvent : Any> ui(
+public inline fun <UiState : Any, UiEvent : Any> ui(
   crossinline body: @Composable (state: UiState, events: (UiEvent) -> Unit) -> Unit
 ): Ui<UiState, UiEvent> {
   return object : Ui<UiState, UiEvent> {
@@ -77,6 +76,6 @@ inline fun <UiState : Any, UiEvent : Any> ui(
 
 @Suppress("NOTHING_TO_INLINE")
 @Composable
-inline fun <E : Any> collectEvents(events: Flow<E>, noinline handler: (event: E) -> Unit) {
+public inline fun <E : Any> collectEvents(events: Flow<E>, noinline handler: (event: E) -> Unit) {
   LaunchedEffect(events) { events.collect(handler) }
 }

--- a/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+public actual interface Screen

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,9 @@ org.gradle.caching=true
 # Enable Gradle configuration caching
 org.gradle.unsafe.configuration-cache=true
 
+# Disable noisy stability warning
+kotlin.mpp.stability.nowarn=true
+
 # Versioning bits
 GROUP=com.slack.circuit
 POM_URL=https://github.com/slackhq/circuit/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ coil = "2.1.0"
 compose = "1.3.0-beta01"
 # Pre-release versions for testing Kotlin previews can be found here
 # https://androidx.dev/storage/compose-compiler/repository
-composeCompiler = "1.3.0-rc02"
+composeCompiler = "1.3.0"
 compose-integration-constraintlayout = "1.0.1"
 coroutines = "1.6.4"
 dagger = "2.43.2"
@@ -98,14 +98,19 @@ androidx-palette = "androidx.palette:palette-ktx:1.0.0"
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version = "1.1.0" }
+
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:1.1.6"
 
 # Test dependencies
+coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 junit = "junit:junit:4.13.2"
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "molecule" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
   implementation(libs.bundles.androidx.activity)
   implementation(libs.coil)
   implementation(libs.coil.compose)
+  implementation(libs.coroutines)
+  implementation(libs.coroutines.android)
   implementation(libs.okhttp)
   implementation(libs.okhttp.loggingInterceptor)
   implementation(libs.okio)


### PR DESCRIPTION
This prototypes a KMP structure for `circuit` core, which allows us to use expect/actual semantics for `Screen` in a more automatic way.

There are two supported platforms: android and JVM. Navigation is only supported on Android.

While a sort of neat tech demo, I'm not totally convinced this is super worthwhile in practice (right now) because every screen implementation would usually be a `Parcelable` anyway and impose an Android env in projects anyway.

Ref #35