### PR TITLE
Give each compose sub-project it's own version to reflect independent release schedule

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,7 +213,7 @@ subprojects {
     compileSdk = 33
 
     buildFeatures { compose = true }
-    composeOptions { kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get() }
+    composeOptions { kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get() }
 
     compileOptions {
       sourceCompatibility = JavaVersion.VERSION_11

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,10 +7,15 @@ androidx-lifecycle = "2.5.1"
 agp = "7.3.1"
 anvil = "2.4.2"
 coil = "2.2.2"
-compose = "1.3.2"
+compose-animation = "1.3.2"
 # Pre-release versions for testing Kotlin previews can be found here
 # https://androidx.dev/storage/compose-compiler/repository
-composeCompiler = "1.3.2"
+compose-compiler = "1.3.2"
+compose-foundation = "1.3.1"
+compose-material = "1.3.1"
+compose-material3 = "1.0.1"
+compose-runtime = "1.3.2"
+compose-ui = "1.3.2"
 composeCompilerKotlinVersion = "1.7.20"
 compose-jb = "1.2.1"
 compose-integration-constraintlayout = "1.0.1"
@@ -77,38 +82,38 @@ androidx-compose-accompanist-permissions = { module = "com.google.accompanist:ac
 androidx-compose-accompanist-placeholder = { module = "com.google.accompanist:accompanist-placeholder", version.ref = "accompanist" }
 androidx-compose-accompanist-swiperefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version.ref = "accompanist" }
 androidx-compose-accompanist-systemUi = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
-androidx-compose-animation = { module = "androidx.compose.animation:animation", version.ref = "compose" }
-androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
+androidx-compose-animation = { module = "androidx.compose.animation:animation", version.ref = "compose-animation" }
+androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 # Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose-foundation" }
 androidx-compose-integration-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-compose-integration-constraintLayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "compose-integration-constraintlayout" }
 androidx-compose-integration-materialThemeAdapter = { module = "com.google.android.material:compose-theme-adapter", version.ref = "material-composeThemeAdapter" }
-androidx-compose-integration-rxjava3 = { module = "androidx.compose.runtime:runtime-rxjava3", version.ref = "compose" }
+androidx-compose-integration-rxjava3 = { module = "androidx.compose.runtime:runtime-rxjava3", version.ref = "compose-runtime" }
 # Material design icons
-androidx-compose-material-icons = { module = "androidx.compose.material:material-icons-core", version.ref = "compose" }
-androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
-androidx-compose-material-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-androidx-compose-material-material3 = { module = "androidx.compose.material3:material3", version = "1.0.1" }
+androidx-compose-material-icons = { module = "androidx.compose.material:material-icons-core", version.ref = "compose-material" }
+androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose-material" }
+androidx-compose-material-material = { module = "androidx.compose.material:material", version.ref = "compose-material" }
+androidx-compose-material-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" }
 # Runtime artifact, must be manually applied.
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
-androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose" }
-androidx-compose-runtime-rxjava3 = { module = "androidx.compose.runtime:runtime-rxjava3", version.ref = "compose" }
-androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics", version.ref = "compose" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose-runtime" }
+androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose-runtime" }
+androidx-compose-runtime-rxjava3 = { module = "androidx.compose.runtime:runtime-rxjava3", version.ref = "compose-runtime" }
+androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics", version.ref = "compose-ui" }
 # UI Tests.
-androidx-compose-ui-testing-junit = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+androidx-compose-ui-testing-junit = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose-ui" }
 # Compose testing library that should be added as a debugImplementation dependency to add properties to the debug manifest necessary for testing an application
-androidx-compose-ui-testing-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
-androidx-compose-ui-text = { module = "androidx.compose.ui:ui-text", version.ref = "compose" }
+androidx-compose-ui-testing-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui" }
+androidx-compose-ui-text = { module = "androidx.compose.ui:ui-text", version.ref = "compose-ui" }
 # Tooling support (Previews, etc.)
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-androidx-compose-ui-tooling-data = { module = "androidx.compose.ui:ui-tooling-data", version.ref = "compose" }
-androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-androidx-compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-androidx-compose-ui-unit = { module = "androidx.compose.ui:ui-unit", version.ref = "compose" }
-androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui" }
+androidx-compose-ui-tooling-data = { module = "androidx.compose.ui:ui-tooling-data", version.ref = "compose-ui" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
+androidx-compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
+androidx-compose-ui-unit = { module = "androidx.compose.ui:ui-unit", version.ref = "compose-ui" }
+androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose-ui" }
 # Embed XML via view binding into Composables
-androidx-compose-ui-viewBinding = { module = "androidx.compose.ui:ui-viewbinding", version.ref = "compose" }
+androidx-compose-ui-viewBinding = { module = "androidx.compose.ui:ui-viewbinding", version.ref = "compose-ui" }
 
 androidx-core = "androidx.core:core-ktx:1.9.0"
 


### PR DESCRIPTION
It seems the compose sub-projects aren't all at the same version as we had assumed. This PR updates the dependency catalog to introduce versions for each compose sub-project.

This addresses the compilation issue in #332 