### PR TITLE
Initial pass at docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 🚧 **Under construction** 🚧
 
-This project is very much a work in progress and far from finished!
+### [slackhq.github.io/circuit](https://slackhq.github.io/circuit)
 
 License
 --------

--- a/docs/circuit-content.md
+++ b/docs/circuit-content.md
@@ -1,0 +1,10 @@
+CircuitContent
+==============
+
+The simplest entry point of a circuit is the composable `CircuitContent` function. This function accepts a `Screen` and automatically finds and pairs corresponding `Presenter` and `Ui` instances to render in it.
+
+```kotlin
+setContent {
+  CircuitContent(HomeScreen)
+}
+```

--- a/docs/code-gen.md
+++ b/docs/code-gen.md
@@ -1,0 +1,14 @@
+Code Generation
+===============
+
+We plan to include code gen tools to cover most of any boilerplate, making the common paths simple while allowing for more complex hand-written structures when needed.
+
+At a high level using the examples above, we want to generate the following bits of code for users
+
+```kotlin
+class FavoritesScreenUiFactory
+class FavoritesScreenPresenterFactory
+private fun favoritesUi()
+```
+
+We’re intentionally saving implementing this step last as it makes making API changes more difficult. Follow along progress here: https://github.com/slackhq/circuit/issues/13

--- a/docs/factories.md
+++ b/docs/factories.md
@@ -1,0 +1,49 @@
+Factories
+=========
+
+At its core, Circuit works on the Factory pattern. Every `Presenter` and `Ui` is contributed to a `CircuitConfig` instance by a corresponding factory that creates them for given `Screen`s. These are intended to be aggregated in the DI layer and added to a `CircuitConfig` instance during construction.
+
+```kotlin
+val circuitConfig = CircuitConfig.Builder()
+  .addUiFactory(FavoritesUiFactory())
+  .addPresenterFactory(FavoritesPresenterFactory())
+  .build()
+```
+
+!!! tip "Look familiar?"
+    If you’ve used Moshi or Retrofit, these should feel fairly familiar!
+
+Presenter factories can be generated or hand-written, depending on if they aggregate an entire screen or are simple one-offs. Presenters are also given access to the current Navigator in this level.
+
+```kotlin
+class FavoritesScreenPresenterFactory @Inject constructor(
+  private val favoritesPresenterFactory: FavoritesPresenter.Factory,
+) : Presenter.Factory {
+  override fun create(screen: Screen, navigator: Navigator): Presenter<*>? {
+    return when (screen) {
+      is FavoritesScreen -> favoritesPresenterFactory.create(screen, navigator)
+      else -> null
+    }
+  }
+}
+```
+
+UI factories are similar, but generally should not aggregate other UIs unless there’s a DI-specific reason to do so (which there usually isn’t!).
+
+```kotlin
+class FavoritesScreenUiFactory : @Inject constructor() : Ui.Factory {
+  override fun create(screen: Screen): ScreenUi? {
+    return when (screen) {
+      is FavoritesScreen -> ScreenUi(favoritesUi())
+      else null ->
+    }
+  }
+}
+
+private fun favoritesUi() = ui<State> { state -> Favorites(state) }
+```
+
+!!! info
+    Note how these return a `ScreenUi` class that holds the Ui instance. We are using this indirection as a toe-hold for possible other future UI metadata, such as `Modifier` instances.
+
+We canonically write these out as a separate function (`favoritesUi()`) that returns a `Ui`, which in turn calls through to the real (basic) Compose UI function (`Favorites()`). This ensures our basic compose functions are top-level and accessible by tests, and also discourages storing anything in class members rather than idiomatic composable state vars.

--- a/docs/interop.md
+++ b/docs/interop.md
@@ -1,0 +1,4 @@
+Interop
+=======
+
+TODO: https://github.com/slackhq/circuit/issues/42

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,55 @@
+Navigation
+==========
+
+For navigable contents, we have a custom compose-based backstack implementation that the androidx folks shared with us. Navigation becomes two parts:
+
+1. A `BackStack`, where we use a `SaveableBackStack` implementation that saves a stack of `Screen`s and the `ProvidedValues` for each record on that stack (allowing us to save and restore on configuration changes automatically).
+2. A `Navigator`, which is a simple interface that we can point at a `BackStack` and offers simple `goTo(<screen>)`/`pop()` semantics. These are offered to presenters to perform navigation as needed to other screens.
+
+A new navigable content surface is handled via the `NavigableCircuitContent` functions.
+
+```kotlin
+setContent {
+  val backstack = rememberSaveableBackStack { push(HomeScreen) }
+  val navigator = rememberCircuitNavigator(backstack, onBackPressedDispatcher::onBackPressed)
+  NavigableCircuitContent(navigator, backstack)
+}
+```
+
+Presenters are then given access to these navigator instances via `Presenter.Factory` (described in TODO link Factories), which they can save if needed to perform navigation.
+
+```kotlin
+fun showAddFavorites() {
+  navigator.goTo(
+    AddFavorites(
+      externalId = uuidGenerator.generate()
+    )
+  )
+}
+```
+
+## Nested Navigation
+
+Navigation carries special semantic value in `CircuitContent` as well, where it’s common for UIs to want to curry navigation events emitted by nested UIs. For this case, there’s a `CircuitContent` overload that accepts an optional onNavEvent callback that you must then forward to a Navigator instance.
+
+```kotlin
+@Composable fun ParentUi(state: ParentState) {
+  CircuitContent(NestedScreen, onNavEvent = { navEvent -> state.eventSink(NestedNav(navEvent)) })
+}
+
+@Composable fun ParentPresenter(navigator: Navigator): ParentState {
+  return ParentState(...) { event ->
+    when (event) {
+      is NestedNav -> navigator.onNavEvent(event.navEvent)
+    }
+  }
+}
+
+@Composable 
+fun NestedPresenter(navigator: Navigator): NestedState {
+  // These are forwarded up!
+  navigator.goTo(AnotherScreen)
+  
+  // ...
+}
+```

--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -1,0 +1,126 @@
+Presenter
+=========
+
+The core Presenter interface is this:
+
+```kotlin
+interface Presenter<UiState : CircuitUiState> {
+  @Composable fun present(): UiState
+}
+```
+
+Presenters are solely intended to be business logic for your UI and a translation layer in front of your data layers. They are generally Dagger-injected types as the data layers they interpret are usually coming from the DI graph. In simple cases, they can be typed as a simple `@Composable` presenter function and Circuit code gen (TODO link) can generate the corresponding interface and (TODO link) factory for you.
+
+A very simple presenter can look like this:
+
+```kotlin
+class FavoritesPresenter(...) : Presenter<State> {
+  @Composable override fun present(): State {
+    var favorites by remember { mutableStateOf(<initial>) }
+    
+    return State(favorites) { event -> ... }
+  }
+}
+```
+
+In this example, the `present()` function simply computes a `state` and returns it. If it has UI events to handle, an `eventSink: (Event) -> Unit` property should be exposed in the `State` type it returns.
+
+With DI, the above example becomes something more like this:
+
+```kotlin
+class FavoritesPresenter @AssistedInject constructor(
+  @Assisted private val screen: FavoritesScreen,
+  @Assisted private val navigator: Navigator,
+  private val favoritesRepository: FavoritesRepository
+) : Presenter<State> {
+  @Composable override fun present(): State {
+    // ...
+  }
+  @AssistedFactory
+  fun interface Factory {
+    fun create(screen: FavoritesScreen, navigator: Navigator): FavoritesPresenter
+  }
+}
+```
+
+Assisted injection allows passing on the `screen` and `navigator` from the relevant `Presenter.Factory` to this presenter for further reference.
+
+When dealing with nested presenters, a presenter could bypass implementing a class entirely by simply being written as a function that other presenters can use. 
+
+```kotlin
+// From cashapp/molecule's README examples
+@Composable
+fun ProfilePresenter(
+  userFlow: Flow<User>,
+  balanceFlow: Flow<Long>,
+): ProfileModel {
+  val user by userFlow.collectAsState(null)
+  val balance by balanceFlow.collectAsState(0L)
+
+  return if (user == null) {
+    Loading
+  } else {
+    Data(user.name, balance)
+  }
+}
+```
+
+Presenters can present other presenters by injecting their assisted factories/providers, but note that this makes them a composite presenter that is now assuming responsibility for managing state of multiple nested presenters. [We have an example of this in the Circuit repo](https://github.com/slackhq/circuit/blob/main/sample/src/main/kotlin/com/slack/circuit/sample/home/HomePresenter.kt).
+
+## Retention
+
+There are three types of composable retention functions used in Circuit.
+
+1. `remember` – from Compose, remembers a value across recompositions. Can be any type.
+2. `rememberRetained` – custom, remembers a value across recompositions and configuration changes. Can be any type, but should not retain leak-able things like `Navigator` instances or `Context` instances. Backed by a hidden `ViewModel` on Android.
+3. `rememberSaveable` – from Compose, remembers a value across recompositions, configuration changes, and process death. Must be `Parcelable` or implement a custom `Saver`, should not retain leakable things like `Navigator` instances or `Context` instances. Backed by the framework saved instance state system.
+
+Developers should use the right tool accordingly depending on their use case. Consider these three examples.
+
+The first one will preserve the `count` value across recompositions, but not configuration changes or process death.
+
+```kotlin
+@Composable
+fun CounterPresenter(): CounterState {
+  var count by remember { mutableStateOf(0) }
+
+  return CounterState(count) { event ->
+    when (event) {
+      is CounterEvent.Increment -> count++
+      is CounterEvent.Decrement -> count--
+    }
+  }
+}
+```
+
+The second one will preserve the state across recompositions and configuration changes, but not process death.
+
+```kotlin
+@Composable
+fun CounterPresenter(): CounterState {
+  var count by rememberRetained { mutableStateOf(0) }
+
+  return CounterState(count) { event ->
+    when (event) {
+      is CounterEvent.Increment -> count++
+      is CounterEvent.Decrement -> count--
+    }
+  }
+}
+```
+
+The third case will preserve the `count` state across recompositions, configuration changes, and process death. However, it only works with primitives or `Parcelable` state types.
+
+```kotlin
+@Composable
+fun CounterPresenter(): CounterState {
+  var count by rememberSaveable { mutableStateOf(0) }
+
+  return CounterState(count) { event ->
+    when (event) {
+      is CounterEvent.Increment -> count++
+      is CounterEvent.Decrement -> count--
+    }
+  }
+}
+```

--- a/docs/screen.md
+++ b/docs/screen.md
@@ -1,0 +1,27 @@
+Screen
+======
+
+The core `Screen` interface is this:
+
+```kotlin
+interface Screen : Parcelable
+```
+
+These types are `Parcelable` for saveability in our backstack and easy deeplinking. A `Screen` can be a simple marker object type or a data object with information to pass on.
+
+```kotlin
+@Parcelize data class AddFavorites(val externalId: UUID) : Screen
+```
+
+These are used by `Navigator`s (when called from presenters) or `CircuitContent` (when called from UIs) to start a new sub-circuit.
+
+```kotlin
+// In a presenter class
+fun showAddFavorites() {
+  navigator.goTo(
+    AddFavorites(
+      externalId = uuidGenerator.generate()
+    )
+  )
+}
+```

--- a/docs/states-and-events.md
+++ b/docs/states-and-events.md
@@ -1,0 +1,24 @@
+States and Events
+=================
+
+The core state and event interfaces in Circuit are `CircuitUiState` and `CircuitUiEvent`. All state and event types should implement/extend these marker interfaces.
+
+Presenters are simple functions that determine and return composable states. UIs are simple functions that render states. Uis can emit events via `eventSink` properties in state classes, which presenters then handle. These are the core building blocks!
+
+States and events should be immutable value types.
+
+> Wait, event callbacks in state types?
+
+Yep! This may feel like a departure from how you’ve written UDF patterns in the past, but we really like it. We tried different patterns before with event `Flow`s and having Circuit internals manage these for you, but we found they came with tradeoffs and friction points that we could avoid by just treating event emissions as another aspect of state. The end result is a tidier structure of state + event flows.
+
+* Simpler cognitive overheads due to not always using `Flow` for events, which comes with caveats in compose (wrapping operators in `remember` calls, pipelining nested event flows, etc)
+* Simple event-less UIs – state just doesn’t have an event sink.
+* Simpler testing – no manual event flow needed. You end up writing more realistic tests where you tick along your presenter by emitting with its returned states directly.
+* Different state types can have different event handling (e.g. `Click` may not make sense for `Loading` states).
+* No internal ceremony around setting up a `Channel` and multicasting event streams.
+* No risk of dropping events (unlike `Flow`).
+
+!!! note
+    Currently, while functions are treated as implicitly `Stable` by the compose compiler, they not skippable when they're non-composable Unit-returning lambdas with equal-but-unstable captures. This may change though, and would be another free benefit for this case.
+
+A longer-form writeup can be found in [this PR](https://github.com/slackhq/circuit/pull/146).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,182 @@
+Testing
+=======
+
+Circuit is designed to make testing as easy as possible. Its core components are not mockable nor do they need to be mocked. Fakes are provided where needed, everything else can be used directly.
+
+Circuit will have a test artifact containing APIs to aid testing both presenters and composable UIs:
+
+1. `Presenter.test()` - an extension function that bridges the Compose and coroutines world. Use of this function is recommended for testing presenter state emissions and incoming UI events. Under the hood it leverages [Molecule](https://github.com/cashapp/molecule) and [Turbine](https://github.com/cashapp/turbine).
+2. `FakeNavigator` - a test fake implementing the Circuit/Navigator interface. Use of this object is recommended when testing screen navigation (ie. goTo, pop/back).
+
+## Example
+
+Testing a Circuit Presenter and UI is a breeze! Consider the following example:
+
+```kotlin
+data class Favorite(id: Long, ...)
+
+@Parcelable
+object FavoritesScreen : Screen {
+  sealed interface State : CircuitUiState {
+    object Loading : State
+    object NoFavorites : State
+    data class Results(
+      val list: List<Favorite>,
+      val eventSink: (Event) -> Unit
+    ) : State
+  }
+  
+  sealed interface Event : CircuitUiEvent {
+    data class ClickFavorite(id: Long): Event
+  }
+}
+
+class FavoritesPresenter @Inject constructor(
+    navigator: Navigator,
+    repo: FavoritesRepository
+) : Presenter<State> {
+  @Composable override fun present(): State {
+    val favorites by produceState<List<Favorites>?>(null) {
+      value = repo.getFavorites()
+    }
+    
+    return when {
+      favorites == null -> Loading
+      favorites.isEmpty() -> NoFavorites
+      else ->
+        Results(favorites) { event ->
+          when (event) {
+            is ClickFavorite -> navigator.goTo(FavoriteScreen(event.id))
+          }
+        }
+    }
+  }
+}
+
+@Composable
+fun FavoritesList(state: FavoritesScreen.State) {
+  when (state) {
+    Loading -> Text(text = stringResource(R.string.loading_favorites))
+    NoFavorites -> Text(
+      modifier = Modifier.testTag("no favorites"),
+      text = stringResource(R.string.no_favorites)
+    )
+    is Results -> {
+      Text(text = "Your Favorites")
+      LazyColumn {
+        items(state.list) { Favorite(it, state.eventSink) }
+      }
+    }
+  }
+}
+
+@Composable
+private fun Favorite(favorite: Favorite, eventSink: (FavoritesScreen.Event) -> Unit) {
+  Row(
+    modifier = Modifier.testTag("favorite"),
+    onClick = { eventSink(ClickFavorite(favorite.id)) }
+  ) {
+    Image(
+      drawable = favorite.drawable, 
+      contentDescription = stringResource(R.string.favorite_image_desc)
+    )
+    Text(text = favorite.name)
+    Text(text = favorite.date)
+  }
+}
+```
+
+### Presenter Unit Tests
+
+Here’s a test to verify presenter emissions using the `Presenter.test()` helper. This function acts as a shorthand over Molecule + Turbine to give you a `ReceiveTurbine.() -> Unit` lambda.
+
+```kotlin
+@Test 
+fun `present - emit loading state then list of favorites`() = runTest {
+  val favorites = listOf(Favorite(1L, ...))
+
+  val repo = TestFavoritesRepository(favorites)
+  val presenter = PetListPresenter(navigator, repo)
+  
+  presenter.test {
+    assertThat(awaitItem()).isEqualTo(PetListScreen.State.Loading)
+    val resultsItem = awaitItem() as Results
+    assertThat(resultsItem.favorites).isEqualTo(favorites)
+  }
+}
+
+The same helper can be used when testing how the presenter responds to incoming events: 
+
+@Test 
+fun `present - navigate to favorite screen`() = runTest {
+  val repo = TestFavoritesRepository(Favorite(123L))
+  val presenter = PetListPresenter(navigator, repo)
+  
+  presenter.test {
+    assertThat(awaitItem()).isEqualTo(PetListScreen.State.Loading)
+    val resultsItem = awaitItem() as Results
+    assertThat(resultsItem.favorites).isEqualTo(favorites)
+    val clickFavorite = FavoriteScreen.Event.ClickFavorite(123L)
+    
+    // simulate user tapping favorite in UI
+    resultsItem.eventSink(clickFavorite)
+    
+    assertThat(navigator.awaitNextScreen()).isEqualTo(FavoriteScreen(clickFavorite.id))
+  }
+}
+```
+
+### Android UI Instrumentation Tests
+
+UI tests can be driven directly through ComposeTestRule and use its Espresso-esque API for assertions:
+
+```kotlin
+@Test
+fun favoritesList_show_favorites_for_result_state() = runTest {
+  val favorites = listOf(Favorite(1L, ...)
+
+  composeTestRule.run {
+    setContent { 
+      // bootstrap the UI in the desired state
+      FavoritesList(
+        state = FavoriteScreen.State.Results(favorites) { /* event callback */ }
+      )
+    }
+
+    onNodeWithTag("no favorites").assertDoesNotExist()
+    onNodeWithText("Your Favorites").assertIsDisplayed()
+    onAllNodesWithTag("favorite").assertCountEquals(1)
+  }
+}
+```
+
+
+### Future: Android UI Unit Tests via Paparazzi
+
+We’ve started exploring use of [Paparazzi](https://github.com/cashapp/paparazzi), which allows us to render Android UI without a physical device or emulator. More to come soon, but in short it would work similar to the above but be for purely non-functional 1:1 state ↔ UI tests.
+
+```kotlin
+@Test
+fun previewFavorite() {
+  paparazzi.snapshot { PreviewFavorite() }
+}
+```
+
+These are easy to maintain and review in GitHub.
+
+Another neat idea is we think this will make it easy to stand up compose preview functions for IDE use and reuse them.
+
+```kotlin
+// In your main source
+@Preview
+@Composable
+internal fun PreviewFavorite() {
+  Favorite()
+}
+
+// In your unit test
+@Test
+fun previewFavorite() {
+  paparazzi.snapshot { PreviewFavorite() }
+}
+```

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,41 @@
+UI
+==
+
+The core Ui interface is simply this:
+
+```kotlin
+interface Ui<UiState : CircuitUiState> {
+  @Composable fun Content(state: UiState)
+}
+```
+
+Like presenters, simple UIs can also skip the class all together for use in other UIs. Core unit of granularity is just the @Composable function. In fact, when implementing these in practice they rarely use dependency injection at all and can normally just be written as top-level composable functions annotated with` @CircuitInject`.
+
+```kotlin
+@CircuitInject<FavoritesScreen> // Relevant DI wiring is generated
+@Composable
+private fun Favorites(state: FavoritesState) {
+  // ...
+}
+```
+
+Writing UIs like this has a number of benefits.
+
+* Functions-only nudges developers toward writing idiomatic compose code and not keeping un-scoped/un-observable state elsewhere (such as class properties).
+* These functions are extremely easy to stand up in tests.
+* These functions are extremely easy to stand up in Compose _preview_ functions.
+
+
+Let’s look a little more closely at the last bullet point about preview functions. With the above example, we can easily stand up previews for all of our different states!
+
+```kotlin
+@Preview
+@Composable
+private fun PreviewFavorites() = Favorites(FavoritesState(listOf("Reeses", "Lola"))
+
+@Preview
+@Composable
+private fun PreviewEmptyFavorites() = Favorites(FavoritesState(listOf())
+```
+
+TODO image sample of IDE preview

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,15 +18,15 @@ theme:
   palette:
     - media: '(prefers-color-scheme: light)'
       scheme: default
-      primary: 'teal'
-      accent: 'white'
+      primary: 'white'
+      accent: 'yellow'
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: '(prefers-color-scheme: dark)'
       scheme: slate
-      primary: 'teal'
-      accent: 'white'
+      primary: 'black'
+      accent: 'yellow'
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -57,14 +57,21 @@ markdown_extensions:
   - admonition
 
 nav:
-  - 'Overview':
-      - 'Circuit': index.md
-  # TODO example is from KotlinPoet, adapt from them once we have docs uploaded
+  - 'Introduction': index.md
+  - 'States and Events': states-and-events.md
+  - 'Screen': screen.md
+  - 'CircuitContent': circuit-content.md
+  - 'Navigation': navigation.md
+  - 'Presenter': presenter.md
+  - 'Ui': ui.md
+  - 'Testing': testing.md
+  - 'Factories': factories.md
+  - 'Code Generation': code-gen.md
+  - 'Interop': interop.md
 #  - 'API':
-#      - 'kotlinpoet': 1.x/kotlinpoet/index.html
-#      - 'interop-javapoet': 1.x/interop-javapoet/index.html
-#      - 'interop-kotlinx-metadata': 1.x/interop-kotlinx-metadata/index.html
-#      - 'interop-ksp': 1.x/interop-ksp/index.html
+#      - 'circuit': 0.x/circuit/index.html
+#      - 'circuit-retained': 0.x/circuit-retained/index.html
+#      - 'backstack': 0.x/backstack/index.html
 #  - 'Discussions ⏏': https://github.com/slackhq/circuit/discussions
 #  - 'Change Log': changelog.md
   - 'Contributing': contributing.md


### PR DESCRIPTION
This is an initial pass at porting our internal design docs up to mkdocs.

Run locally via `./deploy_website.sh --local` to tinker with it.

Resolves #41. Still missing API docs but that can come once we finish setting up dokka later.

Full documentation for mkdocs is here: https://squidfunk.github.io/mkdocs-material/reference/. A lot of stuff we can do!

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1361086/193681228-260965f7-7b24-4b42-8662-049229ab106e.png">
