### PR TITLE
Support material 3 dynamic theming in star app

### DIFF
--- a/samples/star/src/main/kotlin/com/slack/circuit/star/ui/Theme.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/ui/Theme.kt
@@ -15,6 +15,7 @@
  */
 package com.slack.circuit.star.ui
 
+import android.annotation.SuppressLint
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -87,6 +88,7 @@ private val DarkColors =
     surfaceTint = md_theme_dark_surfaceTint,
   )
 
+@SuppressLint("NewApi") // False positive because we do check the API level.
 @Composable
 fun StarTheme(
   useDarkTheme: Boolean = isSystemInDarkTheme(),

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/ui/Theme.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/ui/Theme.kt
@@ -15,11 +15,15 @@
  */
 package com.slack.circuit.star.ui
 
+import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 
 private val LightColors =
   lightColorScheme(
@@ -84,12 +88,22 @@ private val DarkColors =
   )
 
 @Composable
-fun StarTheme(useDarkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+fun StarTheme(
+  useDarkTheme: Boolean = isSystemInDarkTheme(),
+  isDynamicColor: Boolean = true,
+  content: @Composable () -> Unit
+) {
+  val dynamicColor = isDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
   val colors =
-    if (!useDarkTheme) {
-      LightColors
-    } else {
-      DarkColors
+    when {
+      dynamicColor && useDarkTheme -> {
+        dynamicDarkColorScheme(LocalContext.current)
+      }
+      dynamicColor && !useDarkTheme -> {
+        dynamicLightColorScheme(LocalContext.current)
+      }
+      useDarkTheme -> DarkColors
+      else -> LightColors
     }
 
   MaterialTheme(colorScheme = colors, content = content)


### PR DESCRIPTION
More of a fun demo, likely needs more work to pick the right colors because this really only works if everything in your app is neutrally colored. The bottom nav bar _always_ ends up looking hard to read currently :|

| Screenshot (red) | Color change to blue |
| ----------------- | -------------------- |
| ![Screenshot_1665157925](https://user-images.githubusercontent.com/1361086/194595867-6c90aad6-8417-4894-96de-d1fcc6315ac2.png) |  https://user-images.githubusercontent.com/1361086/194782437-c5ab5c02-f9ad-49b0-be9d-702b1584892f.mp4 |
