### PR TITLE
Minor cleanup around use of CircuitContext 

### DIFF
--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -67,7 +67,7 @@ internal fun CircuitContent(
     remember(screen, context) {
       circuitConfig.eventListenerFactory?.create(screen, context) ?: EventListener.NONE
     }
-  DisposableEffect(screen) { onDispose { eventListener.dispose() } }
+  DisposableEffect(screen, context) { onDispose { eventListener.dispose() } }
 
   eventListener.onBeforeCreatePresenter(screen, navigator, context)
   @Suppress("UNCHECKED_CAST")

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -71,11 +71,11 @@ internal fun CircuitContent(
 
   eventListener.onBeforeCreatePresenter(screen, navigator, context)
   @Suppress("UNCHECKED_CAST")
-  val presenter = circuitConfig.presenter(screen, navigator) as Presenter<CircuitUiState>?
+  val presenter = circuitConfig.presenter(screen, navigator, context) as Presenter<CircuitUiState>?
   eventListener.onAfterCreatePresenter(screen, navigator, presenter, context)
 
   eventListener.onBeforeCreateUi(screen, context)
-  val screenUi = circuitConfig.ui(screen)
+  val screenUi = circuitConfig.ui(screen, context)
   eventListener.onAfterCreateUi(screen, screenUi, context)
 
   if (screenUi != null && presenter != null) {


### PR DESCRIPTION
Minor changes that fell out of #338:

1. use `CircuitContext` as `DisposableEffect` key to match `remember` keys
2. pass `CircuitContext` when creating presenter and ui