### PR TITLE
Set up renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "reviewers": [
+    "ZacSweers",
+    "kierse",
+    "iamritav",
+    "jpetote"
+  ],
+  "branchPrefix": "test-renovate/",
+  "gitAuthor": "OSS-Bot <svc-oss-bot@slack-corp.com>",
+  "repositories": [
+    "slackhq/circuit"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["renovatebot/github-action"],
+      "extends": ["schedule:monthly"]
+    }
+  ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,19 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 8am daily
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v32
+        with:
+          configurationFile: config/renovate/renovate.json
+          token: ${{ secrets.SLACK_OSS_GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves #64. Once this is merged it'll start running nightly. This is currently set up to add all of us as reviewers to dependency update PRs and only update the renovate action monthly (it's _very_ noisy otherwise)