### PR TITLE
Fix CircuitContext.putTag generics

### DIFF
--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContext.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContext.kt
@@ -39,7 +39,7 @@ internal constructor(
    * Use this API to attach metadata, debugging, or other application data to a spec so that you may
    * read it in other APIs or callbacks.
    */
-  public inline fun <reified T : Any> putTag(tag: Any?): Unit = putTag(T::class, tag)
+  public inline fun <reified T : Any> putTag(tag: T?): Unit = putTag(T::class, tag)
 
   /**
    * Attaches [tag] to the request using [type] as a key. Tags can be read from a request using
@@ -48,7 +48,7 @@ internal constructor(
    * Use this API to attach metadata, debugging, or other application data to a spec so that you may
    * read it in other APIs or callbacks.
    */
-  public fun putTag(type: KClass<*>, tag: Any?): Unit {
+  public fun <S : Any, T : S> putTag(type: KClass<S>, tag: T?): Unit {
     if (tag == null) {
       this.tags.remove(type)
     } else {


### PR DESCRIPTION
Updated generics and method signature to ensure that `tag` can be cast to `type` KClass

### Details
We don't currently ensure that the key and value used to set a tag on `CircuitContext` are of the same type, or that the value can be cast to the key type. This lead so some unexpected behaviour.

#### Before
```kotlin
// does not work - must specify the generic type because T (type) != Any (tag)
context.putTag("foo")

// this is just wrong
context.putTag<String>(10)
context.putTag(String::class, 10)
```

#### After
```kotlin
// works
context.putTag("foo")
context.putTag<CharSequence>("foo")
context.putTag<Int>(42)

context.putTag(CharSequence::class, "foo")
context.putTag(Number::class, 10)
context.putTag(Int::class, 10)

// does not work
context.putTag<CharSequence>(42)
context.putTag(CharSequence::class, 10)
```
