### PR TITLE
Don't require manual wiring for backing viewmodels

### DIFF
--- a/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/android-tests/src/androidTest/kotlin/com/circuit/retained/android/RetainedTest.kt
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
 package com.circuit.retained.android
 
 import androidx.activity.ComponentActivity

--- a/samples/counter/android/src/main/kotlin/com/slack/circuit/sample/counter/android/CounterActivity.kt
+++ b/samples/counter/android/src/main/kotlin/com/slack/circuit/sample/counter/android/CounterActivity.kt
@@ -10,31 +10,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.slack.circuit.CircuitCompositionLocals
 import com.slack.circuit.CircuitConfig
 import com.slack.circuit.CircuitContent
-import com.slack.circuit.backstack.BackStackRecordLocalProviderViewModel
-import com.slack.circuit.retained.Continuity
 import com.slack.circuit.sample.counter.CounterPresenterFactory
 
 class CounterActivity : AppCompatActivity() {
 
-  private val viewModelProviderFactory: ViewModelProvider.Factory =
-    object : ViewModelProvider.Factory {
-      override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        @Suppress("UNCHECKED_CAST")
-        return when (modelClass) {
-          Continuity::class.java -> Continuity()
-          BackStackRecordLocalProviderViewModel::class.java ->
-            BackStackRecordLocalProviderViewModel()
-          else -> throw IllegalArgumentException("Unknown ViewModel class: $modelClass")
-        }
-          as T
-      }
-    }
   private val circuitConfig: CircuitConfig =
     CircuitConfig.Builder()
       .addPresenterFactory(CounterPresenterFactory())
@@ -57,9 +40,5 @@ class CounterActivity : AppCompatActivity() {
         CircuitCompositionLocals(circuitConfig) { CircuitContent(AndroidCounterScreen) }
       }
     }
-  }
-
-  override fun getDefaultViewModelProviderFactory(): ViewModelProvider.Factory {
-    return viewModelProviderFactory
   }
 }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/di/CircuitModule.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/di/CircuitModule.kt
@@ -2,17 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.star.di
 
-import androidx.lifecycle.ViewModel
 import com.slack.circuit.CircuitConfig
 import com.slack.circuit.Presenter
 import com.slack.circuit.Ui
-import com.slack.circuit.backstack.BackStackRecordLocalProviderViewModel
-import com.slack.circuit.retained.Continuity
 import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import dagger.multibindings.IntoMap
 import dagger.multibindings.Multibinds
 
 @ContributesTo(AppScope::class)
@@ -22,24 +17,7 @@ interface CircuitModule {
 
   @Multibinds fun viewFactories(): Set<Ui.Factory>
 
-  @ViewModelKey(BackStackRecordLocalProviderViewModel::class)
-  @IntoMap
-  @Binds
-  fun BackStackRecordLocalProviderViewModel.bindBackStackRecordLocalProviderViewModel(): ViewModel
-
-  @ViewModelKey(Continuity::class) @IntoMap @Binds fun Continuity.bindContinuity(): ViewModel
-
   companion object {
-    @Provides
-    fun provideBackStackRecordLocalProviderViewModel(): BackStackRecordLocalProviderViewModel {
-      return BackStackRecordLocalProviderViewModel()
-    }
-
-    @Provides
-    fun provideContinuity(): Continuity {
-      return Continuity()
-    }
-
     @Provides
     fun provideCircuit(
       presenterFactories: @JvmSuppressWildcards Set<Presenter.Factory>,


### PR DESCRIPTION
We can bring our own factories by default and spare folks from having to wire all these themselves. This also makes `Continuity` and `BackStackRecordLocalProviderViewModel` internal now, as we sort of always intended.

Left the factory param for continuity in case anyone wants full control over the created retained registry or to bring their own impl.