### PR TITLE
Update NavigatorImpl.pop() to invoke onBackPressedDispatcher

### DIFF
--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -34,9 +34,11 @@ import com.slack.circuit.backstack.isEmpty
 @Composable
 public fun rememberCircuitNavigator(
   backstack: SaveableBackStack,
-  onBackPressedDispatcherOwner: OnBackPressedDispatcherOwner? = LocalOnBackPressedDispatcherOwner.current
+  onBackPressedDispatcherOwner: OnBackPressedDispatcherOwner? =
+    LocalOnBackPressedDispatcherOwner.current
 ): Navigator {
-  val onBackPressedDispatcher = requireNotNull(onBackPressedDispatcherOwner?.onBackPressedDispatcher)
+  val onBackPressedDispatcher =
+    requireNotNull(onBackPressedDispatcherOwner?.onBackPressedDispatcher)
   return remember { NavigatorImpl(backstack, onBackPressedDispatcher) }
 }
 

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -30,6 +30,7 @@ import com.slack.circuit.backstack.isEmpty
  * @see NavigableCircuitContent
  *
  * @param backstack The backing [SaveableBackStack] to navigate.
+ * @param onBackPressedDispatcherOwner Used to obtain the [OnBackPressedDispatcher].
  */
 @Composable
 public fun rememberCircuitNavigator(

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -39,12 +39,12 @@ public fun rememberCircuitNavigator(
 ): Navigator {
   val onBackPressedDispatcher =
     requireNotNull(onBackPressedDispatcherOwner?.onBackPressedDispatcher)
-  return remember { NavigatorImpl(backstack, onBackPressedDispatcher) }
+  return remember { NavigatorImpl(backstack, onBackPressedDispatcher::onBackPressed) }
 }
 
 internal class NavigatorImpl(
   private val backstack: SaveableBackStack,
-  private val onBackPressedDispatcher: OnBackPressedDispatcher
+  private val onRootPop: () -> Unit
 ) : Navigator {
 
   init {
@@ -55,7 +55,7 @@ internal class NavigatorImpl(
 
   override fun pop(): Screen? {
     if (backstack.isAtRoot) {
-      onBackPressedDispatcher.onBackPressed()
+      onRootPop()
       return null
     }
 

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -35,24 +35,33 @@ private object TestScreen : Screen {
 
 @RunWith(RobolectricTestRunner::class)
 class NavigatorTest {
-
   @Test
   fun errorWhenBackstackIsEmpty() {
     val backstack = SaveableBackStack()
-    val t = assertFailsWith<IllegalStateException> { NavigatorImpl(backstack = backstack) }
+    val t = assertFailsWith<IllegalStateException> {
+      NavigatorImpl(backstack) { }
+    }
     assertThat(t).hasMessageThat().contains("Backstack size must not be empty.")
   }
 
   @Test
   fun popAtRoot() {
-    val backstack = SaveableBackStack()
-    backstack.push(TestScreen)
-    backstack.push(TestScreen)
-    val navigator = NavigatorImpl(backstack = backstack)
-    assertThat(backstack).hasSize(2)
-    navigator.pop()
-    assertThat(backstack).hasSize(1)
-    val t = assertFailsWith<IllegalStateException> { navigator.pop() }
-    assertThat(t).hasMessageThat().contains("Cannot pop the root screen.")
+  val backstack = SaveableBackStack()
+  backstack.push(TestScreen)
+  backstack.push(TestScreen)
+
+  var onRootPop = 0
+  val navigator = NavigatorImpl(backstack) { onRootPop++ }
+
+  assertThat(backstack).hasSize(2)
+  assertThat(onRootPop).isEqualTo(0)
+
+  navigator.pop()
+  assertThat(backstack).hasSize(1)
+  assertThat(onRootPop).isEqualTo(0)
+
+  navigator.pop()
+  assertThat(backstack).hasSize(1)
+  assertThat(onRootPop).isEqualTo(1)
   }
 }

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -38,30 +38,28 @@ class NavigatorTest {
   @Test
   fun errorWhenBackstackIsEmpty() {
     val backstack = SaveableBackStack()
-    val t = assertFailsWith<IllegalStateException> {
-      NavigatorImpl(backstack) { }
-    }
+    val t = assertFailsWith<IllegalStateException> { NavigatorImpl(backstack) {} }
     assertThat(t).hasMessageThat().contains("Backstack size must not be empty.")
   }
 
   @Test
   fun popAtRoot() {
-  val backstack = SaveableBackStack()
-  backstack.push(TestScreen)
-  backstack.push(TestScreen)
+    val backstack = SaveableBackStack()
+    backstack.push(TestScreen)
+    backstack.push(TestScreen)
 
-  var onRootPop = 0
-  val navigator = NavigatorImpl(backstack) { onRootPop++ }
+    var onRootPop = 0
+    val navigator = NavigatorImpl(backstack) { onRootPop++ }
 
-  assertThat(backstack).hasSize(2)
-  assertThat(onRootPop).isEqualTo(0)
+    assertThat(backstack).hasSize(2)
+    assertThat(onRootPop).isEqualTo(0)
 
-  navigator.pop()
-  assertThat(backstack).hasSize(1)
-  assertThat(onRootPop).isEqualTo(0)
+    navigator.pop()
+    assertThat(backstack).hasSize(1)
+    assertThat(onRootPop).isEqualTo(0)
 
-  navigator.pop()
-  assertThat(backstack).hasSize(1)
-  assertThat(onRootPop).isEqualTo(1)
+    navigator.pop()
+    assertThat(backstack).hasSize(1)
+    assertThat(onRootPop).isEqualTo(1)
   }
 }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/common/NavigableTopBarScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/common/NavigableTopBarScreen.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.circuit.star.common
+
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.Image
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+
+@Composable
+fun BackPressNavIcon(
+  modifier: Modifier = Modifier,
+  iconButtonContent: @Composable () -> Unit = { ClosedIconImage() },
+) {
+  val onBackPressedDispatcher =
+    LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+      ?: error("No local LocalOnBackPressedDispatcherOwner found.")
+  IconButton(modifier = modifier, onClick = onBackPressedDispatcher::onBackPressed) {
+    iconButtonContent()
+  }
+}
+
+@Composable
+private fun ClosedIconImage(modifier: Modifier = Modifier) {
+  Image(
+    modifier = modifier,
+    painter = rememberVectorPainter(image = Icons.Filled.Close),
+    contentDescription = "Close",
+  )
+}

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/petdetail/PetDetailPresenterTest.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/petdetail/PetDetailPresenterTest.kt
@@ -46,7 +46,7 @@ class PetDetailPresenterTest {
     val presenter = PetDetailPresenter(screen, repository)
 
     presenter.test {
-      assertThat(PetDetailScreen.State.Loading).isEqualTo(awaitItem())
+      assertThat(awaitItem()).isEqualTo(PetDetailScreen.State.Loading)
 
       val success = animal.toPetDetailState(animal.photos.first().small)
       assertThat(awaitItem()).isEqualTo(success)


### PR DESCRIPTION
The current back solution seems to work when tapping the system back button or triggering the back gesture. However, manual calls to Navigator.pop (triggered by an on screen back button) when viewing the root backstack record will crash the app. This happens purposely as we don't want to allow an empty backstack.

To resolve this, NavigatorImpl has been updated to invoke a onBackPressedDispatcher whenever pop() is called while on the root backstack record.