### PR TITLE
Update compose-jb to 1.2.0 stable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ compose = "1.3.0-rc01"
 # https://androidx.dev/storage/compose-compiler/repository
 composeCompiler = "1.3.2"
 composeCompilerKotlinVersion = "1.7.20"
-compose-jb = "1.2.0-beta01"
+compose-jb = "1.2.0"
 compose-integration-constraintlayout = "1.0.1"
 dagger = "2.44"
 datastore = "1.0.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -78,6 +78,9 @@ dependencyResolutionManagement {
         includeGroup("androidx.compose.compiler")
       }
     }
+
+    // JB Compose Repo
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev") { name = "Compose-JB" }
   }
 }
 
@@ -115,6 +118,9 @@ pluginManagement {
         includeGroupByRegex("org\\.jetbrains.*")
       }
     }
+
+    // JB Compose Repo
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev") { name = "Compose-JB" }
 
     // Gradle's plugin portal proxies jcenter, which we don't want. To avoid this, we specify
     // exactly which dependencies to pull from here.


### PR DESCRIPTION
Requires their custom maven repo

https://github.com/JetBrains/compose-jb/releases/tag/v1.2.0