### PR TITLE
Add marker interfaces

### DIFF
--- a/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
@@ -66,7 +66,7 @@ import androidx.compose.runtime.Immutable
 class Circuit private constructor(builder: Builder) {
   private val uiFactories: List<Ui.Factory> = builder.uiFactories.toList()
   private val presenterFactories: List<Presenter.Factory> = builder.presenterFactories.toList()
-  val onUnavailableContent: (@Composable (screen: Any) -> Unit)? = builder.onUnavailableContent
+  val onUnavailableContent: (@Composable (screen: Screen) -> Unit)? = builder.onUnavailableContent
 
   fun presenter(screen: Screen, navigator: Navigator): Presenter<*, *>? {
     return nextPresenter(null, screen, navigator)
@@ -109,7 +109,7 @@ class Circuit private constructor(builder: Builder) {
   class Builder constructor() {
     val uiFactories = mutableListOf<Ui.Factory>()
     val presenterFactories = mutableListOf<Presenter.Factory>()
-    var onUnavailableContent: (@Composable (screen: Any) -> Unit)? = null
+    var onUnavailableContent: (@Composable (screen: Screen) -> Unit)? = null
       private set
 
     internal constructor(circuit: Circuit) : this() {
@@ -139,7 +139,7 @@ class Circuit private constructor(builder: Builder) {
       presenterFactories.addAll(factories)
     }
 
-    fun setOnUnavailableContentCallback(callback: @Composable (screen: Any) -> Unit) = apply {
+    fun setOnUnavailableContentCallback(callback: @Composable (screen: Screen) -> Unit) = apply {
       onUnavailableContent = callback
     }
 

--- a/circuit/src/main/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/CircuitContent.kt
@@ -106,7 +106,7 @@ fun BasicNavigableCircuitContent(
 fun CircuitContent(
   screen: Screen,
   circuit: Circuit = LocalCircuitOwner.current,
-  unavailableContent: (@Composable (screen: Any) -> Unit)? = circuit.onUnavailableContent,
+  unavailableContent: (@Composable (screen: Screen) -> Unit)? = circuit.onUnavailableContent,
 ) {
   CircuitContent(screen, Navigator.NoOp, circuit, unavailableContent)
 }
@@ -116,7 +116,7 @@ private fun CircuitContent(
   screen: Screen,
   navigator: Navigator,
   circuit: Circuit,
-  unavailableContent: (@Composable (screen: Any) -> Unit)?,
+  unavailableContent: (@Composable (screen: Screen) -> Unit)?,
 ) {
   @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen) as Ui<CircuitUiState, CircuitUiEvent>?
 

--- a/circuit/src/main/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/CircuitContent.kt
@@ -115,10 +115,10 @@ private fun CircuitContent(
   circuit: Circuit,
   unavailableContent: (@Composable (screen: Any) -> Unit)?,
 ) {
-  @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen) as Ui<Any, Any>?
+  @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen) as Ui<CircuitUiState, CircuitUiEvent>?
 
   @Suppress("UNCHECKED_CAST")
-  val presenter = circuit.presenter(screen, navigator) as Presenter<Any, Any>?
+  val presenter = circuit.presenter(screen, navigator) as Presenter<CircuitUiState, CircuitUiEvent>?
 
   if (ui != null && presenter != null) {
     CircuitRender(presenter, ui)
@@ -130,7 +130,7 @@ private fun CircuitContent(
 }
 
 @Composable
-private fun <UiState : Any, UiEvent : Any> CircuitRender(
+private fun <UiState : CircuitUiState, UiEvent : CircuitUiEvent> CircuitRender(
   presenter: Presenter<UiState, UiEvent>,
   ui: Ui<UiState, UiEvent>,
 ) {

--- a/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
@@ -24,9 +24,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
  *
  * If a given [Ui] never emits events, then you can use [Nothing] for the [UiEvent] type instead.
  *
+ * If a given [Presenter] only ever emits the same state, you can define a single value-less
+ * `object` type for the state.
+ *
  * @see present for more thorough documentation.
  */
-interface Presenter<UiState : Any, UiEvent : Any> {
+interface Presenter<UiState : CircuitUiState, UiEvent : CircuitUiEvent> {
   /**
    * The primary [Composable] entry point to present a [UiState] and handle its [events]. In
    * production, a [Navigator] is used to automatically connect this with a corresponding [Ui] to

--- a/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
@@ -47,11 +47,14 @@ import kotlinx.coroutines.flow.Flow
  *
  * If a given [Ui] never emits events, then you can use [Nothing] for the [UiEvent] type instead.
  *
+ * If a given [Presenter] only ever emits the same state, you can define a single value-less
+ * `object` type for the state.
+ *
  * Note that due to a bug in studio, we can't make this a `fun interface` _yet_. Instead, use [ui].
  *
  * @see ui
  */
-interface Ui<UiState : Any, UiEvent : Any> {
+interface Ui<UiState : CircuitUiState, UiEvent : CircuitUiEvent> {
   @Composable fun Render(state: UiState, eventSink: (UiEvent) -> Unit)
 
   /**
@@ -104,7 +107,7 @@ data class ScreenUi(
  *
  * @see [Ui] for main docs.
  */
-inline fun <UiState : Any, UiEvent : Any> ui(
+inline fun <UiState : CircuitUiState, UiEvent : CircuitUiEvent> ui(
   crossinline body: @Composable (state: UiState, eventSink: (UiEvent) -> Unit) -> Unit
 ): Ui<UiState, UiEvent> {
   return object : Ui<UiState, UiEvent> {
@@ -117,6 +120,9 @@ inline fun <UiState : Any, UiEvent : Any> ui(
 
 @Suppress("NOTHING_TO_INLINE")
 @Composable
-inline fun <E : Any> EventCollector(events: Flow<E>, noinline eventCollector: (event: E) -> Unit) {
+inline fun <E : CircuitUiEvent> EventCollector(
+  events: Flow<E>,
+  noinline eventCollector: (event: E) -> Unit
+) {
   LaunchedEffect(events) { events.collect(eventCollector) }
 }

--- a/circuit/src/main/kotlin/com/slack/circuit/markers.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/markers.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Marker interface for all UiState types.
+ *
+ * States in Circuit should be minimal data models that [UIs][Ui] can render. They are produced by
+ * [presenters][Presenter] that interpret the underlying data layer and mediate input user/nav
+ * [events][CircuitUiEvent].
+ *
+ * [UIs][Ui] take states as parameters and should act as pure functions that render the input state
+ * as a UI. They should not have any side effects or directly interact with the underlying data
+ * layer.
+ *
+ * **Circuit state types should be truly immutable types.**
+ */
+@Immutable interface CircuitUiState
+
+/**
+ * Marker interface for all UiEvent types.
+ *
+ * Events in Circuit should generally reflect user interactions with the UI. They are mediated by
+ * [presenters][Presenter] and may or may not influence the current [state][CircuitUiState].
+ *
+ * **Circuit event types should be truly immutable types.**
+ */
+@Immutable interface CircuitUiEvent

--- a/sample/src/androidTest/kotlin/com/slack/circuit/sample/petdetail/PetDetailTest.kt
+++ b/sample/src/androidTest/kotlin/com/slack/circuit/sample/petdetail/PetDetailTest.kt
@@ -90,7 +90,7 @@ class PetDetailTest {
       Circuit.Builder()
         .setOnUnavailableContentCallback { screen ->
           carouselScreen = screen as PetPhotoCarouselScreen
-          PetPhotoCarousel(screen)
+          PetPhotoCarousel(PetPhotoCarouselScreen.State(screen))
         }
         .build()
 

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomeNavPresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomeNavPresenter.kt
@@ -16,11 +16,11 @@
 package com.slack.circuit.sample.home
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.EventCollector
 import com.slack.circuit.Screen
 import kotlinx.coroutines.flow.Flow
@@ -30,11 +30,11 @@ private val homeScreenNavItems = listOf(BottomNavItem.Dogs.screen, BottomNavItem
 
 @Parcelize
 object HomeNavScreen : Screen {
-  @Immutable
-  data class HomeNavState(val index: Int = DOGS_SCREEN_INDEX, val bottomNavItems: List<Screen>)
+  data class HomeNavState(val index: Int = DOGS_SCREEN_INDEX, val bottomNavItems: List<Screen>) :
+    CircuitUiEvent
 
-  sealed interface Event {
-    @Immutable data class HomeNavEvent(val index: Int) : Event
+  sealed interface Event : CircuitUiEvent {
+    data class HomeNavEvent(val index: Int) : Event
   }
 }
 

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -32,6 +32,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
+import com.slack.circuit.CircuitUiEvent
+import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
 import com.slack.circuit.Screen
@@ -58,9 +60,9 @@ object HomeScreen : Screen {
   data class State(
     val homeNavState: HomeNavScreen.HomeNavState,
     val petListState: PetListScreen.State
-  )
+  ) : CircuitUiState
 
-  sealed interface Event {
+  sealed interface Event : CircuitUiEvent {
     class HomeEvent(val event: HomeNavScreen.Event.HomeNavEvent) : Event
     class PetListEvent(val event: PetListScreen.Event) : Event
   }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
@@ -18,7 +18,6 @@ package com.slack.circuit.sample.petdetail
 import android.content.Context
 import android.content.res.Configuration
 import android.net.Uri
-import android.os.Parcelable
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_DARK
@@ -58,6 +57,7 @@ import com.google.accompanist.flowlayout.FlowCrossAxisAlignment
 import com.google.accompanist.flowlayout.FlowMainAxisAlignment
 import com.google.accompanist.flowlayout.FlowRow
 import com.slack.circuit.CircuitContent
+import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
 import com.slack.circuit.Screen
@@ -81,12 +81,11 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class PetDetailScreen(val petId: Long, val photoUrlMemoryCacheKey: String?) : Screen {
-  sealed interface State : Parcelable {
-    @Parcelize object Loading : State
+  sealed interface State : CircuitUiState {
+    object Loading : State
 
-    @Parcelize object UnknownAnimal : State
+    object UnknownAnimal : State
 
-    @Parcelize
     data class Success(
       val url: String,
       val photoUrls: List<String>,

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetPhotoCarousel.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetPhotoCarousel.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -50,6 +49,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.calculateCurrentOffsetForPage
 import com.google.accompanist.pager.rememberPagerState
+import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Presenter
 import com.slack.circuit.Screen
 import com.slack.circuit.ScreenUi
@@ -77,25 +77,25 @@ import kotlinx.parcelize.Parcelize
  */
 
 // We're using the screen key as the state as it's all static
-// TODO are we sure we want to do this?
-@Immutable
 @Parcelize
 data class PetPhotoCarouselScreen(
   val name: String,
   val photoUrls: List<String>,
   val photoUrlMemoryCacheKey: String?
-) : Screen
+) : Screen {
+  data class State(val input: PetPhotoCarouselScreen) : CircuitUiState
+}
 
 // TODO can we make a StaticStatePresenter for cases like this? Maybe even generate _from_ the
 //  screen type?
 class PetPhotoCarouselPresenter
 @AssistedInject
 constructor(@Assisted private val screen: PetPhotoCarouselScreen) :
-  Presenter<PetPhotoCarouselScreen, Nothing> {
+  Presenter<PetPhotoCarouselScreen.State, Nothing> {
 
   @Composable
-  override fun present(events: Flow<Nothing>): PetPhotoCarouselScreen {
-    return screen
+  override fun present(events: Flow<Nothing>): PetPhotoCarouselScreen.State {
+    return PetPhotoCarouselScreen.State(screen)
   }
 
   @AssistedFactory
@@ -114,7 +114,7 @@ class PetPhotoCarouselUiFactory @Inject constructor() : Ui.Factory {
   }
 }
 
-fun petPhotoCarousel(): Ui<PetPhotoCarouselScreen, Nothing> = ui { state, _ ->
+fun petPhotoCarousel(): Ui<PetPhotoCarouselScreen.State, Nothing> = ui { state, _ ->
   PetPhotoCarousel(state)
 }
 
@@ -124,19 +124,20 @@ internal object PetPhotoCarouselTestConstants {
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
-internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen) {
+internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen.State) {
+  val (name, photoUrls, photoUrlMemoryCacheKey) = state.input
   val context = LocalContext.current
   val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
   // Prefetch images
   LaunchedEffect(Unit) {
-    for (url in state.photoUrls) {
+    for (url in photoUrls) {
       if (url.isBlank()) continue
       val request = ImageRequest.Builder(context).data(url).build()
       context.imageLoader.enqueue(request)
     }
   }
 
-  val totalPhotos = state.photoUrls.size
+  val totalPhotos = photoUrls.size
   val pagerState = rememberPagerState()
   val scope = rememberCoroutineScope()
   val requester = remember { FocusRequester() }
@@ -172,7 +173,7 @@ internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen) {
     HorizontalPager(
       count = totalPhotos,
       state = pagerState,
-      key = state.photoUrls::get,
+      key = photoUrls::get,
       contentPadding = PaddingValues(16.dp),
     ) { page ->
       Card(
@@ -198,15 +199,15 @@ internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen) {
           modifier = Modifier.fillMaxWidth(),
           model =
             ImageRequest.Builder(LocalContext.current)
-              .data(state.photoUrls[page].takeIf(String::isNotBlank))
+              .data(photoUrls[page].takeIf(String::isNotBlank))
               .apply {
                 if (page == 0) {
-                  placeholderMemoryCacheKey(state.photoUrlMemoryCacheKey)
+                  placeholderMemoryCacheKey(photoUrlMemoryCacheKey)
                   crossfade(true)
                 }
               }
               .build(),
-          contentDescription = state.name,
+          contentDescription = name,
           contentScale = ContentScale.FillWidth,
         )
       }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/AboutScreen.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/AboutScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Screen
 import com.slack.circuit.ScreenUi
 import com.slack.circuit.Ui
@@ -36,7 +37,10 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 
-@Parcelize object AboutScreen : Screen
+@Parcelize
+object AboutScreen : Screen {
+  object State : CircuitUiState
+}
 
 @ContributesMultibinding(AppScope::class)
 class AboutUiFactory @Inject constructor() : Ui.Factory {
@@ -48,7 +52,7 @@ class AboutUiFactory @Inject constructor() : Ui.Factory {
   }
 }
 
-private fun aboutScreenUi() = ui<Any, Any> { _, _ -> About() }
+private fun aboutScreenUi() = ui<AboutScreen.State, Nothing> { _, _ -> About() }
 
 @Composable
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
@@ -16,7 +16,6 @@
 package com.slack.circuit.sample.petlist
 
 import android.graphics.Bitmap
-import android.os.Parcelable
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -39,7 +38,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -63,6 +61,8 @@ import androidx.palette.graphics.Palette.Swatch
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.request.ImageRequest
+import com.slack.circuit.CircuitUiEvent
+import com.slack.circuit.CircuitUiState
 import com.slack.circuit.EventCollector
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
@@ -88,8 +88,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.parcelize.Parcelize
 
-@Immutable
-@Parcelize
 data class PetListAnimal(
   val id: Long,
   val name: String,
@@ -97,17 +95,17 @@ data class PetListAnimal(
   val breed: String?,
   val gender: String,
   val age: String,
-) : Parcelable
+)
 
 @Parcelize
 object PetListScreen : Screen {
-  sealed interface State : Parcelable {
-    @Parcelize object Loading : State
-    @Parcelize object NoAnimals : State
-    @Parcelize data class Success(val animals: List<PetListAnimal>) : State
+  sealed interface State : CircuitUiState {
+    object Loading : State
+    object NoAnimals : State
+    data class Success(val animals: List<PetListAnimal>) : State
   }
 
-  sealed interface Event {
+  sealed interface Event : CircuitUiEvent {
     data class ClickAnimal(val petId: Long, val photoUrlMemoryCacheKey: String?) : Event
   }
 }

--- a/sample/src/test/kotlin/com/slack/circuit/sample/PresenterExtensions.kt
+++ b/sample/src/test/kotlin/com/slack/circuit/sample/PresenterExtensions.kt
@@ -19,15 +19,17 @@ import app.cash.molecule.RecompositionClock
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
+import com.slack.circuit.CircuitUiEvent
+import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Presenter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
-suspend fun <UiState : Any, UiEvent : Any> Presenter<UiState, UiEvent>.test(
+suspend fun <UiState : CircuitUiState, UiEvent : CircuitUiEvent> Presenter<UiState, UiEvent>.test(
   block: suspend ReceiveTurbine<UiState>.() -> Unit
 ) = test(emptyFlow(), block)
 
-suspend fun <UiState : Any, UiEvent : Any> Presenter<UiState, UiEvent>.test(
+suspend fun <UiState : CircuitUiState, UiEvent : CircuitUiEvent> Presenter<UiState, UiEvent>.test(
   events: Flow<UiEvent>,
   block: suspend ReceiveTurbine<UiState>.() -> Unit
 ) {


### PR DESCRIPTION
This gives us a few benefits at the cost of a little extra tedium when defining states and events
- We can denote them all as `@Immutable` on the base interface directly
- We can seal access to some extension functions like `EventCollector` to this, and future ones we may add for filtering events in composite presenters

We still keep the nullability enforcement and allowance for using `Nothing` as an event type.

Resolves #56
