### PR TITLE
Implement CircuitContext

### DIFF
--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Visibility
-import com.slack.circuit.CircuitConfig
+import com.slack.circuit.CircuitContext
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
@@ -71,7 +71,6 @@ private class CircuitSymbols private constructor(resolver: Resolver) {
   val circuitUiState = resolver.loadKSType<CircuitUiState>()
   val screen = resolver.loadKSType<Screen>()
   val navigator = resolver.loadKSType<Navigator>()
-  val circuitConfig = resolver.loadKSType<CircuitConfig>()
   companion object {
     fun create(resolver: Resolver): CircuitSymbols? {
       @Suppress("SwallowedException")
@@ -391,11 +390,6 @@ private fun KSFunctionDeclaration.assistedParameters(
               )
             }
           }
-          type.isInstanceOf(symbols.circuitConfig) -> {
-            addOrError(
-              AssistedType("circuitConfig", type.toTypeName(), param.name!!.getShortName())
-            )
-          }
         }
       }
     }
@@ -422,7 +416,7 @@ private fun TypeSpec.Builder.buildUiFactory(
       FunSpec.builder("create")
         .addModifiers(KModifier.OVERRIDE)
         .addParameter("screen", Screen::class)
-        .addParameter("circuitConfig", CircuitConfig::class)
+        .addParameter("context", CircuitContext::class)
         .returns(ScreenUi::class.asClassName().copy(nullable = true))
         .beginControlFlow("return·when·(screen)")
         .addStatement(
@@ -449,7 +443,7 @@ private fun TypeSpec.Builder.buildPresenterFactory(
   //    public override fun create(
   //      screen: Screen,
   //      navigator: Navigator,
-  //      circuitConfig: CircuitConfig,
+  //      context: CircuitContext,
   //    ): Presenter<*>? = when (screen) {
   //      is AboutScreen -> AboutPresenter()
   //      is AboutScreen -> presenterOf { AboutPresenter() }
@@ -463,7 +457,7 @@ private fun TypeSpec.Builder.buildPresenterFactory(
         .addModifiers(KModifier.OVERRIDE)
         .addParameter("screen", Screen::class)
         .addParameter("navigator", Navigator::class)
-        .addParameter("circuitConfig", CircuitConfig::class)
+        .addParameter("context", CircuitContext::class)
         .returns(Presenter::class.asClassName().parameterizedBy(STAR).copy(nullable = true))
         .beginControlFlow("return when (screen)")
         .addStatement("%L·->·%L", screenBranch, instantiationCodeBlock)

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitConfig.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitConfig.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Immutable
  * ```kotlin
  * val circuitConfig = CircuitConfig.Builder()
  *     .addUiFactory(AddFavoritesUiFactory()
- *     .addPresenterFactory(AddFavoritesPresenterFactory()
+ *     .addPresenterFactory(AddFavoritesPresenterFactory())
  *     .build()
  * ```
  *
@@ -45,9 +45,9 @@ import androidx.compose.runtime.Immutable
  * }
  * ```
  *
- * @see rememberCircuitNavigator
  * @see CircuitContent
- * @see NavigableCircuitContent
+ * @see `rememberCircuitNavigator`
+ * @see `NavigableCircuitContent`
  */
 @Immutable
 public class CircuitConfig private constructor(builder: Builder) {
@@ -57,18 +57,23 @@ public class CircuitConfig private constructor(builder: Builder) {
     builder.onUnavailableContent
   internal val eventListenerFactory: EventListener.Factory? = builder.eventListenerFactory
 
-  public fun presenter(screen: Screen, navigator: Navigator): Presenter<*>? {
-    return nextPresenter(null, screen, navigator)
+  public fun presenter(
+    screen: Screen,
+    navigator: Navigator,
+    context: CircuitContext = CircuitContext(this)
+  ): Presenter<*>? {
+    return nextPresenter(null, screen, navigator, context)
   }
 
   public fun nextPresenter(
     skipPast: Presenter.Factory?,
     screen: Screen,
-    navigator: Navigator
+    navigator: Navigator,
+    context: CircuitContext
   ): Presenter<*>? {
     val start = presenterFactories.indexOf(skipPast) + 1
     for (i in start until presenterFactories.size) {
-      val presenter = presenterFactories[i].create(screen, navigator, this)
+      val presenter = presenterFactories[i].create(screen, navigator, context)
       if (presenter != null) {
         return presenter
       }
@@ -77,14 +82,14 @@ public class CircuitConfig private constructor(builder: Builder) {
     return null
   }
 
-  public fun ui(screen: Screen): ScreenUi? {
-    return nextUi(null, screen)
+  public fun ui(screen: Screen, context: CircuitContext = CircuitContext(this)): ScreenUi? {
+    return nextUi(null, screen, context)
   }
 
-  public fun nextUi(skipPast: Ui.Factory?, screen: Screen): ScreenUi? {
+  public fun nextUi(skipPast: Ui.Factory?, screen: Screen, context: CircuitContext): ScreenUi? {
     val start = uiFactories.indexOf(skipPast) + 1
     for (i in start until uiFactories.size) {
-      val ui = uiFactories[i].create(screen, this)
+      val ui = uiFactories[i].create(screen, context)
       if (ui != null) {
         return ui
       }
@@ -96,9 +101,8 @@ public class CircuitConfig private constructor(builder: Builder) {
   public fun newBuilder(): Builder = Builder(this)
 
   public class Builder constructor() {
-    public val uiFactories: MutableList<Ui.Factory> = mutableListOf<Ui.Factory>()
-    public val presenterFactories: MutableList<Presenter.Factory> =
-      mutableListOf<Presenter.Factory>()
+    public val uiFactories: MutableList<Ui.Factory> = mutableListOf()
+    public val presenterFactories: MutableList<Presenter.Factory> = mutableListOf()
     public var onUnavailableContent: (@Composable (screen: Screen) -> Unit)? = null
       private set
     public var eventListenerFactory: EventListener.Factory? = null

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -52,14 +52,14 @@ internal fun CircuitContent(
       circuitConfig.eventListenerFactory?.create(screen, context) ?: EventListener.NONE
     }
 
-  eventListener.onBeforeCreateUi(screen, context)
-  val screenUi = circuitConfig.ui(screen)
-  eventListener.onAfterCreateUi(screen, screenUi, context)
-
   eventListener.onBeforeCreatePresenter(screen, navigator, context)
   @Suppress("UNCHECKED_CAST")
   val presenter = circuitConfig.presenter(screen, navigator) as Presenter<CircuitUiState>?
   eventListener.onAfterCreatePresenter(screen, navigator, presenter, context)
+
+  eventListener.onBeforeCreateUi(screen, context)
+  val screenUi = circuitConfig.ui(screen)
+  eventListener.onAfterCreateUi(screen, screenUi, context)
 
   if (screenUi != null && presenter != null) {
     @Suppress("UNCHECKED_CAST")

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContext.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContext.kt
@@ -1,0 +1,60 @@
+// Copyright (C) 2022 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit
+
+import kotlin.reflect.KClass
+
+/**
+ * A [CircuitContext] is used in [Presenter.Factory] and [Ui.Factory] to inform creation of their
+ * respective [Presenter] and [Ui] instances.
+ *
+ * Available information includes:
+ * - [CircuitConfig]
+ * - the [CircuitConfig] used in this [CircuitContext].
+ * - [tag] – a tag API to plumb arbitrary metadata through the [CircuitConfig].
+ */
+public class CircuitContext
+internal constructor(
+  /** The [CircuitConfig] used in this context. */
+  public var config: CircuitConfig
+) {
+  // Don't expose the raw map.
+  private val tags = mutableMapOf<KClass<*>, Any>()
+
+  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  public fun <T : Any> tag(type: KClass<T>): T? {
+    @Suppress("UNCHECKED_CAST") return tags[type] as T?
+  }
+
+  /** Returns the tag attached with [T] as a key, or null if no tag is attached with that key. */
+  public inline fun <reified T : Any> tag(): T? = tag(T::class)
+
+  /**
+   * Attaches [tag] to the request using [T] as a key. Tags can be read from a request using
+   * [CircuitContext.tag]. Use `null` to remove any existing tag assigned for [T].
+   *
+   * Use this API to attach metadata, debugging, or other application data to a spec so that you may
+   * read it in other APIs or callbacks.
+   */
+  public inline fun <reified T : Any> putTag(tag: Any?): Unit = putTag(T::class, tag)
+
+  /**
+   * Attaches [tag] to the request using [type] as a key. Tags can be read from a request using
+   * [CircuitContext.tag]. Use `null` to remove any existing tag assigned for [type].
+   *
+   * Use this API to attach metadata, debugging, or other application data to a spec so that you may
+   * read it in other APIs or callbacks.
+   */
+  public fun putTag(type: KClass<*>, tag: Any?): Unit {
+    if (tag == null) {
+      this.tags.remove(type)
+    } else {
+      this.tags[type] = tag
+    }
+  }
+
+  /** Clears all the current tags. */
+  public fun clearTags() {
+    tags.clear()
+  }
+}

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/EventListener.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/EventListener.kt
@@ -8,11 +8,59 @@ package com.slack.circuit
  */
 public interface EventListener {
 
-  /** Called when there is a new [state] returned by the [Presenter]. */
+  /** Called just before creating a [Presenter] for a given [screen]. */
+  public fun onBeforeCreatePresenter(
+    screen: Screen,
+    navigator: Navigator,
+    context: CircuitContext
+  ) {}
+
+  /**
+   * Called just after creating a [presenter] for a given [screen]. The presenter may be null if
+   * none was found.
+   */
+  public fun onAfterCreatePresenter(
+    screen: Screen,
+    navigator: Navigator,
+    presenter: Presenter<*>?,
+    context: CircuitContext
+  ) {}
+
+  /** Called just before creating a [Ui] for a given [screen]. */
+  public fun onBeforeCreateUi(screen: Screen, context: CircuitContext) {}
+
+  /**
+   * Called just after creating a [screenUi] for a given [screen]. The ui may be null if none was
+   * found.
+   */
+  public fun onAfterCreateUi(screen: Screen, screenUi: ScreenUi?, context: CircuitContext) {}
+
+  /** Called when no content was found and one or both of [presenter] and [screenUi] are null. */
+  public fun onUnavailableContent(
+    screen: Screen,
+    presenter: Presenter<*>?,
+    screenUi: ScreenUi?,
+    context: CircuitContext
+  ) {}
+
+  /**
+   * Called when there is a new [state] returned by the [Presenter]. This is called every time state
+   * is recomposed.
+   */
   public fun onState(state: Any) {}
 
+  /** Called once before the initial [Presenter.present] call. */
+  public fun onStartPresent() {}
+  /** Called once after the [Presenter.present] composition is disposed. */
+  public fun onDisposePresent() {}
+
+  /** Called once before the initial [Ui.Content] call. */
+  public fun onStartContent() {}
+  /** Called once after the [Ui.Content] composition is disposed. */
+  public fun onDisposeContent() {}
+
   public fun interface Factory {
-    public fun create(screen: Screen): EventListener
+    public fun create(screen: Screen, context: CircuitContext): EventListener
   }
 
   public companion object {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Presenter.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Presenter.kt
@@ -132,7 +132,7 @@ public interface Presenter<UiState : CircuitUiState> {
    *   val detailsPresenter: ProfilerDetailsPresenter.Factory,
    *   val callScreenRouter: CallScreenRouter.Factory
    * ) : Presenter.Factory {
-   *   override fun create(screen: Screen, navigator: Navigator, circuitConfig: CircuitConfig): Presenter<*, *>? {
+   *   override fun create(screen: Screen, navigator: Navigator, context: CircuitContext): Presenter<*, *>? {
    *     return when (screen) {
    *       is ProfileHeader -> headerPresenter.create(screen)
    *       is ProfileActions -> actionsPresenter.create(screen, callScreenRouter.create(navigator))
@@ -149,11 +149,7 @@ public interface Presenter<UiState : CircuitUiState> {
      * Creates a [Presenter] for the given [screen] if it can handle it, or returns null if it
      * cannot handle the given [screen].
      */
-    public fun create(
-      screen: Screen,
-      navigator: Navigator,
-      circuitConfig: CircuitConfig
-    ): Presenter<*>?
+    public fun create(screen: Screen, navigator: Navigator, context: CircuitContext): Presenter<*>?
   }
 }
 

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Ui.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Ui.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
  * This has two main benefits:
  * 1. Discouraging properties and general non-composable state that writing a class may invite.
  * 2. Ensuring separation of [Ui] instance from [Screen] specific ui composables allows for and
- * encourages easy UI previews via Compose's [@Preview][Preview] annotations.
+ * encourages easy UI previews via Compose's `@Preview` annotations.
  *
  * Usage:
  * ```
@@ -51,7 +51,7 @@ public interface Ui<UiState : CircuitUiState> {
    * class FavoritesUiFactory @Inject constructor() : Ui.Factory {
    *  override fun create(
    *    screen: Screen,
-   *    circuitConfig: CircuitConfig
+   *    context: CircuitContext
    *  ): ScreenUi? {
    *    val ui = when (screen) {
    *      is AddFavorites -> {
@@ -72,7 +72,7 @@ public interface Ui<UiState : CircuitUiState> {
    * ```
    */
   public fun interface Factory {
-    public fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi?
+    public fun create(screen: Screen, context: CircuitContext): ScreenUi?
   }
 }
 

--- a/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
+++ b/circuit/src/jvmTest/kotlin/com/slack/circuit/EventListenerTest.kt
@@ -9,6 +9,8 @@ import app.cash.molecule.RecompositionClock.Immediate
 import app.cash.molecule.launchMolecule
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import java.time.LocalTime
+import java.time.ZoneOffset.UTC
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -69,8 +71,63 @@ private class StringUi : Ui<StringState> {
 private class RecordingEventListener : EventListener {
   val states = Turbine<Any>(name = "recording event listener states")
 
+  private fun log(message: String) {
+    println("${LocalTime.now(UTC).toString().replace("T"," ")}: $message")
+  }
+
   override fun onState(state: Any) {
+    log("onState: $state")
     states.add(state)
+  }
+
+  override fun onBeforeCreatePresenter(
+    screen: Screen,
+    navigator: Navigator,
+    context: CircuitContext,
+  ) {
+    log("onBeforeCreatePresenter: $screen")
+  }
+
+  override fun onAfterCreatePresenter(
+    screen: Screen,
+    navigator: Navigator,
+    presenter: Presenter<*>?,
+    context: CircuitContext,
+  ) {
+    log("onAfterCreatePresenter: $screen, $presenter")
+  }
+
+  override fun onBeforeCreateUi(screen: Screen, context: CircuitContext) {
+    log("onBeforeCreateUi: $screen")
+  }
+
+  override fun onAfterCreateUi(screen: Screen, screenUi: ScreenUi?, context: CircuitContext) {
+    log("onAfterCreateUi: $screen, $screenUi")
+  }
+
+  override fun onUnavailableContent(
+    screen: Screen,
+    presenter: Presenter<*>?,
+    screenUi: ScreenUi?,
+    context: CircuitContext,
+  ) {
+    error("onUnavailableContent: $screen, $presenter, $screenUi")
+  }
+
+  override fun onStartPresent() {
+    log("onStartPresent")
+  }
+
+  override fun onDisposePresent() {
+    log("onDisposePresent")
+  }
+
+  override fun onStartContent() {
+    log("onStartContent")
+  }
+
+  override fun onDisposeContent() {
+    log("onDisposeContent")
   }
 
   class Factory : EventListener.Factory {
@@ -79,6 +136,6 @@ private class RecordingEventListener : EventListener {
     fun get(screen: Screen): RecordingEventListener =
       listeners[screen] ?: (RecordingEventListener().also { listeners[screen] = it })
 
-    override fun create(screen: Screen): EventListener = get(screen)
+    override fun create(screen: Screen, context: CircuitContext) = get(screen)
   }
 }

--- a/samples/counter/android/src/main/kotlin/com/slack/circuit/sample/counter/android/AndroidCounterCircuit.kt
+++ b/samples/counter/android/src/main/kotlin/com/slack/circuit/sample/counter/android/AndroidCounterCircuit.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.slack.circuit.CircuitConfig
+import com.slack.circuit.CircuitContext
 import com.slack.circuit.Screen
 import com.slack.circuit.ScreenUi
 import com.slack.circuit.Ui
@@ -66,7 +66,7 @@ fun Counter(state: CounterState, modifier: Modifier = Modifier) {
 }
 
 class CounterUiFactory : Ui.Factory {
-  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
+  override fun create(screen: Screen, context: CircuitContext): ScreenUi? {
     return when (screen) {
       is CounterScreen -> ScreenUi(ui<CounterState> { state -> Counter(state) })
       else -> null

--- a/samples/counter/desktop/src/main/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
+++ b/samples/counter/desktop/src/main/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.window.singleWindowApplication
 import com.slack.circuit.CircuitCompositionLocals
 import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitContent
+import com.slack.circuit.CircuitContext
 import com.slack.circuit.Screen
 import com.slack.circuit.ScreenUi
 import com.slack.circuit.Ui
@@ -66,7 +67,7 @@ fun Counter(state: CounterState, modifier: Modifier = Modifier) {
 }
 
 class CounterUiFactory : Ui.Factory {
-  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
+  override fun create(screen: Screen, context: CircuitContext): ScreenUi? {
     return when (screen) {
       is CounterScreen -> ScreenUi(ui<CounterState> { state -> Counter(state) })
       else -> null

--- a/samples/counter/mosaic/src/main/kotlin/com/slack/circuit/sample/counter/mosaic/MosaicCounterCircuit.kt
+++ b/samples/counter/mosaic/src/main/kotlin/com/slack/circuit/sample/counter/mosaic/MosaicCounterCircuit.kt
@@ -17,6 +17,7 @@ import com.jakewharton.mosaic.runMosaic
 import com.slack.circuit.CircuitCompositionLocals
 import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitContent
+import com.slack.circuit.CircuitContext
 import com.slack.circuit.Screen
 import com.slack.circuit.ScreenUi
 import com.slack.circuit.Ui
@@ -52,7 +53,7 @@ fun main(args: Array<String>) = MosaicCounterCommand().main(args)
 object MosaicCounterScreen : CounterScreen
 
 class CounterUiFactory : Ui.Factory {
-  override fun create(screen: Screen, circuitConfig: CircuitConfig): ScreenUi? {
+  override fun create(screen: Screen, context: CircuitContext): ScreenUi? {
     return when (screen) {
       MosaicCounterScreen -> ScreenUi(counterUi())
       else -> null

--- a/samples/counter/src/commonMain/kotlin/com/slack/circuit/sample/counter/CounterPresenter.kt
+++ b/samples/counter/src/commonMain/kotlin/com/slack/circuit/sample/counter/CounterPresenter.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import com.slack.circuit.CircuitConfig
+import com.slack.circuit.CircuitContext
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.Navigator
@@ -45,7 +45,7 @@ class CounterPresenterFactory : Presenter.Factory {
   override fun create(
     screen: Screen,
     navigator: Navigator,
-    circuitConfig: CircuitConfig,
+    context: CircuitContext,
   ): Presenter<*>? {
     return when (screen) {
       is CounterScreen -> presenterOf { CounterPresenter() }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import com.slack.circuit.CircuitCompositionLocals
 import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitContent
+import com.slack.circuit.CircuitContext
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
 import com.slack.circuit.ScreenUi
@@ -49,9 +50,9 @@ class MainActivity : AppCompatActivity() {
 
     val circuitConfig =
       CircuitConfig.Builder()
-        .addPresenterFactory { screen, _, circuitConfig ->
+        .addPresenterFactory { screen, _, context ->
           when (screen) {
-            is InteropCounterScreen -> screen.presenterSource.createPresenter(screen, circuitConfig)
+            is InteropCounterScreen -> screen.presenterSource.createPresenter(screen, context)
             else -> null
           }
         }
@@ -172,16 +173,16 @@ private enum class PresenterSource {
   Circuit {
     override fun createPresenter(
       screen: InteropCounterScreen,
-      config: CircuitConfig
+      context: CircuitContext,
     ): Presenter<CounterState> {
-      return CounterPresenterFactory().create(screen, Navigator.NoOp, config)
+      return CounterPresenterFactory().create(screen, Navigator.NoOp, context)
         as Presenter<CounterState>
     }
   },
   Flow {
     override fun createPresenter(
       screen: InteropCounterScreen,
-      config: CircuitConfig
+      context: CircuitContext,
     ): Presenter<CounterState> {
       return FlowCounterPresenter().asCircuitPresenter()
     }
@@ -189,7 +190,7 @@ private enum class PresenterSource {
   RxJava {
     override fun createPresenter(
       screen: InteropCounterScreen,
-      config: CircuitConfig
+      context: CircuitContext,
     ): Presenter<CounterState> {
       return RxCounterPresenter().asCircuitPresenter()
     }
@@ -197,7 +198,7 @@ private enum class PresenterSource {
   Simple {
     override fun createPresenter(
       screen: InteropCounterScreen,
-      config: CircuitConfig
+      context: CircuitContext,
     ): Presenter<CounterState> {
       return SimpleCounterPresenter().asCircuitPresenter()
     }
@@ -205,7 +206,7 @@ private enum class PresenterSource {
 
   abstract fun createPresenter(
     screen: InteropCounterScreen,
-    config: CircuitConfig
+    context: CircuitContext,
   ): Presenter<CounterState>
 }
 


### PR DESCRIPTION
This introduces a new `CircuitContext` API to factories to replace the current `CircuitConfig` parameter.

The goal of `CircuitContext` is to offer a way to easily add extra context to presenter and UI factory requests and allow for extra flexibility to breadcrumb extra information via a tags API. `CircuitContext` is _mutable_ in nature and modeled similarly to Moshi's `JsonReader` API, and should not be kept past factory creation.

Currently it exposes the global `CircuitConfig` and a tags API.

The tags API should allow consumers to plumb through anything extra they need that doesn't necessarily fit in Circuit's core API, such as telemetry infrastructure. This is similar in nature to the tags APIs found in Moshi, OkHttp, KotlinPoet, etc.

Along the way I've implemented some new `EventListener` APIs with access to this. Its test is now beefed up and demonstrates a nice example of a very basic logging listener.

```
22:17:42.257385: onBeforeCreatePresenter: com.slack.circuit.TestScreen@5e501402
22:17:42.262146: onAfterCreatePresenter: com.slack.circuit.TestScreen@5e501402, com.slack.circuit.StringPresenter@40b90bed
22:17:42.262309: onBeforeCreateUi: com.slack.circuit.TestScreen@5e501402
22:17:42.263987: onAfterCreateUi: com.slack.circuit.TestScreen@5e501402, ScreenUi(ui=com.slack.circuit.StringUi@9aa4af8)
22:17:42.267804: onStartPresent
22:17:42.268188: onStartContent
22:17:42.268620: onState: StringState(value=State)
22:17:42.291560: onState: StringState(value=State2)
22:17:42.297336: onDisposeContent
22:17:42.297433: onDisposePresent
```