### PR TITLE
EventListener part 2

### DIFF
--- a/circuit/build.gradle.kts
+++ b/circuit/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("com.android.library")
@@ -62,6 +63,16 @@ kotlin {
     maybeCreate("jvmTest").apply { dependsOn(commonJvmTest) }
   }
 }
+
+tasks
+  .withType<KotlinCompile>()
+  .matching { it.name.contains("test", ignoreCase = true) }
+  .configureEach {
+    kotlinOptions {
+      @Suppress("SuspiciousCollectionReassignment")
+      freeCompilerArgs += listOf("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
+    }
+  }
 
 android { namespace = "com.slack.circuit.core" }
 

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitConfig.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitConfig.kt
@@ -68,6 +68,7 @@ public class CircuitConfig private constructor(builder: Builder) {
   private val presenterFactories: List<Presenter.Factory> = builder.presenterFactories.toList()
   public val onUnavailableContent: (@Composable (screen: Screen) -> Unit)? =
     builder.onUnavailableContent
+  internal val eventListenerFactory: EventListener.Factory? = builder.eventListenerFactory
 
   public fun presenter(screen: Screen, navigator: Navigator): Presenter<*>? {
     return nextPresenter(null, screen, navigator)
@@ -113,10 +114,13 @@ public class CircuitConfig private constructor(builder: Builder) {
       mutableListOf<Presenter.Factory>()
     public var onUnavailableContent: (@Composable (screen: Screen) -> Unit)? = null
       private set
+    public var eventListenerFactory: EventListener.Factory? = null
+      private set
 
     internal constructor(circuitConfig: CircuitConfig) : this() {
       uiFactories.addAll(circuitConfig.uiFactories)
       presenterFactories.addAll(circuitConfig.presenterFactories)
+      eventListenerFactory = circuitConfig.eventListenerFactory
     }
 
     public fun addUiFactory(factory: Ui.Factory): Builder = apply { uiFactories.add(factory) }
@@ -149,6 +153,10 @@ public class CircuitConfig private constructor(builder: Builder) {
       apply {
         onUnavailableContent = content
       }
+
+    public fun eventListenerFactory(factory: EventListener.Factory): Builder = apply {
+      eventListenerFactory = factory
+    }
 
     public fun build(): CircuitConfig {
       return CircuitConfig(this)

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -16,11 +16,9 @@
 package com.slack.circuit
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
 public fun CircuitContent(
@@ -84,7 +82,7 @@ private fun <UiState : CircuitUiState> CircuitContent(
   ui: Ui<UiState>,
 ) {
   val state = presenter.present()
-  val stateChanges = remember(presenter, ui) { snapshotFlow { state }.distinctUntilChanged() }
-  LaunchedEffect(stateChanges) { stateChanges.collect { eventListener.onState(it) } }
+  // TODO not sure why stateFlow + LaunchedEffect + distinctUntilChanged doesn't work here
+  SideEffect { eventListener.onState(state) }
   ui.Content(state)
 }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/EventListener.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/EventListener.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+/**
+ * A listener for tracking the state changes of a given [Screen]. This can be used for
+ * instrumentation and other telemetry.
+ */
+public interface EventListener {
+
+  /** Called when there is a new [state] returned by the [Presenter]. */
+  public fun onState(state: Any) {}
+
+  public fun interface Factory {
+    public fun create(screen: Screen): EventListener
+  }
+
+  public companion object {
+    public val NONE: EventListener = object : EventListener {}
+  }
+}

--- a/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
+++ b/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
@@ -17,11 +17,11 @@ package com.slack.circuit
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import app.cash.molecule.RecompositionClock.Immediate
 import app.cash.molecule.launchMolecule
 import app.cash.turbine.Turbine
-import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.runTest
@@ -50,20 +50,15 @@ class EventListenerTest {
         .eventListenerFactory(eventListenerFactory)
         .build()
 
-    backgroundScope
-      .launchMolecule(Immediate) {
-        CircuitContent(circuitConfig = circuitConfig, screen = TestScreen)
-      }
-      .test {
-        awaitItem()
-        state.value = "State2"
-        awaitItem()
-        val (screen, listener) = eventListenerFactory.listeners.entries.first()
-        assertThat(screen).isEqualTo(TestScreen)
+    backgroundScope.launchMolecule(Immediate) {
+      CircuitContent(circuitConfig = circuitConfig, screen = TestScreen)
+    }
+    val (screen, listener) = eventListenerFactory.listeners.entries.first()
+    assertThat(screen).isEqualTo(TestScreen)
 
-        assertThat(listener.states.awaitItem()).isEqualTo("State")
-        assertThat(listener.states.awaitItem()).isEqualTo("State2")
-      }
+    assertThat(listener.states.awaitItem()).isEqualTo(StringState("State"))
+    state.value = "State2"
+    assertThat(listener.states.awaitItem()).isEqualTo(StringState("State2"))
   }
 }
 

--- a/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
+++ b/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import app.cash.molecule.RecompositionClock.Immediate
-import app.cash.molecule.moleculeFlow
+import app.cash.molecule.launchMolecule
 import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -50,7 +50,10 @@ class EventListenerTest {
         .eventListenerFactory(eventListenerFactory)
         .build()
 
-    moleculeFlow(Immediate) { CircuitContent(circuitConfig = circuitConfig, screen = TestScreen) }
+    backgroundScope
+      .launchMolecule(Immediate) {
+        CircuitContent(circuitConfig = circuitConfig, screen = TestScreen)
+      }
       .test {
         awaitItem()
         state.value = "State2"
@@ -81,7 +84,7 @@ private class StringUi : Ui<StringState> {
 }
 
 private class RecordingEventListener : EventListener {
-  val states = Turbine<Any>()
+  val states = Turbine<Any>(name = "recording event listener states")
 
   override fun onState(state: Any) {
     states.add(state)

--- a/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
+++ b/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import app.cash.molecule.RecompositionClock.Immediate
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.Turbine
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Timeout
+
+class EventListenerTest {
+
+  @JvmField
+  @Rule
+  val timeout: Timeout =
+    Timeout.builder().withTimeout(10, TimeUnit.SECONDS).withLookingForStuckThread(true).build()
+
+  @Test
+  fun basicEventRecording() = runTest {
+    val eventListenerFactory = RecordingEventListener.Factory()
+    val state = mutableStateOf("State")
+
+    val presenter = StringPresenter(state)
+    val ui = StringUi()
+    val circuitConfig =
+      CircuitConfig.Builder()
+        .addPresenterFactory { _, _, _ -> presenter }
+        .addUiFactory { _, _ -> ScreenUi(ui) }
+        .eventListenerFactory(eventListenerFactory)
+        .build()
+
+    moleculeFlow(Immediate) { CircuitContent(circuitConfig = circuitConfig, screen = TestScreen) }
+      .test {
+        awaitItem()
+        state.value = "State2"
+        awaitItem()
+        val (screen, listener) = eventListenerFactory.listeners.entries.first()
+        assertThat(screen).isEqualTo(TestScreen)
+
+        assertThat(listener.states.awaitItem()).isEqualTo("State")
+        assertThat(listener.states.awaitItem()).isEqualTo("State2")
+      }
+  }
+}
+
+private object TestScreen : Screen
+
+private data class StringState(val value: String) : CircuitUiState
+
+private class StringPresenter(val state: State<String>) : Presenter<StringState> {
+  @Composable
+  override fun present(): StringState {
+    return StringState(state.value)
+  }
+}
+
+private class StringUi : Ui<StringState> {
+
+  @Composable override fun Content(state: StringState) {}
+}
+
+private class RecordingEventListener : EventListener {
+  val states = Turbine<Any>()
+
+  override fun onState(state: Any) {
+    states.add(state)
+  }
+
+  class Factory : EventListener.Factory {
+    val listeners = mutableMapOf<Screen, RecordingEventListener>()
+
+    fun get(screen: Screen): RecordingEventListener =
+      listeners[screen] ?: (RecordingEventListener().also { listeners[screen] = it })
+
+    override fun create(screen: Screen): EventListener = get(screen)
+  }
+}


### PR DESCRIPTION
This succeeds #49 and resolves #46.

Getting tests working for this was a bit of a headache at first, and I've yet to figure out why this code snippet doesn't work in `CircuitContent` (with the goal being that deduping state changes would be desireable).


This would be desirable, but we can look into that as an optimization later.
```kotlin
@Composable
private fun <UiState : CircuitUiState> CircuitContent(
  eventListener: EventListener,
  presenter: Presenter<UiState>,
  ui: Ui<UiState>,
) {
  val state = presenter.present()
  LaunchedEffect(presenter, eventListener) {
    snapshotFlow { state }.distinctUntilChanged().collect(eventListener::onState)
  }
  ui.Content(state)
}
```