### PR TITLE
Mark Screen as `@Immutable`

### DIFF
--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
@@ -3,5 +3,7 @@
 package com.slack.circuit
 
 import android.os.Parcelable
+import androidx.compose.runtime.Immutable
 
+@Immutable
 public actual interface Screen : Parcelable

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
@@ -5,5 +5,4 @@ package com.slack.circuit
 import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 
-@Immutable
-public actual interface Screen : Parcelable
+@Immutable public actual interface Screen : Parcelable

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit
 
+import androidx.compose.runtime.Immutable
+
 /**
  * Represents an individual screen, used as a key for [Presenter.Factory] and [Ui.Factory].
  *
@@ -27,4 +29,5 @@ package com.slack.circuit
  * }
  * ```
  */
+@Immutable
 public expect interface Screen

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
@@ -29,5 +29,4 @@ import androidx.compose.runtime.Immutable
  * }
  * ```
  */
-@Immutable
-public expect interface Screen
+@Immutable public expect interface Screen

--- a/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
+++ b/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
@@ -4,5 +4,4 @@ package com.slack.circuit
 
 import androidx.compose.runtime.Immutable
 
-@Immutable
-public actual interface Screen
+@Immutable public actual interface Screen

--- a/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
+++ b/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
@@ -2,4 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 public actual interface Screen


### PR DESCRIPTION
I thought these were already but was surprised to find they're not! This ends up making Composable functions using Screen inputs unstable

<img width="603" alt="image" src="https://user-images.githubusercontent.com/1361086/208318791-49287d68-126a-44b3-96eb-ac057eb05228.png">
