### PR TITLE
Pop root automatically on empty backstacks

### DIFF
--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -23,7 +23,11 @@ import java.util.UUID
 
 @Composable
 public fun rememberSaveableBackStack(init: SaveableBackStack.() -> Unit): SaveableBackStack =
-  rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack().apply(init) }
+  rememberSaveable(saver = SaveableBackStack.Saver) {
+    SaveableBackStack().apply(init).also {
+      check(!it.isEmpty) { "Backstack must be non-empty after init." }
+    }
+  }
 
 public fun SaveableBackStack.push(route: String, args: Map<String, Any?> = emptyMap()) {
   push(SaveableBackStack.Record(route, args))

--- a/circuit/build.gradle.kts
+++ b/circuit/build.gradle.kts
@@ -61,6 +61,10 @@ kotlin {
         }
       }
     maybeCreate("jvmTest").apply { dependsOn(commonJvmTest) }
+    maybeCreate("androidTest").apply {
+      dependsOn(commonJvmTest)
+      dependencies { implementation(libs.robolectric) }
+    }
   }
 }
 

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.android.kt
@@ -43,7 +43,6 @@ import com.slack.circuit.backstack.BackStack
 import com.slack.circuit.backstack.NavDecoration
 import com.slack.circuit.backstack.ProvidedValues
 import com.slack.circuit.backstack.SaveableBackStack
-import com.slack.circuit.backstack.isAtRoot
 import com.slack.circuit.backstack.providedValuesForBackStack
 
 @Composable
@@ -57,7 +56,7 @@ public fun NavigableCircuitContent(
   decoration: NavDecoration = NavigatorDefaults.DefaultDecoration,
   unavailableRoute: @Composable (String) -> Unit = NavigatorDefaults.UnavailableRoute,
 ) {
-  BackHandler(enabled = enableBackHandler && !backstack.isAtRoot) { navigator.pop() }
+  BackHandler(enabled = enableBackHandler && backstack.size > 1, onBack = navigator::pop)
 
   BasicNavigableCircuitContent(
     navigator = navigator,

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -18,6 +18,7 @@ package com.slack.circuit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.backstack.isAtRoot
 import com.slack.circuit.backstack.isEmpty
 
 /**
@@ -42,7 +43,10 @@ internal class NavigatorImpl(
 
   override fun goTo(screen: Screen) = backstack.push(screen)
 
-  override fun pop() = backstack.pop()?.screen
+  override fun pop(): Screen? {
+    check(!backstack.isAtRoot) { "Cannot pop the root screen." }
+    return backstack.pop()?.screen
+  }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -26,36 +26,23 @@ import com.slack.circuit.backstack.isEmpty
  * @see NavigableCircuitContent
  *
  * @param backstack The backing [SaveableBackStack] to navigate.
- * @param onRootPop A callback to handle when the [backstack] is [popped][Navigator.pop] to empty.
  */
 @Composable
 public fun rememberCircuitNavigator(
   backstack: SaveableBackStack,
-  onRootPop: (() -> Unit)
-): Navigator {
-  return remember { NavigatorImpl(backstack, onRootPop) }
-}
+): Navigator = remember { NavigatorImpl(backstack) }
 
 internal class NavigatorImpl(
   private val backstack: SaveableBackStack,
-  private val onRootPop: (() -> Unit),
 ) : Navigator {
 
   init {
     check(!backstack.isEmpty) { "Backstack size must not be empty." }
   }
 
-  override fun goTo(screen: Screen) {
-    backstack.push(screen)
-  }
+  override fun goTo(screen: Screen) = backstack.push(screen)
 
-  override fun pop(): Screen? {
-    val screen = backstack.pop()?.screen
-    if (backstack.size == 0) {
-      onRootPop()
-    }
-    return screen
-  }
+  override fun pop() = backstack.pop()?.screen
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -64,18 +51,11 @@ internal class NavigatorImpl(
     other as NavigatorImpl
 
     if (backstack != other.backstack) return false
-    if (onRootPop != other.onRootPop) return false
 
     return true
   }
 
-  override fun hashCode(): Int {
-    var result = backstack.hashCode()
-    result = 31 * result + onRootPop.hashCode()
-    return result
-  }
+  override fun hashCode() = backstack.hashCode()
 
-  override fun toString(): String {
-    return "NavigatorImpl(backstack=$backstack, onRootPop=$onRootPop)"
-  }
+  override fun toString() = "NavigatorImpl(backstack=$backstack)"
 }

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit
+
+import android.os.Parcel
+import com.google.common.truth.Truth.assertThat
+import com.slack.circuit.backstack.SaveableBackStack
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+private object TestScreen : Screen {
+  override fun describeContents(): Int {
+    throw NotImplementedError()
+  }
+
+  override fun writeToParcel(dest: Parcel, flags: Int) {
+    throw NotImplementedError()
+  }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class NavigatorTest {
+
+  @Test
+  fun rootPopWhenEmpty() {
+    val rootPops = AtomicInteger(0)
+    val backstack = SaveableBackStack()
+    val navigator =
+      NavigatorImpl(
+        backstack = backstack,
+        popRootOnEmpty = true,
+        onRootPop = { rootPops.incrementAndGet() }
+      )
+    assertThat(backstack).hasSize(0)
+    navigator.pop()
+    assertThat(rootPops.get()).isEqualTo(1)
+  }
+
+  @Test
+  fun rootPopWhenOne() {
+    val rootPops = AtomicInteger(0)
+    val backstack = SaveableBackStack()
+    backstack.push(TestScreen)
+    backstack.push(TestScreen)
+    val navigator =
+      NavigatorImpl(
+        backstack = backstack,
+        popRootOnEmpty = true,
+        onRootPop = { rootPops.incrementAndGet() }
+      )
+    assertThat(backstack).hasSize(2)
+    navigator.pop()
+    assertThat(rootPops.get()).isEqualTo(0)
+    assertThat(backstack).hasSize(1)
+    navigator.pop()
+    assertThat(rootPops.get()).isEqualTo(1)
+    assertThat(backstack).hasSize(0)
+  }
+
+  @Test
+  fun rootPopWhenOneNoPopOnempty() {
+    val rootPops = AtomicInteger(0)
+    val backstack = SaveableBackStack()
+    backstack.push(TestScreen)
+    backstack.push(TestScreen)
+    val navigator =
+      NavigatorImpl(
+        backstack = backstack,
+        popRootOnEmpty = false,
+        onRootPop = { rootPops.incrementAndGet() }
+      )
+    assertThat(backstack).hasSize(2)
+    navigator.pop()
+    assertThat(rootPops.get()).isEqualTo(0)
+    assertThat(backstack).hasSize(1)
+    navigator.pop()
+    assertThat(rootPops.get()).isEqualTo(0)
+    assertThat(backstack).hasSize(0)
+    navigator.pop()
+    assertThat(rootPops.get()).isEqualTo(1)
+    assertThat(backstack).hasSize(0)
+  }
+}

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -18,7 +18,6 @@ package com.slack.circuit
 import android.os.Parcel
 import com.google.common.truth.Truth.assertThat
 import com.slack.circuit.backstack.SaveableBackStack
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,28 +38,21 @@ class NavigatorTest {
 
   @Test
   fun errorWhenBackstackIsEmpty() {
-    val rootPops = AtomicInteger(0)
     val backstack = SaveableBackStack()
-    val t =
-      assertFailsWith<IllegalStateException> {
-        NavigatorImpl(backstack = backstack, onRootPop = { rootPops.incrementAndGet() })
-      }
+    val t = assertFailsWith<IllegalStateException> { NavigatorImpl(backstack = backstack) }
     assertThat(t).hasMessageThat().contains("Backstack size must not be empty.")
   }
 
   @Test
-  fun rootPopWhenOne() {
-    val rootPops = AtomicInteger(0)
+  fun popAtRoot() {
     val backstack = SaveableBackStack()
     backstack.push(TestScreen)
     backstack.push(TestScreen)
-    val navigator = NavigatorImpl(backstack = backstack, onRootPop = { rootPops.incrementAndGet() })
+    val navigator = NavigatorImpl(backstack = backstack)
     assertThat(backstack).hasSize(2)
     navigator.pop()
-    assertThat(rootPops.get()).isEqualTo(0)
     assertThat(backstack).hasSize(1)
-    navigator.pop()
-    assertThat(rootPops.get()).isEqualTo(1)
-    assertThat(backstack).hasSize(0)
+    val t = assertFailsWith<IllegalStateException> { navigator.pop() }
+    assertThat(t).hasMessageThat().contains("Cannot pop the root screen.")
   }
 }

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -16,6 +16,9 @@ setContent {
 }
 ```
 
+!!! warning
+    `SaveableBackStack` _must_ have a size of 1 or more after initialization. It's an error to have a backstack with zero items.
+
 Presenters are then given access to these navigator instances via `Presenter.Factory` (described in TODO link Factories), which they can save if needed to perform navigation.
 
 ```kotlin

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -11,7 +11,7 @@ A new navigable content surface is handled via the `NavigableCircuitContent` fun
 ```kotlin
 setContent {
   val backstack = rememberSaveableBackStack { push(HomeScreen) }
-  val navigator = rememberCircuitNavigator(backstack, onBackPressedDispatcher::onBackPressed)
+  val navigator = rememberCircuitNavigator(backstack)
   NavigableCircuitContent(navigator, backstack)
 }
 ```
@@ -19,7 +19,7 @@ setContent {
 !!! warning
     `SaveableBackStack` _must_ have a size of 1 or more after initialization. It's an error to have a backstack with zero items.
 
-Presenters are then given access to these navigator instances via `Presenter.Factory` (described in TODO link Factories), which they can save if needed to perform navigation.
+Presenters are then given access to these navigator instances via `Presenter.Factory` (described in [Factories](https://slackhq.github.io/circuit/factories/)), which they can save if needed to perform navigation.
 
 ```kotlin
 fun showAddFavorites() {
@@ -28,6 +28,18 @@ fun showAddFavorites() {
       externalId = uuidGenerator.generate()
     )
   )
+}
+```
+
+If you want to have custom behavior for when back is pressed on the root screen (i.e. `backstack.size == 1`), you should implement your own `BackHandler` and use it _before_ creating the backstack.
+
+```kotlin
+setContent {
+  val backstack = rememberSaveableBackStack { push(HomeScreen) }
+  BackHandler(onBack = { /* do something on root */ })
+  // The Navigator's internal BackHandler will take precedence until it is at the root screen.
+  val navigator = rememberCircuitNavigator(backstack)
+  NavigableCircuitContent(navigator, backstack)
 }
 ```
 

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -52,8 +52,7 @@ constructor(
         // TODO why isn't the windowBackground enough so we don't need to do this?
         Surface(color = MaterialTheme.colorScheme.background) {
           val backstack = rememberSaveableBackStack { push(HomeScreen) }
-          val navigator =
-            rememberCircuitNavigator(backstack, onBackPressedDispatcher::onBackPressed)
+          val navigator = rememberCircuitNavigator(backstack)
           CircuitCompositionLocals(circuitConfig) {
             ContentWithOverlays { NavigableCircuitContent(navigator, backstack) }
           }


### PR DESCRIPTION
This was an interesting case that @kevineder noticed, where going from a backstack of 1 to 0 doesn't automatically pop the root callback. This makes that the default behavior ~, while allowing for customization of this behavior. I'm not sure what the right default should be though, or if we should even allow it.~

~Maybe we should always require a backstack size > 0 after initialization? Do people ever want to keep backstacks around that are empty to then (re)fill later?~

Updated to require non-empty backstacks on init and pop on empty always