### PR TITLE
Add deep linking to SocialTees demo app

### DIFF
--- a/samples/star/src/main/AndroidManifest.xml
+++ b/samples/star/src/main/AndroidManifest.xml
@@ -26,6 +26,15 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="petfinder.com" android:scheme="https" />
+                <data android:host="www.petfinder.com" android:scheme="https" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Surface
 import androidx.lifecycle.ViewModelProvider
 import com.slack.circuit.CircuitCompositionLocals
 import com.slack.circuit.CircuitConfig
-import com.slack.circuit.CircuitContent
 import com.slack.circuit.NavigableCircuitContent
 import com.slack.circuit.Screen
 import com.slack.circuit.backstack.rememberSaveableBackStack
@@ -35,12 +34,10 @@ import com.slack.circuit.star.di.ActivityKey
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.home.HomeScreen
 import com.slack.circuit.star.petdetail.PetDetailScreen
-import com.slack.circuit.star.petlist.PetListScreen
 import com.slack.circuit.star.ui.StarTheme
 import com.squareup.anvil.annotations.ContributesMultibinding
-import okhttp3.HttpUrl.Companion.toHttpUrl
-import java.net.URL
 import javax.inject.Inject
+import okhttp3.HttpUrl.Companion.toHttpUrl
 
 @ContributesMultibinding(AppScope::class, boundType = Activity::class)
 @ActivityKey(MainActivity::class)
@@ -53,7 +50,7 @@ constructor(
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    var backStack : List<Screen> = listOf(HomeScreen)
+    var backStack: List<Screen> = listOf(HomeScreen)
     if (intent.data != null) {
       val httpUrl = intent.data.toString().toHttpUrl()
       val animalId = httpUrl.pathSegments[1].substringAfterLast("-").toLong()
@@ -65,11 +62,7 @@ constructor(
       StarTheme {
         // TODO why isn't the windowBackground enough so we don't need to do this?
         Surface(color = MaterialTheme.colorScheme.background) {
-          val backstack = rememberSaveableBackStack {
-            backStack.forEach { screen ->
-              push(screen)
-            }
-          }
+          val backstack = rememberSaveableBackStack { backStack.forEach { screen -> push(screen) } }
           val navigator = rememberCircuitNavigator(backstack)
           CircuitCompositionLocals(circuitConfig) {
             ContentWithOverlays { NavigableCircuitContent(navigator, backstack) }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -24,7 +24,9 @@ import androidx.compose.material3.Surface
 import androidx.lifecycle.ViewModelProvider
 import com.slack.circuit.CircuitCompositionLocals
 import com.slack.circuit.CircuitConfig
+import com.slack.circuit.CircuitContent
 import com.slack.circuit.NavigableCircuitContent
+import com.slack.circuit.Screen
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.push
@@ -32,8 +34,12 @@ import com.slack.circuit.rememberCircuitNavigator
 import com.slack.circuit.star.di.ActivityKey
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.home.HomeScreen
+import com.slack.circuit.star.petdetail.PetDetailScreen
+import com.slack.circuit.star.petlist.PetListScreen
 import com.slack.circuit.star.ui.StarTheme
 import com.squareup.anvil.annotations.ContributesMultibinding
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import java.net.URL
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class, boundType = Activity::class)
@@ -47,11 +53,23 @@ constructor(
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    var backStack : List<Screen> = listOf(HomeScreen)
+    if (intent.data != null) {
+      val httpUrl = intent.data.toString().toHttpUrl()
+      val animalId = httpUrl.pathSegments[1].substringAfterLast("-").toLong()
+      val petDetailScreen = PetDetailScreen(animalId, null)
+      backStack = listOf(HomeScreen, petDetailScreen)
+    }
+
     setContent {
       StarTheme {
         // TODO why isn't the windowBackground enough so we don't need to do this?
         Surface(color = MaterialTheme.colorScheme.background) {
-          val backstack = rememberSaveableBackStack { push(HomeScreen) }
+          val backstack = rememberSaveableBackStack {
+            backStack.forEach { screen ->
+              push(screen)
+            }
+          }
           val navigator = rememberCircuitNavigator(backstack)
           CircuitCompositionLocals(circuitConfig) {
             ContentWithOverlays { NavigableCircuitContent(navigator, backstack) }


### PR DESCRIPTION
### Summary
This demos deeplinking in `Circuit` and how we can extract the Screens for the Backstack from the passed in URL. The URL must be setup in a way that matches your scheme then each section can correspond to a Screen in your app. It should be noted that currently will default to running Chrome when clicking on a link, it will work when running from the command line. Resolves https://github.com/slackhq/circuit/issues/14

To test run this command in your terminal:
`adb shell am start -W -a android.intent.action.VIEW -d "https://www.petfinder.com/dog/veronica-54090287/ny/manhattan/social-tees-animal-rescue-foundation-ny835/" com.slack.circuit.sample.star.apk`