### PR TITLE
Enable instrumentation on CI in preparation for follow-up PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,15 @@ jobs:
         with:
           arguments: check
 
-      # TODO eventually also run instrumentation/UI tests?
+      - name: Run instrumentation tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          arch: x86_64
+          disable-animations: true
+          disk-size: 2000M
+          heap-size: 600M
+          script: ./gradlew connectedDebugAndroidTest --stacktrace
 
       - name: (Fail-only) Bundle the build report
         if: failure()


### PR DESCRIPTION
Enabling instrumentation on CI. In preparation for https://github.com/slackhq/circuit/pull/43