### PR TITLE
Add navigator method to clear backstack and set new root screen

### DIFF
--- a/circuit-test/build.gradle.kts
+++ b/circuit-test/build.gradle.kts
@@ -24,11 +24,14 @@ kotlin {
         api(libs.molecule.runtime)
       }
     }
-    //    maybeCreate("androidMain").apply {
-    //      dependencies {
-    //        api(libs.androidx.compose.runtime)
-    //      }
-    //    }
+
+    commonTest {
+      dependencies {
+        implementation(libs.coroutines.test)
+        implementation(libs.junit)
+        implementation(libs.truth)
+      }
+    }
   }
 }
 

--- a/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -24,7 +24,7 @@ import com.slack.circuit.Screen
  */
 public class FakeNavigator : Navigator {
   private val navigatedScreens = Turbine<Screen>()
-  private val resets = Turbine<Screen>()
+  private val newRoots = Turbine<Screen>()
   private val pops = Turbine<Unit>()
 
   override fun goTo(screen: Screen) {
@@ -36,9 +36,9 @@ public class FakeNavigator : Navigator {
     return null
   }
 
-  override fun reset(newRoot: Screen): List<Screen> {
-    resets.add(newRoot)
-    return null
+  override fun newRoot(newRoot: Screen): List<Screen> {
+    newRoots.add(newRoot)
+    return emptyList()
   }
 
   /**
@@ -51,8 +51,8 @@ public class FakeNavigator : Navigator {
   /** Awaits the next [Screen] that was navigated to or throws if no screens were navigated to. */
   public suspend fun awaitNextScreen(): Screen = navigatedScreens.awaitItem()
 
-  /** Awaits the next navigation [reset] or throws if no resets were performed. */
-  public suspend fun awaitReset(): Screen = resets.awaitItem()
+  /** Awaits the next navigation [newRoot] or throws if no resets were performed. */
+  public suspend fun awaitReset(): Screen = newRoots.awaitItem()
 
   /** Awaits the next navigation [pop] event or throws if no pops are performed. */
   public suspend fun awaitPop(): Unit = pops.awaitItem()

--- a/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -36,7 +36,7 @@ public class FakeNavigator : Navigator {
     return null
   }
 
-  override fun newRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: Screen): List<Screen> {
     newRoots.add(newRoot)
     return emptyList()
   }
@@ -51,7 +51,7 @@ public class FakeNavigator : Navigator {
   /** Awaits the next [Screen] that was navigated to or throws if no screens were navigated to. */
   public suspend fun awaitNextScreen(): Screen = navigatedScreens.awaitItem()
 
-  /** Awaits the next navigation [newRoot] or throws if no resets were performed. */
+  /** Awaits the next navigation [resetRoot] or throws if no resets were performed. */
   public suspend fun awaitReset(): Screen = newRoots.awaitItem()
 
   /** Awaits the next navigation [pop] event or throws if no pops are performed. */

--- a/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -36,7 +36,7 @@ public class FakeNavigator : Navigator {
     return null
   }
 
-  override fun reset(newRoot: Screen): Screen? {
+  override fun reset(newRoot: Screen): List<Screen> {
     resets.add(newRoot)
     return null
   }

--- a/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -38,7 +38,18 @@ public class FakeNavigator : Navigator {
 
   override fun resetRoot(newRoot: Screen): List<Screen> {
     newRoots.add(newRoot)
-    return emptyList()
+    val oldScreens = buildList {
+      val channel = navigatedScreens.asChannel()
+      while (true) {
+        val screen = channel.tryReceive().getOrNull() ?: break
+        add(screen)
+      }
+    }
+
+    // Note: to simulate popping off the backstack, screens should be returned in the reverse
+    // order that they were added. As the channel returns them in the order they were added, we
+    // need to reverse here before returning.
+    return oldScreens.reversed()
   }
 
   /**

--- a/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -24,6 +24,7 @@ import com.slack.circuit.Screen
  */
 public class FakeNavigator : Navigator {
   private val navigatedScreens = Turbine<Screen>()
+  private val resets = Turbine<Screen>()
   private val pops = Turbine<Unit>()
 
   override fun goTo(screen: Screen) {
@@ -32,6 +33,11 @@ public class FakeNavigator : Navigator {
 
   override fun pop(): Screen? {
     pops.add(Unit)
+    return null
+  }
+
+  override fun reset(newRoot: Screen): Screen? {
+    resets.add(newRoot)
     return null
   }
 
@@ -44,6 +50,9 @@ public class FakeNavigator : Navigator {
 
   /** Awaits the next [Screen] that was navigated to or throws if no screens were navigated to. */
   public suspend fun awaitNextScreen(): Screen = navigatedScreens.awaitItem()
+
+  /** Awaits the next navigation [reset] or throws if no resets were performed. */
+  public suspend fun awaitReset(): Screen = resets.awaitItem()
 
   /** Awaits the next navigation [pop] event or throws if no pops are performed. */
   public suspend fun awaitPop(): Unit = pops.awaitItem()

--- a/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -63,7 +63,7 @@ public class FakeNavigator : Navigator {
   public suspend fun awaitNextScreen(): Screen = navigatedScreens.awaitItem()
 
   /** Awaits the next navigation [resetRoot] or throws if no resets were performed. */
-  public suspend fun awaitReset(): Screen = newRoots.awaitItem()
+  public suspend fun awaitResetRoot(): Screen = newRoots.awaitItem()
 
   /** Awaits the next navigation [pop] event or throws if no pops are performed. */
   public suspend fun awaitPop(): Unit = pops.awaitItem()

--- a/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
+++ b/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
@@ -1,0 +1,45 @@
+package com.slack.circuit.test
+
+import android.os.Parcel
+import com.google.common.truth.Truth.assertThat
+import com.slack.circuit.Screen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FakeNavigatorTest {
+  @Test
+  fun `resetRoot - ensure resetRoot returns old screens in proper order`() = runTest {
+    val navigator = FakeNavigator()
+    navigator.goTo(TestScreen1)
+    navigator.goTo(TestScreen2)
+
+    val oldScreens = navigator.resetRoot(TestScreen3)
+
+    assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen1))
+    assertThat(navigator.awaitReset()).isEqualTo(TestScreen3)
+  }
+
+  @Test
+  fun resetRoot() = runTest {
+    val navigator = FakeNavigator()
+
+    val oldScreens = navigator.resetRoot(TestScreen1)
+
+    assertThat(oldScreens).isEmpty()
+    assertThat(navigator.awaitReset()).isEqualTo(TestScreen1)
+  }
+}
+
+private object TestScreen1 : Screen {
+  override fun describeContents(): Int {
+    throw NotImplementedError()
+  }
+
+  override fun writeToParcel(dest: Parcel, flags: Int) {
+    throw NotImplementedError()
+  }
+}
+private object TestScreen2 : Screen by TestScreen1
+private object TestScreen3 : Screen by TestScreen2

--- a/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
+++ b/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.test
 
 import android.os.Parcel
@@ -41,5 +43,7 @@ private object TestScreen1 : Screen {
     throw NotImplementedError()
   }
 }
+
 private object TestScreen2 : Screen by TestScreen1
+
 private object TestScreen3 : Screen by TestScreen2

--- a/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
+++ b/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
@@ -18,7 +18,7 @@ class FakeNavigatorTest {
     val oldScreens = navigator.resetRoot(TestScreen3)
 
     assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen1))
-    assertThat(navigator.awaitReset()).isEqualTo(TestScreen3)
+    assertThat(navigator.awaitResetRoot()).isEqualTo(TestScreen3)
   }
 
   @Test
@@ -28,7 +28,7 @@ class FakeNavigatorTest {
     val oldScreens = navigator.resetRoot(TestScreen1)
 
     assertThat(oldScreens).isEmpty()
-    assertThat(navigator.awaitReset()).isEqualTo(TestScreen1)
+    assertThat(navigator.awaitResetRoot()).isEqualTo(TestScreen1)
   }
 }
 

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -55,7 +55,7 @@ internal class NavigatorImpl(
     return backstack.pop()?.screen
   }
 
-  override fun newRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: Screen): List<Screen> {
     return buildList {
       backstack.popUntil { record ->
         add(record.screen)

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -55,7 +55,7 @@ internal class NavigatorImpl(
     return backstack.pop()?.screen
   }
 
-  override fun reset(newRoot: Screen): List<Screen> {
+  override fun newRoot(newRoot: Screen): List<Screen> {
     return buildList {
       backstack.popUntil { record ->
         add(record.screen)

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -56,7 +56,7 @@ internal class NavigatorImpl(
   }
 
   override fun resetRoot(newRoot: Screen): List<Screen> {
-    return buildList {
+    return buildList(backstack.size) {
       backstack.popUntil { record ->
         add(record.screen)
         false

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import com.slack.circuit.backstack.SaveableBackStack
 import com.slack.circuit.backstack.isAtRoot
 import com.slack.circuit.backstack.isEmpty
+import com.slack.circuit.backstack.popUntil
 
 /**
  * Returns a new [Navigator] for navigating within [CircuitContents][CircuitContent].
@@ -54,9 +55,14 @@ internal class NavigatorImpl(
     return backstack.pop()?.screen
   }
 
-  override fun reset(newRoot: Screen): Screen? {
-    while (backstack.size > 1) pop()
-    return backstack.pop()?.screen?.also { backstack.push(newRoot) }
+  override fun reset(newRoot: Screen): List<Screen> {
+    return buildList {
+      backstack.popUntil { record ->
+        add(record.screen)
+        false
+      }
+      backstack.push(newRoot)
+    }
   }
 
   override fun equals(other: Any?): Boolean {

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -54,6 +54,12 @@ internal class NavigatorImpl(
     return backstack.pop()?.screen
   }
 
+  override fun reset(newRoot: Screen): Screen? {
+    while (backstack.size > 1) pop()
+    return backstack.pop()?.screen
+      ?.also { backstack.push(newRoot) }
+  }
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -56,8 +56,7 @@ internal class NavigatorImpl(
 
   override fun reset(newRoot: Screen): Screen? {
     while (backstack.size > 1) pop()
-    return backstack.pop()?.screen
-      ?.also { backstack.push(newRoot) }
+    return backstack.pop()?.screen?.also { backstack.push(newRoot) }
   }
 
   override fun equals(other: Any?): Boolean {

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -56,7 +56,7 @@ class NavigatorTest {
   }
 
   @Test
-  fun newRoot() {
+  fun resetRoot() {
     val backStack = SaveableBackStack()
     backStack.push(TestScreen)
     backStack.push(TestScreen2)
@@ -65,7 +65,7 @@ class NavigatorTest {
 
     assertThat(backStack).hasSize(2)
 
-    val oldScreens = navigator.newRoot(TestScreen3)
+    val oldScreens = navigator.resetRoot(TestScreen3)
 
     assertThat(backStack).hasSize(1)
     assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen3)

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -65,10 +65,11 @@ class NavigatorTest {
 
     assertThat(backStack).hasSize(2)
 
-    val oldRoot = navigator.reset(TestScreen3)
+    val oldScreens = navigator.reset(TestScreen3)
 
     assertThat(backStack).hasSize(1)
     assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen3)
-    assertThat(oldRoot).isEqualTo(TestScreen)
+    assertThat(oldScreens).hasSize(2)
+    assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen))
   }
 }

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -6,10 +6,10 @@ import android.os.Parcel
 import com.google.common.truth.Truth.assertThat
 import com.slack.circuit.backstack.SaveableBackStack
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.fail
 
 private object TestScreen : Screen {
   override fun describeContents(): Int {
@@ -22,6 +22,7 @@ private object TestScreen : Screen {
 }
 
 private object TestScreen2 : Screen by TestScreen
+
 private object TestScreen3 : Screen by TestScreen
 
 @RunWith(RobolectricTestRunner::class)

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -65,9 +65,10 @@ class NavigatorTest {
 
     assertThat(backStack).hasSize(2)
 
-    navigator.reset(TestScreen3)
+    val oldRoot = navigator.reset(TestScreen3)
 
     assertThat(backStack).hasSize(1)
     assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen3)
+    assertThat(oldRoot).isEqualTo(TestScreen)
   }
 }

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -56,7 +56,7 @@ class NavigatorTest {
   }
 
   @Test
-  fun resetAndSetNewRoot() {
+  fun newRoot() {
     val backStack = SaveableBackStack()
     backStack.push(TestScreen)
     backStack.push(TestScreen2)
@@ -65,7 +65,7 @@ class NavigatorTest {
 
     assertThat(backStack).hasSize(2)
 
-    val oldScreens = navigator.reset(TestScreen3)
+    val oldScreens = navigator.newRoot(TestScreen3)
 
     assertThat(backStack).hasSize(1)
     assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen3)

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.fail
 
 private object TestScreen : Screen {
   override fun describeContents(): Int {
@@ -19,6 +20,9 @@ private object TestScreen : Screen {
     throw NotImplementedError()
   }
 }
+
+private object TestScreen2 : Screen by TestScreen
+private object TestScreen3 : Screen by TestScreen
 
 @RunWith(RobolectricTestRunner::class)
 class NavigatorTest {
@@ -48,5 +52,21 @@ class NavigatorTest {
     navigator.pop()
     assertThat(backstack).hasSize(1)
     assertThat(onRootPop).isEqualTo(1)
+  }
+
+  @Test
+  fun resetAndSetNewRoot() {
+    val backStack = SaveableBackStack()
+    backStack.push(TestScreen)
+    backStack.push(TestScreen2)
+
+    val navigator = NavigatorImpl(backStack) { fail() }
+
+    assertThat(backStack).hasSize(2)
+
+    navigator.reset(TestScreen3)
+
+    assertThat(backStack).hasSize(1)
+    assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen3)
   }
 }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -31,8 +31,8 @@ public fun CircuitContent(
           onNavEvent(GoToNavEvent(screen))
         }
 
-        override fun newRoot(newRoot: Screen): List<Screen> {
-          onNavEvent(NewRootNavEvent(newRoot))
+        override fun resetRoot(newRoot: Screen): List<Screen> {
+          onNavEvent(ResetRootNavEvent(newRoot))
           return emptyList()
         }
 

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -31,8 +31,8 @@ public fun CircuitContent(
           onNavEvent(GoToNavEvent(screen))
         }
 
-        override fun reset(newRoot: Screen): List<Screen> {
-          onNavEvent(ResetNavEvent(newRoot))
+        override fun newRoot(newRoot: Screen): List<Screen> {
+          onNavEvent(NewRootNavEvent(newRoot))
           return emptyList()
         }
 

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -31,6 +31,11 @@ public fun CircuitContent(
           onNavEvent(GoToNavEvent(screen))
         }
 
+        override fun reset(newRoot: Screen): Screen? {
+          onNavEvent(ResetNavEvent(newRoot))
+          return null
+        }
+
         override fun pop(): Screen? {
           onNavEvent(PopNavEvent)
           return null

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -31,9 +31,9 @@ public fun CircuitContent(
           onNavEvent(GoToNavEvent(screen))
         }
 
-        override fun reset(newRoot: Screen): Screen? {
+        override fun reset(newRoot: Screen): List<Screen> {
           onNavEvent(ResetNavEvent(newRoot))
-          return null
+          return emptyList()
         }
 
         override fun pop(): Screen? {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -25,15 +25,15 @@ public interface Navigator {
    * navigator.push(LoginScreen2)
    *
    * // Login flow is complete. Wipe backstack and set new root screen
-   * val loginScreens = navigator.newRoot(HomeScreen)
+   * val loginScreens = navigator.resetRoot(HomeScreen)
    * ```
    */
-  public fun newRoot(newRoot: Screen): List<Screen>
+  public fun resetRoot(newRoot: Screen): List<Screen>
 
   public object NoOp : Navigator {
     override fun goTo(screen: Screen) {}
     override fun pop(): Screen? = null
-    override fun newRoot(newRoot: Screen): List<Screen> = emptyList()
+    override fun resetRoot(newRoot: Screen): List<Screen> = emptyList()
   }
 }
 
@@ -44,7 +44,7 @@ public interface Navigator {
 public fun Navigator.onNavEvent(event: NavEvent) {
   when (event) {
     is GoToNavEvent -> goTo(event.screen)
-    is NewRootNavEvent -> newRoot(event.newRoot)
+    is ResetRootNavEvent -> resetRoot(event.newRoot)
     PopNavEvent -> pop()
   }
 }
@@ -56,7 +56,7 @@ internal object PopNavEvent : NavEvent
 
 internal data class GoToNavEvent(internal val screen: Screen) : NavEvent
 
-internal data class NewRootNavEvent(internal val newRoot: Screen) : NavEvent
+internal data class ResetRootNavEvent(internal val newRoot: Screen) : NavEvent
 
 /** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
 public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -11,7 +11,23 @@ public interface Navigator {
 
   public fun pop(): Screen?
 
-  /** Clear the existing backstack of [Screens][Screen] and navigate to [newRoot]. */
+  /**
+   * Clear the existing backstack of [screens][Screen] and navigate to [newRoot].
+   *
+   * This is useful in preventing the user from returning to a completed workflow, such as a
+   * tutorial, wizard, or authentication flow.
+   *
+   * Example
+   *
+   * ```kotlin
+   * val navigator = Navigator()
+   * navigator.push(LoginScreen1)
+   * navigator.push(LoginScreen2)
+   *
+   * // Login flow is complete. Wipe backstack and set new root screen
+   * val loginScreens = navigator.newRoot(HomeScreen)
+   * ```
+   */
   public fun newRoot(newRoot: Screen): List<Screen>
 
   public object NoOp : Navigator {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -12,12 +12,12 @@ public interface Navigator {
   public fun pop(): Screen?
 
   /** Clear the existing backstack of [Screens][Screen] and navigate to [newRoot]. */
-  public fun reset(newRoot: Screen): List<Screen>
+  public fun newRoot(newRoot: Screen): List<Screen>
 
   public object NoOp : Navigator {
     override fun goTo(screen: Screen) {}
     override fun pop(): Screen? = null
-    override fun reset(newRoot: Screen): List<Screen> = emptyList()
+    override fun newRoot(newRoot: Screen): List<Screen> = emptyList()
   }
 }
 
@@ -28,7 +28,7 @@ public interface Navigator {
 public fun Navigator.onNavEvent(event: NavEvent) {
   when (event) {
     is GoToNavEvent -> goTo(event.screen)
-    is ResetNavEvent -> reset(event.newRoot)
+    is NewRootNavEvent -> newRoot(event.newRoot)
     PopNavEvent -> pop()
   }
 }
@@ -40,7 +40,7 @@ internal object PopNavEvent : NavEvent
 
 internal data class GoToNavEvent(internal val screen: Screen) : NavEvent
 
-internal data class ResetNavEvent(internal val newRoot: Screen) : NavEvent
+internal data class NewRootNavEvent(internal val newRoot: Screen) : NavEvent
 
 /** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
 public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -17,6 +17,7 @@ public interface Navigator {
   public object NoOp : Navigator {
     override fun goTo(screen: Screen) {}
     override fun pop(): Screen? = null
+    override fun reset(newRoot: Screen): Screen? = null
   }
 }
 

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -28,6 +28,7 @@ public interface Navigator {
 public fun Navigator.onNavEvent(event: NavEvent) {
   when (event) {
     is GoToNavEvent -> goTo(event.screen)
+    is ResetNavEvent -> reset(event.newRoot)
     PopNavEvent -> pop()
   }
 }
@@ -38,6 +39,8 @@ public sealed interface NavEvent : CircuitUiEvent
 internal object PopNavEvent : NavEvent
 
 internal data class GoToNavEvent(internal val screen: Screen) : NavEvent
+
+internal data class ResetNavEvent(internal val newRoot: Screen) : NavEvent
 
 /** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
 public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -11,6 +11,9 @@ public interface Navigator {
 
   public fun pop(): Screen?
 
+  /** Clear the existing backstack of [Screens][Screen] and navigate to [newRoot]. */
+  public fun reset(newRoot: Screen): Screen?
+
   public object NoOp : Navigator {
     override fun goTo(screen: Screen) {}
     override fun pop(): Screen? = null

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -12,12 +12,12 @@ public interface Navigator {
   public fun pop(): Screen?
 
   /** Clear the existing backstack of [Screens][Screen] and navigate to [newRoot]. */
-  public fun reset(newRoot: Screen): Screen?
+  public fun reset(newRoot: Screen): List<Screen>
 
   public object NoOp : Navigator {
     override fun goTo(screen: Screen) {}
     override fun pop(): Screen? = null
-    override fun reset(newRoot: Screen): Screen? = null
+    override fun reset(newRoot: Screen): List<Screen> = emptyList()
   }
 }
 


### PR DESCRIPTION
Added method to `Navigator` allowing the caller to clear the backstack and set a new root screen. This addresses #334.

```Kotlin
navigator.goTo(screen1)   // [screen1]
navigator.goTo(screen2)   // [screen1, screen2]
...
val oldRoot = navigator.reset(screen3) // [screen3], oldRoot == screen1
```