### PR TITLE
Minor home tweaks

### DIFF
--- a/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Circuit.kt
@@ -88,16 +88,16 @@ class Circuit private constructor(builder: Builder) {
     return null
   }
 
-  fun ui(screen: Screen): Ui<*, *>? {
+  fun ui(screen: Screen): ScreenUi? {
     return nextUi(null, screen)
   }
 
-  fun nextUi(skipPast: Ui.Factory?, screen: Screen): Ui<*, *>? {
+  fun nextUi(skipPast: Ui.Factory?, screen: Screen): ScreenUi? {
     val start = uiFactories.indexOf(skipPast) + 1
     for (i in start until uiFactories.size) {
       val ui = uiFactories[i].create(screen)
       if (ui != null) {
-        return ui.ui
+        return ui
       }
     }
 

--- a/circuit/src/main/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/CircuitContent.kt
@@ -141,13 +141,14 @@ private fun CircuitContent(
   circuit: Circuit,
   unavailableContent: (@Composable (screen: Screen) -> Unit)?,
 ) {
-  @Suppress("UNCHECKED_CAST") val ui = circuit.ui(screen) as Ui<CircuitUiState, CircuitUiEvent>?
+  val screenUi = circuit.ui(screen)
 
   @Suppress("UNCHECKED_CAST")
   val presenter = circuit.presenter(screen, navigator) as Presenter<CircuitUiState, CircuitUiEvent>?
 
-  if (ui != null && presenter != null) {
-    CircuitRender(presenter, ui)
+  if (screenUi != null && presenter != null) {
+    @Suppress("UNCHECKED_CAST")
+    CircuitRender(presenter, screenUi.ui as Ui<CircuitUiState, CircuitUiEvent>)
   } else if (unavailableContent != null) {
     unavailableContent(screen)
   } else {

--- a/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
@@ -94,11 +94,7 @@ interface Ui<UiState : CircuitUiState, UiEvent : CircuitUiEvent> {
   }
 }
 
-data class ScreenUi(
-  val ui: Ui<*, *>,
-// TODO does this kind of thing eventually move to compose Modifier instead?
-//  val uiMetadata: UiMetadata = UiMetadata()
-)
+data class ScreenUi(val ui: Ui<*, *>)
 
 /**
  * Due to this bug in Studio, we can't write lambda impls of [Ui] directly. This works around it by

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
   implementation(libs.androidx.compose.accompanist.pager)
   implementation(libs.androidx.compose.accompanist.pager.indicators)
   implementation(libs.androidx.compose.accompanist.flowlayout)
+  implementation(libs.androidx.compose.accompanist.systemUi)
   implementation(libs.androidx.palette)
   debugImplementation(libs.androidx.compose.ui.tooling)
   implementation(libs.bundles.androidx.activity)

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/BottomNavItem.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/BottomNavItem.kt
@@ -21,14 +21,18 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.slack.circuit.Screen
 import com.slack.circuit.sample.petlist.AboutScreen
+import com.slack.circuit.sample.petlist.Filters
 import com.slack.circuit.sample.petlist.PetListScreen
 
-private const val DOGS_SCREEN_NAME = "Dogs"
+private const val DOGS_SCREEN_NAME = "Adoptables"
 private const val ABOUT_SCREEN_NAME = "About"
-const val DOGS_SCREEN_INDEX = 0
-const val ABOUT_SCREEN_INDEX = 1
 
-sealed class BottomNavItem(val title: String, val screen: Screen, val icon: ImageVector) {
-  object Dogs : BottomNavItem(DOGS_SCREEN_NAME, PetListScreen(), Icons.Filled.Home)
-  object About : BottomNavItem(ABOUT_SCREEN_NAME, AboutScreen(), Icons.Filled.Info)
+sealed class BottomNavItem(val title: String, val icon: ImageVector) {
+  abstract fun screenFor(filters: Filters): Screen
+  object Adoptables : BottomNavItem(DOGS_SCREEN_NAME, Icons.Filled.Home) {
+    override fun screenFor(filters: Filters) = PetListScreen(filters)
+  }
+  object About : BottomNavItem(ABOUT_SCREEN_NAME, Icons.Filled.Info) {
+    override fun screenFor(filters: Filters) = AboutScreen
+  }
 }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomeNavPresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomeNavPresenter.kt
@@ -26,12 +26,11 @@ import com.slack.circuit.Screen
 import kotlinx.coroutines.flow.Flow
 import kotlinx.parcelize.Parcelize
 
-private val homeScreenNavItems = listOf(BottomNavItem.Dogs.screen, BottomNavItem.About.screen)
+private val HOME_NAV_ITEMS = listOf(BottomNavItem.Adoptables, BottomNavItem.About)
 
 @Parcelize
 object HomeNavScreen : Screen {
-  data class HomeNavState(val index: Int = DOGS_SCREEN_INDEX, val bottomNavItems: List<Screen>) :
-    CircuitUiEvent
+  data class HomeNavState(val index: Int, val bottomNavItems: List<BottomNavItem>) : CircuitUiEvent
 
   sealed interface Event : CircuitUiEvent {
     data class HomeNavEvent(val index: Int) : Event
@@ -41,7 +40,7 @@ object HomeNavScreen : Screen {
 @Composable
 fun homeNavPresenter(events: Flow<HomeNavScreen.Event.HomeNavEvent>): HomeNavScreen.HomeNavState {
   var state by remember {
-    mutableStateOf(HomeNavScreen.HomeNavState(bottomNavItems = homeScreenNavItems))
+    mutableStateOf(HomeNavScreen.HomeNavState(index = 0, bottomNavItems = HOME_NAV_ITEMS))
   }
 
   // LaunchedEffect/EventCollector makes it take two clicks, figure it out when i come back.

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.slack.circuit.CircuitContent
@@ -59,12 +58,9 @@ import com.slack.circuit.ScreenUi
 import com.slack.circuit.Ui
 import com.slack.circuit.onNavEvent
 import com.slack.circuit.sample.di.AppScope
-import com.slack.circuit.sample.petlist.AboutScreen
-import com.slack.circuit.sample.petlist.Filters
 import com.slack.circuit.sample.petlist.Gender
 import com.slack.circuit.sample.petlist.PetListFilterPresenter
 import com.slack.circuit.sample.petlist.PetListFilterScreen
-import com.slack.circuit.sample.petlist.PetListScreen
 import com.slack.circuit.sample.petlist.Size
 import com.slack.circuit.sample.ui.StarTheme
 import com.slack.circuit.ui
@@ -222,23 +218,12 @@ fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) 
     ) { paddingValues ->
       Box(modifier = Modifier.padding(paddingValues)) {
         val screen =
-          getScreen(
-            state.homeNavState.index,
-            state.petListFilterState.gender,
-            state.petListFilterState.size
+          state.homeNavState.bottomNavItems[state.homeNavState.index].screenFor(
+            state.petListFilterState.filters
           )
         CircuitContent(screen, { event -> eventSink(HomeScreen.Event.ChildNav(event)) })
       }
     }
-  }
-}
-
-@Composable
-private fun getScreen(index: Int, gender: Gender, size: Size): Screen {
-  return if (index == DOGS_SCREEN_INDEX) {
-    PetListScreen(Filters(gender = gender, size = size))
-  } else {
-    AboutScreen()
   }
 }
 
@@ -272,7 +257,7 @@ private fun GenderFilterOption(
       Column {
         Text(text = gender.name)
         RadioButton(
-          selected = state.gender == gender,
+          selected = state.filters.gender == gender,
           onClick = {
             eventSink(
               HomeScreen.Event.PetListFilterEvent(PetListFilterScreen.Event.FilterByGender(gender))
@@ -295,7 +280,7 @@ private fun SizeFilterOption(
       Column {
         Text(text = size.name)
         RadioButton(
-          selected = state.size == size,
+          selected = state.filters.size == size,
           onClick = {
             eventSink(
               HomeScreen.Event.PetListFilterEvent(PetListFilterScreen.Event.FilterBySize(size))

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -188,12 +188,12 @@ fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) 
             Text(
               "Adoptables",
               fontSize = 22.sp,
-              color = MaterialTheme.colorScheme.onPrimaryContainer
+              color = MaterialTheme.colorScheme.onBackground
             )
           },
           colors =
             TopAppBarDefaults.centerAlignedTopAppBarColors(
-              containerColor = MaterialTheme.colorScheme.primaryContainer
+              containerColor = MaterialTheme.colorScheme.background
             ),
           actions = {
             IconButton(
@@ -203,10 +203,10 @@ fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) 
                 )
               }
             ) {
-              androidx.compose.material.Icon(
+              Icon(
                 imageVector = Icons.Default.FilterList,
-                contentDescription = "filter pet list",
-                tint = Color.White
+                contentDescription = "Filter pet list",
+                tint = MaterialTheme.colorScheme.onBackground
               )
             }
           },

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -150,7 +150,7 @@ private fun homeUi() =
 @Composable
 fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) {
   val systemUiController = rememberSystemUiController()
-  systemUiController.setStatusBarColor(MaterialTheme.colorScheme.background)
+  systemUiController.setStatusBarColor(MaterialTheme.colorScheme.surface)
   systemUiController.setNavigationBarColor(MaterialTheme.colorScheme.primaryContainer)
   val modalState =
     rememberModalBottomSheetState(
@@ -189,7 +189,7 @@ fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) 
           },
           colors =
             TopAppBarDefaults.centerAlignedTopAppBarColors(
-              containerColor = MaterialTheme.colorScheme.background
+              containerColor = MaterialTheme.colorScheme.surface
             ),
           actions = {
             IconButton(

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -23,10 +23,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.material.BottomNavigation
-import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.IconButton
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.icons.Icons
@@ -34,7 +31,10 @@ import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -148,7 +148,6 @@ class HomeUiFactory @Inject constructor() : Ui.Factory {
 private fun homeUi() =
   ui<HomeScreen.State, HomeScreen.Event> { state, events -> HomeContent(state, events) }
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) {
@@ -185,11 +184,7 @@ fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) 
       topBar = {
         CenterAlignedTopAppBar(
           title = {
-            Text(
-              "Adoptables",
-              fontSize = 22.sp,
-              color = MaterialTheme.colorScheme.onBackground
-            )
+            Text("Adoptables", fontSize = 22.sp, color = MaterialTheme.colorScheme.onBackground)
           },
           colors =
             TopAppBarDefaults.centerAlignedTopAppBarColors(
@@ -213,8 +208,10 @@ fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) 
         )
       },
       bottomBar = {
-        BottomNavigationBar(selectedIndex = state.homeNavState.index) { index ->
-          eventSink(HomeScreen.Event.HomeEvent(HomeNavScreen.Event.HomeNavEvent(index)))
+        StarTheme(useDarkTheme = true) {
+          BottomNavigationBar(selectedIndex = state.homeNavState.index) { index ->
+            eventSink(HomeScreen.Event.HomeEvent(HomeNavScreen.Event.HomeNavEvent(index)))
+          }
         }
       }
     ) { paddingValues ->
@@ -243,17 +240,14 @@ private fun getScreen(index: Int, gender: Gender, size: Size): Screen {
 @Composable
 private fun BottomNavigationBar(selectedIndex: Int, onSelectedIndex: (Int) -> Unit) {
   // These are the buttons on the NavBar, they dictate where we navigate too.
-  val items = listOf(BottomNavItem.Dogs, BottomNavItem.About)
-  BottomNavigation(
-    backgroundColor = MaterialTheme.colorScheme.onPrimaryContainer,
-    contentColor = Color.White
+  val items = listOf(BottomNavItem.Adoptables, BottomNavItem.About)
+  NavigationBar(
+    containerColor = MaterialTheme.colorScheme.primaryContainer,
   ) {
     items.forEachIndexed { index, item ->
-      BottomNavigationItem(
+      NavigationBarItem(
         icon = { Icon(imageVector = item.icon, contentDescription = item.title) },
         label = { Text(text = item.title) },
-        selectedContentColor = MaterialTheme.colorScheme.secondary,
-        unselectedContentColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(0.4f),
         alwaysShowLabel = true,
         selected = selectedIndex == index,
         onClick = { onSelectedIndex(index) }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.slack.circuit.CircuitContent
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
@@ -65,6 +66,7 @@ import com.slack.circuit.sample.petlist.PetListFilterPresenter
 import com.slack.circuit.sample.petlist.PetListFilterScreen
 import com.slack.circuit.sample.petlist.PetListScreen
 import com.slack.circuit.sample.petlist.Size
+import com.slack.circuit.sample.ui.StarTheme
 import com.slack.circuit.ui
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.assisted.Assisted
@@ -151,6 +153,9 @@ private fun homeUi() =
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) {
+  val systemUiController = rememberSystemUiController()
+  systemUiController.setStatusBarColor(MaterialTheme.colorScheme.background)
+  systemUiController.setNavigationBarColor(MaterialTheme.colorScheme.primaryContainer)
   val modalState =
     rememberModalBottomSheetState(
       initialValue =

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -15,12 +15,12 @@
  */
 package com.slack.circuit.sample.home
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.BottomNavigation
@@ -217,14 +217,16 @@ fun HomeContent(state: HomeScreen.State, eventSink: (HomeScreen.Event) -> Unit) 
           eventSink(HomeScreen.Event.HomeEvent(HomeNavScreen.Event.HomeNavEvent(index)))
         }
       }
-    ) {
-      val screen =
-        getScreen(
-          state.homeNavState.index,
-          state.petListFilterState.gender,
-          state.petListFilterState.size
-        )
-      CircuitContent(screen, { event -> eventSink(HomeScreen.Event.ChildNav(event)) })
+    ) { paddingValues ->
+      Box(modifier = Modifier.padding(paddingValues)) {
+        val screen =
+          getScreen(
+            state.homeNavState.index,
+            state.petListFilterState.gender,
+            state.petListFilterState.size
+          )
+        CircuitContent(screen, { event -> eventSink(HomeScreen.Event.ChildNav(event)) })
+      }
     }
   }
 }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
@@ -180,8 +180,8 @@ internal object PetDetailTestConstants {
 @Composable
 internal fun PetDetail(state: PetDetailScreen.State) {
   val systemUiController = rememberSystemUiController()
-  systemUiController.setStatusBarColor(MaterialTheme.colorScheme.background)
-  systemUiController.setNavigationBarColor(MaterialTheme.colorScheme.background)
+  systemUiController.setStatusBarColor(MaterialTheme.colorScheme.surface)
+  systemUiController.setNavigationBarColor(MaterialTheme.colorScheme.surface)
   val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
   Scaffold(modifier = Modifier.systemBarsPadding()) { padding ->
     when (state) {

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.flowlayout.FlowCrossAxisAlignment
 import com.google.accompanist.flowlayout.FlowMainAxisAlignment
 import com.google.accompanist.flowlayout.FlowRow
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.slack.circuit.CircuitContent
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
@@ -178,6 +179,9 @@ internal object PetDetailTestConstants {
 
 @Composable
 internal fun PetDetail(state: PetDetailScreen.State) {
+  val systemUiController = rememberSystemUiController()
+  systemUiController.setStatusBarColor(MaterialTheme.colorScheme.background)
+  systemUiController.setNavigationBarColor(MaterialTheme.colorScheme.background)
   val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
   Scaffold(modifier = Modifier.systemBarsPadding()) { padding ->
     when (state) {

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/AboutScreen.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/AboutScreen.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class AboutScreen : Screen {
+object AboutScreen : Screen {
   object State : CircuitUiState
   object Event : CircuitUiEvent
 }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
@@ -112,7 +112,8 @@ enum class Size {
   LARGE
 }
 
-@Parcelize class Filters(val gender: Gender = Gender.ALL, val size: Size = Size.ALL) : Parcelable
+@Parcelize
+data class Filters(val gender: Gender = Gender.ALL, val size: Size = Size.ALL) : Parcelable
 
 @Parcelize
 data class PetListScreen(val filters: Filters = Filters()) : Screen {

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetListFilterBottomSheet.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetListFilterBottomSheet.kt
@@ -15,7 +15,6 @@
  */
 package com.slack.circuit.sample.petlist
 
-import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,9 +39,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 object PetListFilterScreen : Screen {
-  @Parcelize
-  data class State(val gender: Gender, val size: Size, val showBottomSheet: Boolean) :
-    CircuitUiState, Parcelable
+  data class State(val filters: Filters, val showBottomSheet: Boolean) : CircuitUiState
 
   sealed interface Event : CircuitUiEvent {
     object ToggleAnimalFilter : Event
@@ -74,9 +71,7 @@ class PetListFilterPresenter @AssistedInject constructor() :
   Presenter<PetListFilterScreen.State, PetListFilterScreen.Event> {
   @Composable
   override fun present(events: Flow<PetListFilterScreen.Event>): PetListFilterScreen.State {
-    var state by remember {
-      mutableStateOf(PetListFilterScreen.State(gender = Gender.ALL, size = Size.ALL, false))
-    }
+    var state by remember { mutableStateOf(PetListFilterScreen.State(Filters(), false)) }
 
     EventCollector(events) { event ->
       state =
@@ -85,10 +80,10 @@ class PetListFilterPresenter @AssistedInject constructor() :
             state.copy(showBottomSheet = !state.showBottomSheet)
           }
           is PetListFilterScreen.Event.FilterByGender -> {
-            state.copy(gender = event.gender)
+            state.copy(filters = state.filters.copy(gender = event.gender))
           }
           is PetListFilterScreen.Event.FilterBySize -> {
-            state.copy(size = event.size)
+            state.copy(filters = state.filters.copy(size = event.size))
           }
         }
     }


### PR DESCRIPTION
This makes a few UI cleanup tweaks to the home screen

- Fix missing padding with a `Box()`
- Fix home tab name (resolves #122)
- Use correct material3 nav bar - https://m3.material.io/components/navigation-bar/implementation/android. Resolves #126 along the way
- Simplify screen management by reducing hardcoding 
- Opportunistic fix wrong return type for Circuit.ui() functions
- Use system UI controller to color status bar and nav bar

| **Before** | **After** |
| ---------- | --------- |
| ![Screenshot_1663797119](https://user-images.githubusercontent.com/1361086/191617081-89a55b4f-df24-46a2-9993-6a50e44f1976.png) | ![Screenshot_1663797067](https://user-images.githubusercontent.com/1361086/191617098-af8b7831-03a9-4282-90f1-80b2b8eb27e8.png) |
