### PR TITLE
Add initial tests for rememberRetained

### DIFF
--- a/circuit-retained/android-tests/build.gradle.kts
+++ b/circuit-retained/android-tests/build.gradle.kts
@@ -31,8 +31,6 @@ android {
   testBuildType = "release"
 }
 
-configurations.configureEach { println(name) }
-
 dependencies {
   implementation(libs.androidx.activity.ktx)
   implementation(libs.androidx.activity.ktx)

--- a/circuit-retained/android-tests/build.gradle.kts
+++ b/circuit-retained/android-tests/build.gradle.kts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+  id("com.android.library")
+  kotlin("android")
+  kotlin("plugin.parcelize")
+}
+
+android {
+  namespace = "com.slack.circuit.retained.androidTest"
+
+  defaultConfig {
+    minSdk = 28
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
+
+  testOptions { unitTests.isIncludeAndroidResources = true }
+  testBuildType = "release"
+}
+
+configurations.configureEach { println(name) }
+
+dependencies {
+  implementation(libs.androidx.activity.ktx)
+  implementation(libs.androidx.activity.ktx)
+  implementation(libs.coroutines)
+  implementation(libs.coroutines.android)
+  implementation(libs.androidx.core)
+  androidTestImplementation(configurations.getByName("implementation"))
+  androidTestImplementation(libs.coroutines)
+  androidTestImplementation(libs.coroutines.android)
+  androidTestImplementation(projects.circuitRetained)
+  androidTestImplementation(libs.androidx.compose.integration.activity)
+  androidTestImplementation(libs.androidx.compose.ui.testing.junit)
+  androidTestImplementation(libs.androidx.compose.foundation)
+  androidTestImplementation(libs.androidx.compose.ui.ui)
+  androidTestImplementation(libs.androidx.compose.material.material)
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.truth)
+}

--- a/circuit-retained/android-tests/src/androidTest/AndroidManifest.xml
+++ b/circuit-retained/android-tests/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity android:name="androidx.activity.ComponentActivity"/>
+    </application>
+</manifest>

--- a/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
@@ -136,6 +136,27 @@ class RetainedTest {
     composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2")
   }
 
+  @Test
+  fun multipleNoKeys() {
+    val content = @Composable { MultipleRetains(useKeys = false) }
+    setActivityContent(content)
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).performTextInput("Text_Retained2")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_3).performTextInput("2")
+    // Check that our input worked
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2")
+    // Restart the activity
+    scenario.recreate()
+    // Compose our content
+    setActivityContent(content)
+    // Was the text saved
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2")
+  }
+
   private fun setActivityContent(content: @Composable () -> Unit) {
     scenario.onActivity { activity ->
       activity.setContent {

--- a/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.circuit.retained.android
+
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
+import com.slack.circuit.retained.Continuity
+import com.slack.circuit.retained.LocalRetainedStateRegistryOwner
+import com.slack.circuit.retained.continuityRetainedStateRegistry
+import com.slack.circuit.retained.rememberRetained
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+
+private const val TAG_REMEMBER = "remember"
+private const val TAG_RETAINED_1 = "retained1"
+private const val TAG_RETAINED_2 = "retained2"
+
+class RetainedTest {
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  private val scenario: ActivityScenario<ComponentActivity>
+    get() = composeTestRule.activityRule.scenario
+
+  private val vmFactory =
+    object : ViewModelProvider.Factory {
+      override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST") return Continuity() as T
+      }
+    }
+
+  // TODO
+  //  - tests without using keys, but doesn't appear to work right in tests
+  //  - tests with multiple retained state vars
+
+  @Test
+  fun singleWithKey() {
+    setActivityContent { KeyContent("retainedText") }
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).performTextInput("Text_Remember")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained")
+    // Check that our input worked
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("Text_Remember")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")
+    // Restart the activity
+    scenario.recreate()
+    // Compose our content
+    setActivityContent { KeyContent("retainedText") }
+    // Was the text saved
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")
+  }
+
+  @Test
+  fun noRegistryBehavesLikeRegularRemember() {
+    scenario.onActivity { it.setContent { KeyContent("retainedText") } }
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).performTextInput("Text_Remember")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained")
+    // Check that our input worked
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("Text_Remember")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")
+    // Restart the activity
+    scenario.recreate()
+    // Compose our content
+    scenario.onActivity { it.setContent { KeyContent("retainedText") } }
+    // Was the text saved
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("")
+  }
+
+  @Ignore("This doesn't appear to work from tests")
+  @Test
+  fun singleWithNoKey() {
+    setActivityContent { KeyContent(null) }
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).performTextInput("Text_Remember")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained")
+    // Check that our input worked
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("Text_Remember")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")
+    // Restart the activity
+    scenario.recreate()
+    // Compose our content
+    setActivityContent { KeyContent(null) }
+    // Was the text saved
+    composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")
+  }
+
+  @Test
+  fun multipleKeys() {
+    setActivityContent { MultipleRetains() }
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).performTextInput("Text_Retained2")
+    // Check that our input worked
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
+    // Restart the activity
+    scenario.recreate()
+    // Compose our content
+    setActivityContent { MultipleRetains() }
+    // Was the text saved
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
+  }
+
+  private fun setActivityContent(content: @Composable () -> Unit) {
+    scenario.onActivity { activity ->
+      activity.setContent {
+        CompositionLocalProvider(
+          LocalRetainedStateRegistryOwner provides continuityRetainedStateRegistry(vmFactory),
+        ) {
+          content()
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun KeyContent(key: String?) {
+  var text1 by remember { mutableStateOf("") }
+  // By default rememberSavable uses it's line number as its key, this doesn't seem
+  // to work when testing, instead pass a key
+  var retainedText: String by rememberRetained(key = key) { mutableStateOf("") }
+  Column {
+    TextField(
+      modifier = Modifier.testTag(TAG_REMEMBER),
+      value = text1,
+      onValueChange = { text1 = it },
+      label = {}
+    )
+    TextField(
+      modifier = Modifier.testTag(TAG_RETAINED_1),
+      value = retainedText,
+      onValueChange = { retainedText = it },
+      label = {}
+    )
+  }
+}
+
+@Composable
+private fun MultipleRetains() {
+  // By default rememberSavable uses it's line number as its key, this doesn't seem
+  // to work when testing, instead pass a key
+  var retainedText1: String by rememberRetained(key = "retained1") { mutableStateOf("") }
+  var retainedText2: String by rememberRetained(key = "retained2") { mutableStateOf("") }
+  Column {
+    TextField(
+      modifier = Modifier.testTag(TAG_RETAINED_1),
+      value = retainedText1,
+      onValueChange = { retainedText1 = it },
+      label = {}
+    )
+    TextField(
+      modifier = Modifier.testTag(TAG_RETAINED_2),
+      value = retainedText2,
+      onValueChange = { retainedText2 = it },
+      label = {}
+    )
+  }
+}

--- a/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
@@ -60,12 +60,12 @@ class RetainedTest {
     }
 
   // TODO
-  //  - tests without using keys, but doesn't appear to work right in tests
-  //  - tests with multiple retained state vars
+  //  - clearing after done
 
   @Test
   fun singleWithKey() {
-    setActivityContent { KeyContent("retainedText") }
+    val content = @Composable { KeyContent("retainedText") }
+    setActivityContent(content)
     composeTestRule.onNodeWithTag(TAG_REMEMBER).performTextInput("Text_Remember")
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained")
     // Check that our input worked
@@ -74,7 +74,7 @@ class RetainedTest {
     // Restart the activity
     scenario.recreate()
     // Compose our content
-    setActivityContent { KeyContent("retainedText") }
+    setActivityContent(content)
     // Was the text saved
     composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("")
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")
@@ -82,7 +82,8 @@ class RetainedTest {
 
   @Test
   fun noRegistryBehavesLikeRegularRemember() {
-    scenario.onActivity { it.setContent { KeyContent("retainedText") } }
+    val content = @Composable { KeyContent("retainedText") }
+    scenario.onActivity { it.setContent(content = content) }
     composeTestRule.onNodeWithTag(TAG_REMEMBER).performTextInput("Text_Remember")
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained")
     // Check that our input worked
@@ -91,7 +92,7 @@ class RetainedTest {
     // Restart the activity
     scenario.recreate()
     // Compose our content
-    scenario.onActivity { it.setContent { KeyContent("retainedText") } }
+    scenario.onActivity { it.setContent(content = content) }
     // Was the text saved
     composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("")
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("")
@@ -194,9 +195,12 @@ private fun KeyContent(key: String?) {
 
 @Composable
 private fun MultipleRetains(useKeys: Boolean) {
-  var retainedInt: Int by rememberRetained(key = "retainedInt".takeIf { useKeys }) { mutableStateOf(0) }
-  var retainedText1: String by rememberRetained(key = "retained1".takeIf { useKeys }) { mutableStateOf("") }
-  var retainedText2: String by rememberRetained(key = "retained2".takeIf { useKeys }) { mutableStateOf("") }
+  var retainedInt: Int by
+    rememberRetained(key = "retainedInt".takeIf { useKeys }) { mutableStateOf(0) }
+  var retainedText1: String by
+    rememberRetained(key = "retained1".takeIf { useKeys }) { mutableStateOf("") }
+  var retainedText2: String by
+    rememberRetained(key = "retained2".takeIf { useKeys }) { mutableStateOf("") }
   Column {
     TextField(
       modifier = Modifier.testTag(TAG_RETAINED_1),

--- a/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
@@ -38,7 +38,6 @@ import com.slack.circuit.retained.Continuity
 import com.slack.circuit.retained.LocalRetainedStateRegistryOwner
 import com.slack.circuit.retained.continuityRetainedStateRegistry
 import com.slack.circuit.retained.rememberRetained
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -97,10 +96,10 @@ class RetainedTest {
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("")
   }
 
-  @Ignore("This doesn't appear to work from tests")
   @Test
   fun singleWithNoKey() {
-    setActivityContent { KeyContent(null) }
+    val content = @Composable { KeyContent(null) }
+    setActivityContent(content)
     composeTestRule.onNodeWithTag(TAG_REMEMBER).performTextInput("Text_Remember")
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained")
     // Check that our input worked
@@ -109,7 +108,7 @@ class RetainedTest {
     // Restart the activity
     scenario.recreate()
     // Compose our content
-    setActivityContent { KeyContent(null) }
+    setActivityContent(content)
     // Was the text saved
     composeTestRule.onNodeWithTag(TAG_REMEMBER).assertTextContains("")
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")

--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
@@ -17,6 +17,7 @@ package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 public class Continuity : ViewModel(), RetainedStateRegistry {
@@ -35,7 +36,15 @@ public class Continuity : ViewModel(), RetainedStateRegistry {
   }
 }
 
+/**
+ * Provides a [RetainedStateRegistry].
+ *
+ * @param factory an optional [ViewModelProvider.Factory] to use when creating the [Continuity]
+ * instance.
+ */
 @Composable
-public fun continuityRetainedStateRegistry(): RetainedStateRegistry {
-  return viewModel<Continuity>()
+public fun continuityRetainedStateRegistry(
+  factory: ViewModelProvider.Factory? = null
+): RetainedStateRegistry {
+  return viewModel<Continuity>(factory = factory)
 }

--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
@@ -16,8 +16,10 @@
 package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -35,6 +37,10 @@ public class Continuity : ViewModel(), RetainedStateRegistry {
 
   override fun performSave() {
     delegate.performSave()
+  }
+
+  override fun forgetUnclaimedValues() {
+    delegate.forgetUnclaimedValues()
   }
 
   override fun onCleared() {
@@ -71,6 +77,12 @@ public fun continuityRetainedStateRegistry(
         }
       }
     }
+  }
+  LaunchedEffect(vm) {
+    withFrameNanos {}
+    // This resumes after the just-composed frame completes drawing. Any unclaimed values at this
+    // point can be assumed to be no longer used
+    vm.forgetUnclaimedValues()
   }
   return vm
 }

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -114,7 +114,7 @@ public fun <T : Any> rememberRetained(vararg inputs: Any?, key: String? = null, 
 
   val canRetain = rememberCanRetainChecker()
   remember(registry, finalKey) {
-    val entry = registry.registerValue(finalKey, valueState.value)
+    val entry = registry.registerValue(finalKey) { valueState.value }
     object : RememberObserver {
       override fun onAbandoned() = unregisterIfNotRetainable()
 

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
@@ -57,6 +57,9 @@ public interface RetainedStateRegistry {
    */
   public fun performSave()
 
+  /** Releases all currently unconsumed values. Useful as a GC mechanism for the registry. */
+  public fun forgetUnclaimedValues()
+
   /** The registry entry which you get when you use [registerValue]. */
   public interface Entry {
     /** Unregister previously registered entry. */
@@ -156,12 +159,17 @@ internal class RetainedStateRegistryImpl(retained: MutableMap<String, List<Any?>
     valueProviders.clear()
     retained.putAll(map)
   }
+
+  override fun forgetUnclaimedValues() {
+    retained.clear()
+  }
 }
 
 internal object NoOpRetainedStateRegistry : RetainedStateRegistry {
   override fun consumeValue(key: String): Any? = null
   override fun registerValue(key: String, valueProvider: () -> Any?): Entry = NoOpEntry
   override fun performSave() {}
+  override fun forgetUnclaimedValues() {}
 
   private object NoOpEntry : Entry {
     override fun unregister() {}

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
@@ -144,10 +144,10 @@ internal class RetainedStateRegistryImpl(retained: MutableMap<String, List<Any?>
           map[key] = arrayListOf<Any?>(value)
         }
       } else {
-        // if we have multiple providers we should store null values as well to preserve
-        // the order in which providers were registered. say there were two providers.
+        // If we have multiple providers we should store null values as well to preserve
+        // the order in which providers were registered. Say there were two providers.
         // the first provider returned null(nothing to save) and the second one returned
-        // "1". when we will be restoring the first provider would restore null (it is the
+        // "1". When we will be restoring the first provider would restore null (it is the
         // same as to have nothing to restore) and the second one restore "1".
         map[key] =
           List(list.size) { index ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,7 @@ android.disableAutomaticComponentCreation=true
 # Suppress warnings about experimental AGP properties we're using
 # Ironically, this property itself is also experimental, so we have to suppress it too.
 android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,\
+  android.experimental.testOptions.emulatorSnapshots.maxSnapshotsForTestFailures,\
   android.enableAdditionalTestOutput
 
 # Disabled as this has no benefits in studio builds and only marginal benefits in command line, but

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,8 @@ androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref
 # Embed XML via view binding into Composables
 androidx-compose-ui-viewBinding = { module = "androidx.compose.ui:ui-viewbinding", version.ref = "compose" }
 
+androidx-core = "androidx.core:core-ktx:1.9.0"
+
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 androidx-lifecycle-viewModel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -166,6 +166,7 @@ include(
   ":backstack",
   ":circuit",
   ":circuit-retained",
+  ":circuit-retained:android-tests",
   ":circuit-test",
   ":samples:star",
   ":samples:star:apk",


### PR DESCRIPTION
Resolves #190

This fixes it by deferring writes until we call `performSave()`, which `rememberSaveable` does something similar under the hood as well. On top of that though, we need to also GC unclaimed values, which @adamp pointed me at a clever solution for using `withFrameNanos`.

~Not marking it as resolved though as there's still more work to do on that front. This just adds some initial tests + a toe-hold ignored test for plain key-less remembers. I think there's a bug in compose testing that breaks `currentCompositeKeyHash` consistency as it's not consistent between recreations 🤔.~ Fixed!

~These tests are just a starting point and better than nothing. They do cover custom keys and no-op implementations though.~

Next steps would be
- [ ] verifying forgotten entries are removed. This may be more involved so will look at this in a followup if need be, please don't hold review on this
- [x] fixing the actual bug in #190