### PR TITLE
Offer CircuitConfig to factories

### DIFF
--- a/circuit/src/main/kotlin/com/slack/circuit/CircuitConfig.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/CircuitConfig.kt
@@ -20,8 +20,8 @@ import androidx.compose.runtime.Immutable
 
 /**
  * [CircuitConfig] adapts [presenter factories][Presenter.Factory] to their corresponding renderable
- * [uifactories][Ui.Factory] using [screens][Screen]. Create instances using [the Builder] [Builder]
- * and create new [CircuitContent] with it to run presenter/UI pairings.
+ * [ui factories][Ui.Factory] using [screens][Screen]. Create instances using [the Builder]
+ * [Builder] and create new [CircuitContent] with it to run presenter/UI pairings.
  *
  * ## Construction
  *
@@ -79,7 +79,7 @@ class CircuitConfig private constructor(builder: Builder) {
   ): Presenter<*>? {
     val start = presenterFactories.indexOf(skipPast) + 1
     for (i in start until presenterFactories.size) {
-      val presenter = presenterFactories[i].create(screen, navigator)
+      val presenter = presenterFactories[i].create(screen, navigator, this)
       if (presenter != null) {
         return presenter
       }
@@ -95,7 +95,7 @@ class CircuitConfig private constructor(builder: Builder) {
   fun nextUi(skipPast: Ui.Factory?, screen: Screen): ScreenUi? {
     val start = uiFactories.indexOf(skipPast) + 1
     for (i in start until uiFactories.size) {
-      val ui = uiFactories[i].create(screen)
+      val ui = uiFactories[i].create(screen, this)
       if (ui != null) {
         return ui
       }

--- a/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Presenter.kt
@@ -145,7 +145,7 @@ interface Presenter<UiState : CircuitUiState> {
    *   val detailsPresenter: ProfilerDetailsPresenter.Factory,
    *   val callScreenRouter: CallScreenRouter.Factory
    * ) : Presenter.Factory {
-   *   override fun create(screen: Screen, navigator: Navigator): Presenter<*, *>? {
+   *   override fun create(screen: Screen, navigator: Navigator, circuitConfig: CircuitConfig): Presenter<*, *>? {
    *     return when (screen) {
    *       is ProfileHeader -> headerPresenter.create(screen)
    *       is ProfileActions -> actionsPresenter.create(screen, callScreenRouter.create(navigator))
@@ -162,6 +162,6 @@ interface Presenter<UiState : CircuitUiState> {
      * Creates a [Presenter] for the given [screen] if it can handle it, or returns null if it
      * cannot handle the given [screen].
      */
-    fun create(screen: Screen, navigator: Navigator): Presenter<*>?
+    fun create(screen: Screen, navigator: Navigator, circuitConfig: CircuitConfig): Presenter<*>?
   }
 }

--- a/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/main/kotlin/com/slack/circuit/Ui.kt
@@ -64,6 +64,7 @@ interface Ui<UiState : CircuitUiState> {
    * class FavoritesUiFactory @Inject constructor() : Ui.Factory {
    *  override fun create(
    *    screen: Screen,
+   *    circuitConfig: CircuitConfig
    *  ): ScreenUi? {
    *    val ui = when (screen) {
    *      is AddFavorites -> {
@@ -84,7 +85,7 @@ interface Ui<UiState : CircuitUiState> {
    * ```
    */
   fun interface Factory {
-    fun create(screen: Screen): ScreenUi?
+    fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi?
   }
 }
 

--- a/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.sp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitContent
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
@@ -91,7 +92,11 @@ object HomeScreen : Screen {
 class HomeScreenPresenterFactory
 @Inject
 constructor(private val homePresenterFactory: HomePresenter.Factory) : Presenter.Factory {
-  override fun create(screen: Screen, navigator: Navigator): Presenter<*>? {
+  override fun create(
+    screen: Screen,
+    navigator: Navigator,
+    circuitConfig: CircuitConfig
+  ): Presenter<*>? {
     if (screen is HomeScreen) return homePresenterFactory.create(navigator)
     return null
   }
@@ -126,7 +131,7 @@ constructor(
 
 @ContributesMultibinding(AppScope::class)
 class HomeUiFactory @Inject constructor() : Ui.Factory {
-  override fun create(screen: Screen): ScreenUi? {
+  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
     if (screen is HomeScreen) {
       return ScreenUi(homeUi())
     }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetDetail.kt
@@ -55,6 +55,7 @@ import com.google.accompanist.flowlayout.FlowCrossAxisAlignment
 import com.google.accompanist.flowlayout.FlowMainAxisAlignment
 import com.google.accompanist.flowlayout.FlowRow
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitContent
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
@@ -123,7 +124,11 @@ constructor(
   private val petDetailPresenterFactory: PetDetailPresenter.Factory,
   private val petPhotoCarousel: PetPhotoCarouselPresenter.Factory,
 ) : Presenter.Factory {
-  override fun create(screen: Screen, navigator: Navigator): Presenter<*>? {
+  override fun create(
+    screen: Screen,
+    navigator: Navigator,
+    circuitConfig: CircuitConfig
+  ): Presenter<*>? {
     return when (screen) {
       is PetDetailScreen -> petDetailPresenterFactory.create(screen)
       is PetPhotoCarouselScreen -> petPhotoCarousel.create(screen)
@@ -161,7 +166,7 @@ constructor(
 
 @ContributesMultibinding(AppScope::class)
 class PetDetailUiFactory @Inject constructor() : Ui.Factory {
-  override fun create(screen: Screen): ScreenUi? {
+  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
     if (screen is PetDetailScreen) return ScreenUi(petDetailUi())
     return null
   }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetPhotoCarousel.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petdetail/PetPhotoCarousel.kt
@@ -50,6 +50,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.calculateCurrentOffsetForPage
 import com.google.accompanist.pager.rememberPagerState
+import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Presenter
 import com.slack.circuit.Screen
@@ -103,7 +104,7 @@ constructor(@Assisted private val screen: PetPhotoCarouselScreen) :
 
 @ContributesMultibinding(AppScope::class)
 class PetPhotoCarouselUiFactory @Inject constructor() : Ui.Factory {
-  override fun create(screen: Screen): ScreenUi? {
+  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
     return when (screen) {
       is PetPhotoCarouselScreen -> ScreenUi(petPhotoCarousel())
       else -> null

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/AboutScreen.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/AboutScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
@@ -50,7 +51,11 @@ object AboutScreen : Screen {
 class AboutPresenterFactory
 @Inject
 constructor(private val aboutPresenterFactory: AboutPresenter.Factory) : Presenter.Factory {
-  override fun create(screen: Screen, navigator: Navigator): Presenter<*>? {
+  override fun create(
+    screen: Screen,
+    navigator: Navigator,
+    circuitConfig: CircuitConfig
+  ): Presenter<*>? {
     if (screen is AboutScreen) return aboutPresenterFactory.create()
     return null
   }
@@ -67,7 +72,7 @@ class AboutPresenter @AssistedInject constructor() : Presenter<AboutScreen.State
 
 @ContributesMultibinding(AppScope::class)
 class AboutUiFactory @Inject constructor() : Ui.Factory {
-  override fun create(screen: Screen): ScreenUi? {
+  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
     if (screen is AboutScreen) {
       return ScreenUi(aboutScreenUi())
     }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetList.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
@@ -126,7 +127,11 @@ class PetListScreenPresenterFactory
 constructor(
   private val petListPresenterFactory: PetListPresenter.Factory,
 ) : Presenter.Factory {
-  override fun create(screen: Screen, navigator: Navigator): Presenter<*>? {
+  override fun create(
+    screen: Screen,
+    navigator: Navigator,
+    circuitConfig: CircuitConfig
+  ): Presenter<*>? {
     if (screen is PetListScreen) return petListPresenterFactory.create(navigator, screen)
     return null
   }
@@ -200,7 +205,7 @@ internal fun Animal.toPetListAnimal(): PetListAnimal {
 
 @ContributesMultibinding(AppScope::class)
 class PetListUiFactory @Inject constructor() : Ui.Factory {
-  override fun create(screen: Screen): ScreenUi? {
+  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
     if (screen is PetListScreen) {
       return ScreenUi(petListUi())
     }

--- a/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetListFilterBottomSheet.kt
+++ b/sample/src/main/kotlin/com/slack/circuit/sample/petlist/PetListFilterBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
@@ -52,7 +53,7 @@ object PetListFilterScreen : Screen {
 
 @ContributesMultibinding(AppScope::class)
 class PetListFilterScreenFactory @Inject constructor() : Ui.Factory {
-  override fun create(screen: Screen): ScreenUi? {
+  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
     if (screen is PetListFilterScreen) return ScreenUi(petListFilterUi())
     return null
   }
@@ -63,7 +64,11 @@ class PetListFilterPresenterFactory
 @Inject
 constructor(private val petListFilterPresenterFactory: PetListFilterPresenter.Factory) :
   Presenter.Factory {
-  override fun create(screen: Screen, navigator: Navigator): Presenter<*>? {
+  override fun create(
+    screen: Screen,
+    navigator: Navigator,
+    circuitConfig: CircuitConfig
+  ): Presenter<*>? {
     if (screen is PetListFilterScreen) return petListFilterPresenterFactory.create()
     return null
   }


### PR DESCRIPTION
This way factories can do delegation and composition. For example, a factory can handle all screen types just to trace them but delegate to "real" ones under the hood that it fetches from Circuit.

Resolves #152