### PR TITLE
Implement basic interop docs + sample

### DIFF
--- a/docs/interop.md
+++ b/docs/interop.md
@@ -1,4 +1,36 @@
 Interop
 =======
 
-TODO: https://github.com/slackhq/circuit/issues/42
+Circuit can interop anywhere that Compose can interop. This includes common cases like Android 
+`Views`, RxJava, Kotlin `Flow`, and more.
+
+## `Presenter`
+
+Lean on first-party interop-APIs where possible! See examples of interop with different libraries in the `:samples:interop` project.
+
+## `UI`
+
+### `Ui` -> `View`
+
+Just embed the Circuit in a `ComposeView` like any other Compose UI.
+
+### `View` -> `Ui`
+
+You can wrap your view in an `AndroidView` in a custom `Ui` implementation. 
+
+```kotlin
+class ExistingCustomViewUi : Ui<State> {
+  @Composable
+  fun Content(state: State) {
+    AndroidView(
+      modifier = ...
+      factory = { context ->
+        ExistingCustomView(context)
+      },
+      update = { view ->
+        view.setState(state)
+        view.setOnClickListener { state.eventSink(Event.Click) }
+      }
+  }
+}
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -129,6 +129,7 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+coroutines-rxjava = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx3", version.ref = "kotlinx-coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
@@ -159,6 +160,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 retrofit-converters-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
 retrofit-converters-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref="robolectric" }
+rxjava = "io.reactivex.rxjava3:rxjava:3.1.5"
 truth = "com.google.truth:truth:1.1.3"
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 

--- a/samples/interop/README.md
+++ b/samples/interop/README.md
@@ -1,0 +1,17 @@
+Interop
+=======
+
+A set of examples of interop from different paradigms into Circuit using a simple Counter example.
+
+**Presenter examples**
+- Circuit
+- Kotlin `Flow`
+- RxJava
+- Simple (no framework, just simple callbacks)
+
+**UI examples**
+- Circuit/Compose
+- Android `View`
+
+Different UIs and different presenters can be paired together to interop to Circuit and run
+together. All of these examples interop _to_ Circuit, but not _from_ Circuit (yet).

--- a/samples/interop/build.gradle.kts
+++ b/samples/interop/build.gradle.kts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+  id("com.android.application")
+  kotlin("android")
+  kotlin("plugin.parcelize")
+}
+
+android {
+  namespace = "com.slack.circuit.sample.interop"
+  defaultConfig {
+    minSdk = 33
+    targetSdk = 33
+    versionCode = 1
+    versionName = "1"
+  }
+  buildFeatures { viewBinding = true }
+}
+
+dependencies {
+  implementation(projects.circuit)
+  // Reuse the counter presenter logic for this sample
+  implementation(projects.samples.counter)
+  implementation(libs.androidx.compose.integration.activity)
+  implementation(libs.androidx.appCompat)
+  implementation(libs.androidx.browser)
+  implementation(libs.bundles.compose.ui)
+  implementation(libs.androidx.compose.ui.util)
+  implementation(libs.androidx.compose.integration.materialThemeAdapter)
+  implementation(libs.androidx.compose.material.icons)
+  implementation(libs.androidx.compose.material.iconsExtended)
+  implementation(libs.androidx.compose.accompanist.pager)
+  implementation(libs.androidx.compose.accompanist.pager.indicators)
+  implementation(libs.androidx.compose.accompanist.flowlayout)
+  implementation(libs.androidx.compose.accompanist.swiperefresh)
+  implementation(libs.androidx.compose.accompanist.systemUi)
+  debugImplementation(libs.androidx.compose.ui.tooling)
+  implementation(libs.bundles.androidx.activity)
+  implementation(libs.kotlinx.immutable)
+  implementation(libs.rxjava)
+  implementation(libs.coroutines.rxjava)
+  implementation(libs.molecule.runtime)
+  implementation(libs.androidx.compose.runtime.rxjava3)
+}

--- a/samples/interop/src/main/AndroidManifest.xml
+++ b/samples/interop/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2022 Slack Technologies, LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="Circuit Interop"
+        android:theme="@style/Theme.Material3.DayNight"
+        android:enableOnBackInvokedCallback="true">
+        <activity
+            android:name="com.slack.circuit.sample.interop.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/ComposeCounterUi.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/ComposeCounterUi.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.sample.interop
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.unit.dp
+import com.slack.circuit.sample.counter.CounterEvent
+import com.slack.circuit.sample.counter.CounterState
+
+/** A standard Circuit Counter UI in Compose. */
+@Composable
+fun Counter(state: CounterState, modifier: Modifier = Modifier) {
+  val color = if (state.count >= 0) Color.Unspecified else MaterialTheme.colorScheme.error
+  Box(modifier.fillMaxSize()) {
+    Column(Modifier.align(Alignment.Center)) {
+      Text(
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+        text = "Count: ${state.count}",
+        style = MaterialTheme.typography.displayLarge,
+        color = color
+      )
+      Spacer(modifier = Modifier.height(16.dp))
+      val sink = state.eventSink
+      Button(
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+        onClick = { sink(CounterEvent.Increment) }
+      ) {
+        Icon(rememberVectorPainter(Icons.Filled.Add), "Increment")
+      }
+      Button(
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+        onClick = { sink(CounterEvent.Decrement) }
+      ) {
+        Icon(rememberVectorPainter(Icons.Filled.Remove), "Decrement")
+      }
+    }
+  }
+}

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
@@ -75,10 +75,10 @@ constructor(
 
 /** An interop compose function that renders [CounterView] as a Circuit-powered [AndroidView]. */
 @Composable
-fun CounterViewComposable(state: CounterState) {
+fun CounterViewComposable(state: CounterState, modifier: Modifier = Modifier) {
   val eventSink = state.eventSink
   AndroidView(
-    modifier = Modifier.fillMaxSize(),
+    modifier = modifier.fillMaxSize(),
     factory = { context ->
       CounterView(context).apply {
         setOnIncrementClickListener { eventSink(CounterEvent.Increment) }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.sample.interop
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.slack.circuit.sample.counter.CounterEvent
+import com.slack.circuit.sample.counter.CounterState
+import com.slack.circuit.sample.interop.databinding.CounterViewBinding
+
+/**
+ * A traditional Android View implementation of a counter UI. It uses lightweight MVI semantics via
+ * [setState] and setters for increment/decrement.
+ */
+class CounterView
+@JvmOverloads
+constructor(
+  context: Context,
+  attrs: AttributeSet? = null,
+  @AttrRes defStyleAttr: Int = 0,
+  @StyleRes defStyleRes: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
+
+  private val binding: CounterViewBinding
+  private var onIncrementClickListener: OnClickListener? = null
+  private var onDecrementClickListener: OnClickListener? = null
+
+  init {
+    binding = CounterViewBinding.inflate(LayoutInflater.from(context), this, true)
+    binding.increment.setOnClickListener { onIncrementClickListener?.onClick(it) }
+    binding.decrement.setOnClickListener { onDecrementClickListener?.onClick(it) }
+  }
+
+  @SuppressLint("SetTextI18n")
+  fun setState(count: Int) {
+    binding.count.text = "Count: $count"
+    if (count >= 0) {
+      binding.count.setTextColor(Color.BLACK)
+    } else {
+      binding.count.setTextColor(Color.RED)
+    }
+  }
+
+  fun setOnIncrementClickListener(listener: OnClickListener?) {
+    onIncrementClickListener = listener
+  }
+
+  fun setOnDecrementClickListener(listener: OnClickListener?) {
+    onDecrementClickListener = listener
+  }
+}
+
+/** An interop compose function that renders [CounterView] as a Circuit-powered [AndroidView]. */
+@Composable
+fun CounterViewComposable(state: CounterState) {
+  val eventSink = state.eventSink
+  AndroidView(
+    modifier = Modifier.fillMaxSize(),
+    factory = { context ->
+      CounterView(context).apply {
+        setOnIncrementClickListener { eventSink(CounterEvent.Increment) }
+        setOnDecrementClickListener { eventSink(CounterEvent.Decrement) }
+      }
+    },
+    update = { view -> view.setState(state.count) }
+  )
+}

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.sample.interop
+
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.slack.circuit.Presenter
+import com.slack.circuit.presenterOf
+import com.slack.circuit.sample.counter.CounterEvent
+import com.slack.circuit.sample.counter.CounterState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/** An [Flow] presenter that exposes a [StateFlow] of count changes. */
+class FlowCounterPresenter {
+  private var count = MutableStateFlow(0)
+
+  fun increment() {
+    count.tryEmit(count.value + 1)
+  }
+
+  fun decrement() {
+    count.tryEmit(count.value - 1)
+  }
+
+  fun countStateFlow(): StateFlow<Int> = count
+}
+
+fun FlowCounterPresenter.asCircuitPresenter(): Presenter<CounterState> {
+  return presenterOf {
+    val count by countStateFlow().collectAsState()
+    CounterState(count) { event ->
+      when (event) {
+        is CounterEvent.Increment -> increment()
+        is CounterEvent.Decrement -> decrement()
+      }
+    }
+  }
+}

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 /** An [Flow] presenter that exposes a [StateFlow] of count changes. */
 class FlowCounterPresenter {
-  private var count = MutableStateFlow(0)
+  private val count = MutableStateFlow(0)
 
   fun increment() {
     count.tryEmit(count.value + 1)

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.sample.interop
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.slack.circuit.CircuitCompositionLocals
+import com.slack.circuit.CircuitConfig
+import com.slack.circuit.CircuitContent
+import com.slack.circuit.Navigator
+import com.slack.circuit.Presenter
+import com.slack.circuit.ScreenUi
+import com.slack.circuit.Ui
+import com.slack.circuit.sample.counter.CounterPresenterFactory
+import com.slack.circuit.sample.counter.CounterScreen
+import com.slack.circuit.sample.counter.CounterState
+import com.slack.circuit.ui
+import kotlinx.parcelize.Parcelize
+
+class MainActivity : AppCompatActivity() {
+  @OptIn(ExperimentalMaterial3Api::class)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val circuitConfig =
+      CircuitConfig.Builder()
+        .addPresenterFactory { screen, _, circuitConfig ->
+          when (screen) {
+            is InteropCounterScreen -> screen.presenterSource.createPresenter(screen, circuitConfig)
+            else -> null
+          }
+        }
+        .addUiFactory { screen, _ ->
+          when (screen) {
+            is InteropCounterScreen -> ScreenUi(screen.uiSource.createUi())
+            else -> null
+          }
+        }
+        .build()
+
+    setContent {
+      CircuitCompositionLocals(circuitConfig) {
+        var selectedPresenterIndex by rememberSaveable { mutableStateOf(0) }
+        var selectedUiIndex by rememberSaveable { mutableStateOf(0) }
+        val circuitScreen =
+          remember(selectedUiIndex, selectedPresenterIndex) {
+            InteropCounterScreen(
+              PresenterSource.values()[selectedPresenterIndex],
+              UiSource.values()[selectedUiIndex]
+            )
+          }
+        Scaffold(
+          modifier = Modifier,
+          bottomBar = {
+            Column(Modifier.padding(16.dp).fillMaxWidth(), Arrangement.spacedBy(16.dp)) {
+              SourceMenu("Presenter Source", selectedPresenterIndex, PresenterSource.values()) {
+                index ->
+                selectedPresenterIndex = index
+              }
+              SourceMenu("UI Source", selectedUiIndex, UiSource.values()) { index ->
+                selectedUiIndex = index
+              }
+            }
+          },
+        ) { paddingValues ->
+          Box(Modifier.padding(paddingValues)) {
+            // TODO this is necessary because the CircuitContent caches the Ui and Presenter, which
+            //  doesn't play well swapping out the Ui and Presenter sources. Might be nice to make
+            //  them live enough to support this, but also sort of orthogonal to the point of this
+            //  sample.
+            key(circuitScreen) { CircuitContent(screen = circuitScreen) }
+          }
+        }
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SourceMenu(
+  label: String,
+  selectedIndex: Int,
+  sourceValues: Array<out Enum<*>>,
+  onSelected: (Int) -> Unit,
+) {
+  var expanded by remember { mutableStateOf(false) }
+  val selectedName: String by
+    remember(selectedIndex) { mutableStateOf(sourceValues[selectedIndex].name) }
+  ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+    TextField(
+      readOnly = true,
+      value = selectedName,
+      label = { Text(label) },
+      onValueChange = {},
+      trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+      colors = ExposedDropdownMenuDefaults.textFieldColors(),
+      modifier = Modifier.menuAnchor(),
+    )
+    ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+      for (source in sourceValues) {
+        SourceMenuItem(source, selectedIndex, onSelected)
+      }
+    }
+  }
+}
+
+@Composable
+private fun SourceMenuItem(
+  source: Enum<*>,
+  selectedIndex: Int,
+  onSelected: (Int) -> Unit,
+) {
+  val isSelected = selectedIndex == source.ordinal
+  val style =
+    if (isSelected) {
+      MaterialTheme.typography.labelLarge.copy(
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.secondary
+      )
+    } else {
+      MaterialTheme.typography.labelLarge.copy(
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.colorScheme.onSurface
+      )
+    }
+  DropdownMenuItem(
+    text = {
+      Text(
+        modifier = Modifier.padding(8.dp),
+        text = source.name,
+        style = style,
+      )
+    },
+    onClick = { onSelected(source.ordinal) },
+  )
+}
+
+@Parcelize
+private data class InteropCounterScreen(
+  val presenterSource: PresenterSource,
+  val uiSource: UiSource
+) : CounterScreen, Parcelable
+
+@Suppress("UNCHECKED_CAST")
+private enum class PresenterSource {
+  Circuit {
+    override fun createPresenter(
+      screen: InteropCounterScreen,
+      config: CircuitConfig
+    ): Presenter<CounterState> {
+      return CounterPresenterFactory().create(screen, Navigator.NoOp, config)
+        as Presenter<CounterState>
+    }
+  },
+  Flow {
+    override fun createPresenter(
+      screen: InteropCounterScreen,
+      config: CircuitConfig
+    ): Presenter<CounterState> {
+      return FlowCounterPresenter().asCircuitPresenter()
+    }
+  },
+  RxJava {
+    override fun createPresenter(
+      screen: InteropCounterScreen,
+      config: CircuitConfig
+    ): Presenter<CounterState> {
+      return RxCounterPresenter().asCircuitPresenter()
+    }
+  },
+  Simple {
+    override fun createPresenter(
+      screen: InteropCounterScreen,
+      config: CircuitConfig
+    ): Presenter<CounterState> {
+      return SimpleCounterPresenter().asCircuitPresenter()
+    }
+  };
+
+  abstract fun createPresenter(
+    screen: InteropCounterScreen,
+    config: CircuitConfig
+  ): Presenter<CounterState>
+}
+
+enum class UiSource {
+  Circuit {
+    override fun createUi(): Ui<CounterState> {
+      return ui { state -> Counter(state) }
+    }
+  },
+  View {
+    override fun createUi(): Ui<CounterState> {
+      return ui { state -> CounterViewComposable(state) }
+    }
+  };
+
+  abstract fun createUi(): Ui<CounterState>
+}

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/RxCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/RxCounterPresenter.kt
@@ -26,7 +26,7 @@ import io.reactivex.rxjava3.subjects.BehaviorSubject
 
 /** An RxJava presenter that exposes an [Observable] of count changes. */
 class RxCounterPresenter {
-  private var count = BehaviorSubject.createDefault(0)
+  private val count = BehaviorSubject.createDefault(0)
 
   fun increment() {
     count.onNext(count.value!! + 1)

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/RxCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/RxCounterPresenter.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.sample.interop
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rxjava3.subscribeAsState
+import com.slack.circuit.Presenter
+import com.slack.circuit.presenterOf
+import com.slack.circuit.sample.counter.CounterEvent
+import com.slack.circuit.sample.counter.CounterState
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.subjects.BehaviorSubject
+
+/** An RxJava presenter that exposes an [Observable] of count changes. */
+class RxCounterPresenter {
+  private var count = BehaviorSubject.createDefault(0)
+
+  fun increment() {
+    count.onNext(count.value!! + 1)
+  }
+
+  fun decrement() {
+    count.onNext(count.value!! - 1)
+  }
+
+  fun countObservable(): Observable<Int> = count.hide()
+}
+
+fun RxCounterPresenter.asCircuitPresenter(): Presenter<CounterState> {
+  return presenterOf {
+    val count by countObservable().subscribeAsState(initial = 0)
+    CounterState(count) { event ->
+      when (event) {
+        is CounterEvent.Increment -> increment()
+        is CounterEvent.Decrement -> decrement()
+      }
+    }
+  }
+}

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/SimpleCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/SimpleCounterPresenter.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.sample.interop
+
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.slack.circuit.Presenter
+import com.slack.circuit.presenterOf
+import com.slack.circuit.sample.counter.CounterEvent
+import com.slack.circuit.sample.counter.CounterState
+
+/** A simple presenter that uses a listener for signaling count changes. */
+class SimpleCounterPresenter {
+
+  private var onCountChangedListener: OnCountChangedListener? = null
+
+  private var count = 0
+
+  fun increment() {
+    count++
+    notifyCountChanged()
+  }
+
+  fun decrement() {
+    count--
+    notifyCountChanged()
+  }
+
+  fun setOnCountChangedListener(listener: OnCountChangedListener?) {
+    onCountChangedListener = listener
+  }
+
+  private fun notifyCountChanged() {
+    onCountChangedListener?.onCountChanged(count)
+  }
+
+  fun interface OnCountChangedListener {
+    fun onCountChanged(count: Int)
+  }
+}
+
+fun SimpleCounterPresenter.asCircuitPresenter(): Presenter<CounterState> {
+  return presenterOf {
+    var count by remember { mutableStateOf(0) }
+    remember {
+      object : RememberObserver {
+        val listener =
+          SimpleCounterPresenter.OnCountChangedListener { newCount -> count = newCount }
+        override fun onAbandoned() {
+          setOnCountChangedListener(null)
+        }
+
+        override fun onForgotten() {
+          setOnCountChangedListener(null)
+        }
+
+        override fun onRemembered() {
+          setOnCountChangedListener(listener)
+        }
+      }
+    }
+    CounterState(count) { event ->
+      when (event) {
+        is CounterEvent.Increment -> increment()
+        is CounterEvent.Decrement -> decrement()
+      }
+    }
+  }
+}

--- a/samples/interop/src/main/res/layout/counter_view.xml
+++ b/samples/interop/src/main/res/layout/counter_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_gravity="center">
+
+    <TextView
+        android:id="@+id/count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:textSize="48sp"
+        tools:text="Count: 0"/>
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="16dp" />
+
+    <Button
+        android:id="@+id/increment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:textSize="48sp"
+        android:text="+"/>
+
+    <Button
+        android:id="@+id/decrement"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:textSize="48sp"
+        android:text="-"/>
+
+</LinearLayout>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -176,6 +176,7 @@ include(
   ":samples:counter:android",
   ":samples:counter:desktop",
   ":samples:counter:mosaic",
+  ":samples:interop",
 )
 
 // https://docs.gradle.org/5.6/userguide/groovy_plugin.html#sec:groovy_compilation_avoidance


### PR DESCRIPTION
This implements a Counter-based interop example that has demos interop-ing to RxJava, Flow, simple Android, and Android Views. Initially starting with one-way interop (going _to_ Circuit), planning to do the other direction in a separate PR.

Resolves #42

[interopdemo.webm](https://user-images.githubusercontent.com/1361086/199153914-2360f72e-f01e-49ec-aed7-5bfc42a49298.webm)
