### PR TITLE
Convert Circuit Core to KMP

### DIFF
--- a/circuit/build.gradle.kts
+++ b/circuit/build.gradle.kts
@@ -1,21 +1,62 @@
+import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+
 plugins {
   id("com.android.library")
-  kotlin("android")
+  kotlin("multiplatform")
 }
 
 if (hasProperty("SlackRepositoryUrl")) {
   apply(plugin = "com.vanniktech.maven.publish")
 }
 
+kotlin {
+  //region KMP Targets
+  android {
+    publishLibraryVariants("release")
+  }
+  jvm()
+  //endregion
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(libs.compose.runtime)
+        api(libs.coroutines)
+        api(projects.backstack)
+        api(projects.circuitRetained)
+      }
+    }
+    maybeCreate("androidMain").apply {
+      dependencies {
+        api(libs.bundles.compose)
+        implementation(libs.androidx.compose.integration.activity)
+      }
+    }
+    maybeCreate("commonTest").apply {
+      dependencies {
+        implementation(libs.kotlin.test)
+      }
+    }
+    val commonJvmTest = maybeCreate("commonJvmTest").apply {
+      dependencies {
+        implementation(libs.junit)
+        implementation(libs.truth)
+      }
+    }
+    maybeCreate("jvmTest").apply {
+      dependsOn(commonJvmTest)
+    }
+  }
+}
+
 android {
   namespace = "com.slack.circuit.core"
 }
 
+androidComponents {
+  beforeVariants { variant -> variant.enableAndroidTest = false }
+}
+
 dependencies {
-  api(libs.bundles.compose)
-  api(projects.backstack)
-  api(projects.circuitRetained)
-  implementation(libs.androidx.compose.integration.activity)
-  testImplementation(libs.junit)
-  testImplementation(libs.truth)
+  add(PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.androidx.compose.compiler)
 }

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/CircuitCompositionLocals.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/CircuitCompositionLocals.android.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.slack.circuit.retained.LocalRetainedStateRegistryOwner
+import com.slack.circuit.retained.continuityRetainedStateRegistry
+
+@Composable
+internal actual fun PlatformCompositionLocals(content: @Composable () -> Unit) {
+  CompositionLocalProvider(
+    LocalRetainedStateRegistryOwner provides continuityRetainedStateRegistry(),
+  ) {
+    content()
+  }
+}

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.android.kt
@@ -33,7 +33,7 @@ import com.slack.circuit.backstack.isAtRoot
 import com.slack.circuit.backstack.providedValuesForBackStack
 
 @Composable
-fun NavigableCircuitContent(
+public fun NavigableCircuitContent(
   navigator: Navigator,
   backstack: SaveableBackStack,
   modifier: Modifier = Modifier,
@@ -57,7 +57,7 @@ fun NavigableCircuitContent(
 }
 
 @Composable
-fun BasicNavigableCircuitContent(
+public fun BasicNavigableCircuitContent(
   navigator: Navigator,
   backstack: SaveableBackStack,
   providedValues: Map<out BackStack.Record, ProvidedValues>,
@@ -94,66 +94,4 @@ fun BasicNavigableCircuitContent(
       CompositionLocalProvider(*providedLocals) { provider() }
     }
   }
-}
-
-@Composable
-fun CircuitContent(
-  screen: Screen,
-  circuitConfig: CircuitConfig = LocalCircuitOwner.current,
-  unavailableContent: (@Composable (screen: Screen) -> Unit)? = circuitConfig.onUnavailableContent,
-) {
-  CircuitContent(screen, Navigator.NoOp, circuitConfig, unavailableContent)
-}
-
-@Composable
-fun CircuitContent(
-  screen: Screen,
-  onNavEvent: (event: NavEvent) -> Unit,
-  circuitConfig: CircuitConfig = LocalCircuitOwner.current,
-  unavailableContent: (@Composable (screen: Screen) -> Unit)? = circuitConfig.onUnavailableContent,
-) {
-  val navigator =
-    remember(onNavEvent) {
-      object : Navigator {
-        override fun goTo(screen: Screen) {
-          onNavEvent(GoToNavEvent(screen))
-        }
-
-        override fun pop(): Screen? {
-          onNavEvent(PopNavEvent)
-          return null
-        }
-      }
-    }
-  CircuitContent(screen, navigator, circuitConfig, unavailableContent)
-}
-
-@Composable
-private fun CircuitContent(
-  screen: Screen,
-  navigator: Navigator,
-  circuitConfig: CircuitConfig,
-  unavailableContent: (@Composable (screen: Screen) -> Unit)?,
-) {
-  val screenUi = circuitConfig.ui(screen)
-
-  @Suppress("UNCHECKED_CAST")
-  val presenter = circuitConfig.presenter(screen, navigator) as Presenter<CircuitUiState>?
-
-  if (screenUi != null && presenter != null) {
-    @Suppress("UNCHECKED_CAST") (CircuitContent(presenter, screenUi.ui as Ui<CircuitUiState>))
-  } else if (unavailableContent != null) {
-    unavailableContent(screen)
-  } else {
-    error("Could not render screen $screen")
-  }
-}
-
-@Composable
-private fun <UiState : CircuitUiState> CircuitContent(
-  presenter: Presenter<UiState>,
-  ui: Ui<UiState>,
-) {
-  val state = presenter.present()
-  ui.Content(state)
 }

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -16,40 +16,8 @@
 package com.slack.circuit
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import com.slack.circuit.backstack.SaveableBackStack
-
-/** A basic navigation interface for navigating between [screens][Screen]. */
-@Stable
-interface Navigator {
-  fun goTo(screen: Screen)
-
-  fun pop(): Screen?
-
-  object NoOp : Navigator {
-    override fun goTo(screen: Screen) {}
-    override fun pop(): Screen? = null
-  }
-}
-
-/**
- * A Circuit call back to help navigate to different screens. Intended to be used when forwarding
- * [NavEvent]s from nested [Presenter]s.
- */
-fun Navigator.onNavEvent(event: NavEvent) {
-  when (event) {
-    is GoToNavEvent -> goTo(event.screen)
-    PopNavEvent -> pop()
-  }
-}
-
-/** A sealed navigation interface intended to be used when making a navigation call back. */
-sealed interface NavEvent : CircuitUiEvent
-
-internal object PopNavEvent : NavEvent
-
-internal data class GoToNavEvent(internal val screen: Screen) : NavEvent
 
 /**
  * Returns a new [Navigator] for navigating within [CircuitContents][CircuitContent].
@@ -60,7 +28,10 @@ internal data class GoToNavEvent(internal val screen: Screen) : NavEvent
  * @param onRootPop The callback to handle root [Navigator.pop] calls.
  */
 @Composable
-fun rememberCircuitNavigator(backstack: SaveableBackStack, onRootPop: (() -> Unit)?): Navigator {
+public fun rememberCircuitNavigator(
+  backstack: SaveableBackStack,
+  onRootPop: (() -> Unit)?
+): Navigator {
   return remember { NavigatorImpl(backstack, onRootPop) }
 }
 
@@ -101,15 +72,5 @@ private class NavigatorImpl(
 
   override fun toString(): String {
     return "NavigatorImpl(backstack=$backstack, onRootPop=$onRootPop)"
-  }
-}
-
-/** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
-fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
-  while (true) {
-    val screen = pop() ?: break
-    if (predicate(screen)) {
-      break
-    }
   }
 }

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import com.slack.circuit.backstack.SaveableBackStack
+
+public fun SaveableBackStack.push(screen: Screen) {
+  push(
+    SaveableBackStack.Record(
+      route = screen.javaClass.simpleName,
+      args = mapOf("screen" to screen),
+      key = screen.hashCode().toString()
+    )
+  )
+}
+
+public val SaveableBackStack.Record.screen: Screen
+  get() = args.getValue("screen") as Screen

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import android.os.Parcelable
+
+public actual interface Screen : Parcelable

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitConfig.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitConfig.kt
@@ -48,7 +48,7 @@ import androidx.compose.runtime.Immutable
  * }
  * ```
  *
- * If using navigation, use [NavigableCircuitContent] instead.
+ * If using navigation, use `NavigableCircuitContent` instead.
  *
  * ```kotlin
  * val backstack = rememberSaveableBackStack { push(AddFavoritesScreen()) }
@@ -63,16 +63,17 @@ import androidx.compose.runtime.Immutable
  * @see NavigableCircuitContent
  */
 @Immutable
-class CircuitConfig private constructor(builder: Builder) {
+public class CircuitConfig private constructor(builder: Builder) {
   private val uiFactories: List<Ui.Factory> = builder.uiFactories.toList()
   private val presenterFactories: List<Presenter.Factory> = builder.presenterFactories.toList()
-  val onUnavailableContent: (@Composable (screen: Screen) -> Unit)? = builder.onUnavailableContent
+  public val onUnavailableContent: (@Composable (screen: Screen) -> Unit)? =
+    builder.onUnavailableContent
 
-  fun presenter(screen: Screen, navigator: Navigator): Presenter<*>? {
+  public fun presenter(screen: Screen, navigator: Navigator): Presenter<*>? {
     return nextPresenter(null, screen, navigator)
   }
 
-  fun nextPresenter(
+  public fun nextPresenter(
     skipPast: Presenter.Factory?,
     screen: Screen,
     navigator: Navigator
@@ -88,11 +89,11 @@ class CircuitConfig private constructor(builder: Builder) {
     return null
   }
 
-  fun ui(screen: Screen): ScreenUi? {
+  public fun ui(screen: Screen): ScreenUi? {
     return nextUi(null, screen)
   }
 
-  fun nextUi(skipPast: Ui.Factory?, screen: Screen): ScreenUi? {
+  public fun nextUi(skipPast: Ui.Factory?, screen: Screen): ScreenUi? {
     val start = uiFactories.indexOf(skipPast) + 1
     for (i in start until uiFactories.size) {
       val ui = uiFactories[i].create(screen, this)
@@ -104,12 +105,13 @@ class CircuitConfig private constructor(builder: Builder) {
     return null
   }
 
-  fun newBuilder() = Builder(this)
+  public fun newBuilder(): Builder = Builder(this)
 
-  class Builder constructor() {
-    val uiFactories = mutableListOf<Ui.Factory>()
-    val presenterFactories = mutableListOf<Presenter.Factory>()
-    var onUnavailableContent: (@Composable (screen: Screen) -> Unit)? = null
+  public class Builder constructor() {
+    public val uiFactories: MutableList<Ui.Factory> = mutableListOf<Ui.Factory>()
+    public val presenterFactories: MutableList<Presenter.Factory> =
+      mutableListOf<Presenter.Factory>()
+    public var onUnavailableContent: (@Composable (screen: Screen) -> Unit)? = null
       private set
 
     internal constructor(circuitConfig: CircuitConfig) : this() {
@@ -117,33 +119,37 @@ class CircuitConfig private constructor(builder: Builder) {
       presenterFactories.addAll(circuitConfig.presenterFactories)
     }
 
-    fun addUiFactory(factory: Ui.Factory) = apply { uiFactories.add(factory) }
+    public fun addUiFactory(factory: Ui.Factory): Builder = apply { uiFactories.add(factory) }
 
-    fun addUiFactory(vararg factory: Ui.Factory) = apply {
+    public fun addUiFactory(vararg factory: Ui.Factory): Builder = apply {
       for (f in factory) {
         uiFactories.add(f)
       }
     }
 
-    fun addUiFactories(factories: Iterable<Ui.Factory>) = apply { uiFactories.addAll(factories) }
+    public fun addUiFactories(factories: Iterable<Ui.Factory>): Builder = apply {
+      uiFactories.addAll(factories)
+    }
 
-    fun addPresenterFactory(factory: Presenter.Factory) = apply { presenterFactories.add(factory) }
+    public fun addPresenterFactory(factory: Presenter.Factory): Builder = apply {
+      presenterFactories.add(factory)
+    }
 
-    fun addPresenterFactory(vararg factory: Presenter.Factory) = apply {
+    public fun addPresenterFactory(vararg factory: Presenter.Factory): Builder = apply {
       for (f in factory) {
         presenterFactories.add(f)
       }
     }
 
-    fun addPresenterFactories(factories: Iterable<Presenter.Factory>) = apply {
+    public fun addPresenterFactories(factories: Iterable<Presenter.Factory>): Builder = apply {
       presenterFactories.addAll(factories)
     }
 
-    fun setOnUnavailableContentCallback(callback: @Composable (screen: Screen) -> Unit) = apply {
-      onUnavailableContent = callback
-    }
+    public fun setOnUnavailableContentCallback(
+      callback: @Composable (screen: Screen) -> Unit
+    ): Builder = apply { onUnavailableContent = callback }
 
-    fun build(): CircuitConfig {
+    public fun build(): CircuitConfig {
       return CircuitConfig(this)
     }
   }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+@Composable
+public fun CircuitContent(
+  screen: Screen,
+  circuitConfig: CircuitConfig = LocalCircuitOwner.current,
+  unavailableContent: (@Composable (screen: Screen) -> Unit)? = circuitConfig.onUnavailableContent,
+) {
+  CircuitContent(screen, Navigator.NoOp, circuitConfig, unavailableContent)
+}
+
+@Composable
+public fun CircuitContent(
+  screen: Screen,
+  onNavEvent: (event: NavEvent) -> Unit,
+  circuitConfig: CircuitConfig = LocalCircuitOwner.current,
+  unavailableContent: (@Composable (screen: Screen) -> Unit)? = circuitConfig.onUnavailableContent,
+) {
+  val navigator =
+    remember(onNavEvent) {
+      object : Navigator {
+        override fun goTo(screen: Screen) {
+          onNavEvent(GoToNavEvent(screen))
+        }
+
+        override fun pop(): Screen? {
+          onNavEvent(PopNavEvent)
+          return null
+        }
+      }
+    }
+  CircuitContent(screen, navigator, circuitConfig, unavailableContent)
+}
+
+@Composable
+internal fun CircuitContent(
+  screen: Screen,
+  navigator: Navigator,
+  circuitConfig: CircuitConfig,
+  unavailableContent: (@Composable (screen: Screen) -> Unit)?,
+) {
+  val screenUi = circuitConfig.ui(screen)
+
+  @Suppress("UNCHECKED_CAST")
+  val presenter = circuitConfig.presenter(screen, navigator) as Presenter<CircuitUiState>?
+
+  if (screenUi != null && presenter != null) {
+    @Suppress("UNCHECKED_CAST") (CircuitContent(presenter, screenUi.ui as Ui<CircuitUiState>))
+  } else if (unavailableContent != null) {
+    unavailableContent(screen)
+  } else {
+    error("Could not render screen $screen")
+  }
+}
+
+@Composable
+private fun <UiState : CircuitUiState> CircuitContent(
+  presenter: Presenter<UiState>,
+  ui: Ui<UiState>,
+) {
+  val state = presenter.present()
+  ui.Content(state)
+}

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Stable
+
+/** A basic navigation interface for navigating between [screens][Screen]. */
+@Stable
+public interface Navigator {
+  public fun goTo(screen: Screen)
+
+  public fun pop(): Screen?
+
+  public object NoOp : Navigator {
+    override fun goTo(screen: Screen) {}
+    override fun pop(): Screen? = null
+  }
+}
+
+/**
+ * A Circuit call back to help navigate to different screens. Intended to be used when forwarding
+ * [NavEvent]s from nested [Presenter]s.
+ */
+public fun Navigator.onNavEvent(event: NavEvent) {
+  when (event) {
+    is GoToNavEvent -> goTo(event.screen)
+    PopNavEvent -> pop()
+  }
+}
+
+/** A sealed navigation interface intended to be used when making a navigation call back. */
+public sealed interface NavEvent : CircuitUiEvent
+
+internal object PopNavEvent : NavEvent
+
+internal data class GoToNavEvent(internal val screen: Screen) : NavEvent
+
+/** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
+public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
+  while (true) {
+    val screen = pop() ?: break
+    if (predicate(screen)) {
+      break
+    }
+  }
+}

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Presenter.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Presenter.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
  *
  * @see present for more thorough documentation.
  */
-interface Presenter<UiState : CircuitUiState> {
+public interface Presenter<UiState : CircuitUiState> {
   /**
    * The primary [Composable] entry point to present a [UiState]. In production, a [Navigator] is
    * used to automatically connect this with a corresponding [Ui] to render the state returned by
@@ -102,7 +102,7 @@ interface Presenter<UiState : CircuitUiState> {
    * Note that Circuit's test artifact has a `Presenter.test()` helper extension function for the
    * above case.
    */
-  @Composable fun present(): UiState
+  @Composable public fun present(): UiState
 
   /**
    * A factory that produces [presenters][Presenter] for a given [Screen]. [CircuitConfig] instances
@@ -157,11 +157,15 @@ interface Presenter<UiState : CircuitUiState> {
    * ```
    */
   // Diagram generated from asciiflow: https://shorturl.at/fgjtA
-  fun interface Factory {
+  public fun interface Factory {
     /**
      * Creates a [Presenter] for the given [screen] if it can handle it, or returns null if it
      * cannot handle the given [screen].
      */
-    fun create(screen: Screen, navigator: Navigator, circuitConfig: CircuitConfig): Presenter<*>?
+    public fun create(
+      screen: Screen,
+      navigator: Navigator,
+      circuitConfig: CircuitConfig
+    ): Presenter<*>?
   }
 }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
@@ -15,8 +15,6 @@
  */
 package com.slack.circuit
 
-import android.os.Parcelable
-
 /**
  * Represents an individual screen, used as a key for [Presenter.Factory] and [Ui.Factory].
  *
@@ -25,7 +23,6 @@ import android.os.Parcelable
  * begin presenting state.
  *
  * ```
- * @Parcelize
  * data class AddFavorites(
  *   val externalId: UUID,
  * ) : Screen
@@ -43,4 +40,4 @@ import android.os.Parcelable
  * }
  * ```
  */
-interface Screen : Parcelable
+public expect interface Screen

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Ui.kt
@@ -50,8 +50,8 @@ import androidx.compose.runtime.Composable
  *
  * @see ui
  */
-interface Ui<UiState : CircuitUiState> {
-  @Composable fun Content(state: UiState)
+public interface Ui<UiState : CircuitUiState> {
+  @Composable public fun Content(state: UiState)
 
   /**
    * A factory that creates [ScreenUis][ScreenUi], which in turn contain the desired [Ui] for a
@@ -84,12 +84,12 @@ interface Ui<UiState : CircuitUiState> {
    * @Composable private fun Favorites(state: State) {...}
    * ```
    */
-  fun interface Factory {
-    fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi?
+  public fun interface Factory {
+    public fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi?
   }
 }
 
-data class ScreenUi(val ui: Ui<*>)
+public data class ScreenUi(val ui: Ui<*>)
 
 /**
  * Due to this bug in Studio, we can't write lambda impls of [Ui] directly. This works around it by
@@ -100,7 +100,7 @@ data class ScreenUi(val ui: Ui<*>)
  *
  * @see [Ui] for main docs.
  */
-inline fun <UiState : CircuitUiState> ui(
+public inline fun <UiState : CircuitUiState> ui(
   crossinline body: @Composable (state: UiState) -> Unit
 ): Ui<UiState> {
   return object : Ui<UiState> {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/markers.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/markers.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.Immutable
  *
  * **Circuit state types should be truly immutable types.**
  */
-@Immutable interface CircuitUiState
+@Immutable public interface CircuitUiState
 
 /**
  * Marker interface for all UiEvent types.
@@ -40,4 +40,4 @@ import androidx.compose.runtime.Immutable
  *
  * **Circuit event types should be truly immutable types.**
  */
-@Immutable interface CircuitUiEvent
+@Immutable public interface CircuitUiEvent

--- a/circuit/src/jvmMain/kotlin/com/slack/circuit/CompositionLocals.jvm.kt
+++ b/circuit/src/jvmMain/kotlin/com/slack/circuit/CompositionLocals.jvm.kt
@@ -15,17 +15,10 @@
  */
 package com.slack.circuit
 
-import com.slack.circuit.backstack.SaveableBackStack
+import androidx.compose.runtime.Composable
 
-fun SaveableBackStack.push(screen: Screen) {
-  push(
-    SaveableBackStack.Record(
-      route = screen.javaClass.simpleName,
-      args = mapOf("screen" to screen),
-      key = screen.hashCode().toString()
-    )
-  )
+@Composable
+internal actual fun PlatformCompositionLocals(content: @Composable () -> Unit) {
+  // No JVM-specific locals currently!
+  content()
 }
-
-val SaveableBackStack.Record.screen: Screen
-  get() = args.getValue("screen") as Screen

--- a/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
+++ b/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+public actual interface Screen


### PR DESCRIPTION
Main bits:
- Using the `Name.<platform>.kt` convention like other KMP libs do. Will update others in a followup.
- NavigableCircuitContent is only applicable for android right now
- Screen is expect/actual so it can be parcelable on android
- Added an expect/actual for platform-specific composition locals

Resolves #35 