### PR TITLE
Convert backstack project to KMP

### DIFF
--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -1,18 +1,61 @@
+import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+
 plugins {
   id("com.android.library")
-  kotlin("android")
+  kotlin("multiplatform")
 }
 
 if (hasProperty("SlackRepositoryUrl")) {
   apply(plugin = "com.vanniktech.maven.publish")
 }
 
+kotlin {
+  //region KMP Targets
+  android {
+    publishLibraryVariants("release")
+  }
+  jvm()
+  //endregion
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(libs.compose.runtime)
+        api(libs.coroutines)
+      }
+    }
+    maybeCreate("androidMain").apply {
+      dependencies {
+        implementation(libs.androidx.lifecycle.viewModel.compose)
+        api(libs.androidx.lifecycle.viewModel)
+        api(libs.bundles.compose)
+      }
+    }
+    maybeCreate("commonTest").apply {
+      dependencies {
+        implementation(libs.kotlin.test)
+      }
+    }
+    val commonJvmTest = maybeCreate("commonJvmTest").apply {
+      dependencies {
+        implementation(libs.junit)
+        implementation(libs.truth)
+      }
+    }
+    maybeCreate("jvmTest").apply {
+      dependsOn(commonJvmTest)
+    }
+  }
+}
+
 android {
   namespace = "com.slack.circuit.backstack"
 }
 
+androidComponents {
+  beforeVariants { variant -> variant.enableAndroidTest = false }
+}
+
 dependencies {
-  implementation(libs.androidx.lifecycle.viewModel.compose)
-  api(libs.androidx.lifecycle.viewModel)
-  api(libs.bundles.compose)
+  add(PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.androidx.compose.compiler)
 }

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/AndroidBackStackRecordLocalProvider.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/AndroidBackStackRecordLocalProvider.kt
@@ -1,0 +1,9 @@
+package com.slack.circuit.backstack
+
+import androidx.compose.runtime.compositionLocalOf
+
+@Suppress("RemoveExplicitTypeArguments")
+internal actual val LocalBackStackRecordLocalProviders =
+  compositionLocalOf<List<BackStackRecordLocalProvider<BackStack.Record>>> {
+    listOf(SaveableStateRegistryBackStackRecordLocalProvider, ViewModelBackStackRecordLocalProvider)
+  }

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/Navigation.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/Navigation.kt
@@ -36,9 +36,9 @@ import androidx.compose.ui.text.TextStyle
 
 /** Presentation logic for currently visible routes of a navigable UI. */
 @Stable
-interface NavDecoration {
+public interface NavDecoration {
   @Composable
-  fun <T> DecoratedContent(
+  public fun <T> DecoratedContent(
     arg: T,
     backStackDepth: Int,
     modifier: Modifier,
@@ -47,14 +47,14 @@ interface NavDecoration {
 }
 
 /** Default values and common alternatives used by navigable composables. */
-object NavigatorDefaults {
+public object NavigatorDefaults {
 
   private const val FIVE_PERCENT = 0.05f
   private val SlightlyRight = { width: Int -> (width * FIVE_PERCENT).toInt() }
   private val SlightlyLeft = { width: Int -> 0 - (width * FIVE_PERCENT).toInt() }
 
   /** The default [NavDecoration] used in navigation. */
-  object DefaultDecoration : NavDecoration {
+  public object DefaultDecoration : NavDecoration {
     @OptIn(ExperimentalAnimationApi::class)
     @Composable
     override fun <T> DecoratedContent(
@@ -96,7 +96,7 @@ object NavigatorDefaults {
   }
 
   /** An empty [NavDecoration] that emits the content with no surrounding decoration or logic. */
-  object EmptyDecoration : NavDecoration {
+  public object EmptyDecoration : NavDecoration {
     @Composable
     override fun <T> DecoratedContent(
       arg: T,
@@ -112,7 +112,7 @@ object NavigatorDefaults {
    * Bright ugly error text telling a developer they didn't provide a route that a [BackStack] asked
    * for.
    */
-  val UnavailableRoute: @Composable (String) -> Unit = { route ->
+  public val UnavailableRoute: @Composable (String) -> Unit = { route ->
     BasicText(
       "Route not available: $route",
       Modifier.background(Color.Red),

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -22,14 +22,14 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import java.util.UUID
 
 @Composable
-fun rememberSaveableBackStack(init: SaveableBackStack.() -> Unit): SaveableBackStack =
+public fun rememberSaveableBackStack(init: SaveableBackStack.() -> Unit): SaveableBackStack =
   rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack().apply(init) }
 
-fun SaveableBackStack.push(route: String, args: Map<String, Any?> = emptyMap()) {
+public fun SaveableBackStack.push(route: String, args: Map<String, Any?> = emptyMap()) {
   push(SaveableBackStack.Record(route, args))
 }
 
-inline fun SaveableBackStack.popUntil(predicate: (SaveableBackStack.Record) -> Boolean) {
+public inline fun SaveableBackStack.popUntil(predicate: (SaveableBackStack.Record) -> Boolean) {
   while (topRecord?.let(predicate) == false) pop()
 }
 
@@ -37,7 +37,7 @@ inline fun SaveableBackStack.popUntil(predicate: (SaveableBackStack.Record) -> B
  * A [BackStack] that supports saving its state via [rememberSaveable]. See
  * [rememberSaveableBackStack].
  */
-class SaveableBackStack : BackStack<SaveableBackStack.Record> {
+public class SaveableBackStack : BackStack<SaveableBackStack.Record> {
 
   private val entryList = mutableStateListOf<Record>()
 
@@ -46,21 +46,21 @@ class SaveableBackStack : BackStack<SaveableBackStack.Record> {
 
   override fun iterator(): Iterator<Record> = entryList.iterator()
 
-  val topRecord: Record?
+  public val topRecord: Record?
     get() = entryList.firstOrNull()
 
-  fun push(record: Record) {
+  public fun push(record: Record) {
     entryList.add(0, record)
   }
 
   override fun pop(): Record? = entryList.removeFirstOrNull()
 
-  data class Record(
+  public data class Record(
     override val route: String,
     val args: Map<String, Any?> = emptyMap(),
     override val key: String = UUID.randomUUID().toString()
   ) : BackStack.Record {
-    companion object {
+    internal companion object {
       val Saver: Saver<Record, List<Any>> =
         Saver(
           save = { value ->
@@ -82,7 +82,7 @@ class SaveableBackStack : BackStack<SaveableBackStack.Record> {
     }
   }
 
-  companion object {
+  internal companion object {
     val Saver =
       Saver<SaveableBackStack, List<Any>>(
         save = { value -> value.entryList.map { with(Record.Saver) { save(it)!! } } },

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableStateRegistryBackStackRecordLocalProvider.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableStateRegistryBackStackRecordLocalProvider.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 
 /** A [BackStackRecordLocalProvider] that provides a [SaveableStateRegistry] for each record. */
-object SaveableStateRegistryBackStackRecordLocalProvider :
+public object SaveableStateRegistryBackStackRecordLocalProvider :
   BackStackRecordLocalProvider<BackStack.Record> {
   @Composable
   override fun providedValuesFor(record: BackStack.Record): ProvidedValues {
@@ -43,7 +43,6 @@ object SaveableStateRegistryBackStackRecordLocalProvider :
     // This write depends on childRegistry.parentRegistry being snapshot state backed
     childRegistry.parentRegistry = LocalSaveableStateRegistry.current
     return remember(childRegistry) {
-      @Suppress("ObjectLiteralToLambda")
       object : ProvidedValues {
         val list = listOf(LocalSaveableStateRegistry provides childRegistry)
         @Composable

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/ViewModelBackStackRecordLocalProvider.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/ViewModelBackStackRecordLocalProvider.kt
@@ -39,7 +39,8 @@ private fun Context.findActivity(): Activity? {
 }
 
 /** A [BackStackRecordLocalProvider] that provides [LocalViewModelStoreOwner] */
-object ViewModelBackStackRecordLocalProvider : BackStackRecordLocalProvider<BackStack.Record> {
+internal object ViewModelBackStackRecordLocalProvider :
+  BackStackRecordLocalProvider<BackStack.Record> {
   @Composable
   override fun providedValuesFor(record: BackStack.Record): ProvidedValues {
     // Implementation note: providedValuesFor stays in the composition as long as the
@@ -81,12 +82,13 @@ object ViewModelBackStackRecordLocalProvider : BackStackRecordLocalProvider<Back
   }
 }
 
-class BackStackRecordLocalProviderViewModel : ViewModel() {
+public class BackStackRecordLocalProviderViewModel : ViewModel() {
   private val owners = mutableMapOf<String, ViewModelStore>()
 
-  fun viewModelStoreForKey(key: String): ViewModelStore = owners.getOrPut(key) { ViewModelStore() }
+  internal fun viewModelStoreForKey(key: String): ViewModelStore =
+    owners.getOrPut(key) { ViewModelStore() }
 
-  fun removeViewModelStoreOwnerForKey(key: String): ViewModelStore? = owners.remove(key)
+  internal fun removeViewModelStoreOwnerForKey(key: String): ViewModelStore? = owners.remove(key)
 
   override fun onCleared() {
     owners.forEach { (_, store) -> store.clear() }

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
@@ -22,17 +22,17 @@ import androidx.compose.runtime.Stable
  * order is top-first (first element is the top of the stack).
  */
 @Stable
-interface BackStack<R : BackStack.Record> : Iterable<R> {
+public interface BackStack<R : BackStack.Record> : Iterable<R> {
   /** The number of records contained in this [BackStack] that will be seen by an iterator. */
-  val size: Int
+  public val size: Int
 
   /**
    * Attempt to pop the top item off of the back stack, returning the popped [Record] if popping was
    * successful or `null` if no entry was popped.
    */
-  fun pop(): R?
+  public fun pop(): R?
 
-  interface Record {
+  public interface Record {
     /**
      * A value that identifies this record uniquely, even if it shares the same [route] with another
      * record. This key may be used by [BackStackRecordLocalProvider]s to associate presentation
@@ -40,17 +40,17 @@ interface BackStack<R : BackStack.Record> : Iterable<R> {
      *
      * [key] MUST NOT change for the life of the record.
      */
-    val key: String
+    public val key: String
 
     /** The name of the route that should present this record. */
-    val route: String
+    public val route: String
   }
 }
 
 /** `true` if the [BackStack] contains no records. [BackStack.firstOrNull] will return `null`. */
-val BackStack<*>.isEmpty: Boolean
+public val BackStack<*>.isEmpty: Boolean
   get() = size == 0
 
 /** `true` if the [BackStack] contains exactly one record. */
-val BackStack<*>.isAtRoot: Boolean
+public val BackStack<*>.isAtRoot: Boolean
   get() = size == 1

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.kt
@@ -16,19 +16,19 @@
 package com.slack.circuit.backstack
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ProvidedValue
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.key
 
-fun interface BackStackRecordLocalProvider<in R : BackStack.Record> {
-  @Composable fun providedValuesFor(record: R): ProvidedValues
+public fun interface BackStackRecordLocalProvider<in R : BackStack.Record> {
+  @Composable public fun providedValuesFor(record: R): ProvidedValues
 }
 
-fun interface ProvidedValues {
-  @Composable fun provideValues(): List<ProvidedValue<*>>
+public fun interface ProvidedValues {
+  @Composable public fun provideValues(): List<ProvidedValue<*>>
 }
 
-class CompositeProvidedValues(private val list: List<ProvidedValues>) : ProvidedValues {
+internal class CompositeProvidedValues(private val list: List<ProvidedValues>) : ProvidedValues {
   @Composable
   override fun provideValues(): List<ProvidedValue<*>> = buildList {
     list.forEach { addAll(key(it) { it.provideValues() }) }
@@ -36,7 +36,7 @@ class CompositeProvidedValues(private val list: List<ProvidedValues>) : Provided
 }
 
 @Composable
-fun <R : BackStack.Record> providedValuesForBackStack(
+public fun <R : BackStack.Record> providedValuesForBackStack(
   backStack: BackStack<R>,
   stackLocalProviders: List<BackStackRecordLocalProvider<R>> = emptyList(),
   includeDefaults: Boolean = true,
@@ -61,8 +61,5 @@ fun <R : BackStack.Record> providedValuesForBackStack(
     }
   }
 
-@Suppress("RemoveExplicitTypeArguments")
-val LocalBackStackRecordLocalProviders =
-  compositionLocalOf<List<BackStackRecordLocalProvider<BackStack.Record>>> {
-    listOf(SaveableStateRegistryBackStackRecordLocalProvider, ViewModelBackStackRecordLocalProvider)
-  }
+internal expect val LocalBackStackRecordLocalProviders:
+  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>

--- a/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/JvmBackStackRecordLocalProvider.kt
+++ b/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/JvmBackStackRecordLocalProvider.kt
@@ -1,0 +1,8 @@
+package com.slack.circuit.backstack
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+internal actual val LocalBackStackRecordLocalProviders:
+  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
+  get() = compositionLocalOf { emptyList() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,9 @@ org.gradle.configureondemand=false
 # https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
 
+# Disable noisy stability warning
+kotlin.mpp.stability.nowarn=true
+
 # Enable Gradle configuration caching
 org.gradle.unsafe.configuration-cache=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,11 +101,19 @@ androidx-lifecycle-viewModel-compose = { module = "androidx.lifecycle:lifecycle-
 
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version = "1.1.0" }
+
+coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
+
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:1.1.6"
 junit = "junit:junit:4.13.2"
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "molecule" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ compose = "1.3.0-beta01"
 # Pre-release versions for testing Kotlin previews can be found here
 # https://androidx.dev/storage/compose-compiler/repository
 composeCompiler = "1.3.1"
+compose-jb = "1.2.0-beta01"
 compose-integration-constraintlayout = "1.0.1"
 dagger = "2.44"
 dependencyAnalysisPlugin = "1.13.1"
@@ -102,7 +103,7 @@ androidx-lifecycle-viewModel-compose = { module = "androidx.lifecycle:lifecycle-
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version = "1.1.0" }
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-jb" }
 
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
Part one of trying to enable plain JVM usage, starting with backstack!

There are two supported platforms: android and JVM. Navigation and saveable backstack are only supported on Android.

Prior art: #60

Ref #35
