### PR TITLE
Added NavigableScreen interface

### DIFF
--- a/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/main/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -3,8 +3,8 @@
 package com.slack.circuit.test
 
 import app.cash.turbine.Turbine
+import com.slack.circuit.NavigableScreen
 import com.slack.circuit.Navigator
-import com.slack.circuit.Screen
 
 /**
  * A fake [Navigator] that can be used in tests to record and assert navigation events.
@@ -24,20 +24,20 @@ import com.slack.circuit.Screen
  * ```
  */
 public class FakeNavigator : Navigator {
-  private val navigatedScreens = Turbine<Screen>()
-  private val newRoots = Turbine<Screen>()
+  private val navigatedScreens = Turbine<NavigableScreen>()
+  private val newRoots = Turbine<NavigableScreen>()
   private val pops = Turbine<Unit>()
 
-  override fun goTo(screen: Screen) {
+  override fun goTo(screen: NavigableScreen) {
     navigatedScreens.add(screen)
   }
 
-  override fun pop(): Screen? {
+  override fun pop(): NavigableScreen? {
     pops.add(Unit)
     return null
   }
 
-  override fun resetRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: NavigableScreen): List<NavigableScreen> {
     newRoots.add(newRoot)
     val oldScreens = buildList {
       val channel = navigatedScreens.asChannel()
@@ -58,13 +58,13 @@ public class FakeNavigator : Navigator {
    *
    * For non-coroutines users only.
    */
-  public fun takeNextScreen(): Screen = navigatedScreens.takeItem()
+  public fun takeNextScreen(): NavigableScreen = navigatedScreens.takeItem()
 
   /** Awaits the next [Screen] that was navigated to or throws if no screens were navigated to. */
-  public suspend fun awaitNextScreen(): Screen = navigatedScreens.awaitItem()
+  public suspend fun awaitNextScreen(): NavigableScreen = navigatedScreens.awaitItem()
 
   /** Awaits the next navigation [resetRoot] or throws if no resets were performed. */
-  public suspend fun awaitResetRoot(): Screen = newRoots.awaitItem()
+  public suspend fun awaitResetRoot(): NavigableScreen = newRoots.awaitItem()
 
   /** Awaits the next navigation [pop] event or throws if no pops are performed. */
   public suspend fun awaitPop(): Unit = pops.awaitItem()

--- a/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
+++ b/circuit-test/src/test/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
@@ -4,7 +4,7 @@ package com.slack.circuit.test
 
 import android.os.Parcel
 import com.google.common.truth.Truth.assertThat
-import com.slack.circuit.Screen
+import com.slack.circuit.NavigableScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -34,7 +34,10 @@ class FakeNavigatorTest {
   }
 }
 
-private object TestScreen1 : Screen {
+private object TestScreen1 : NavigableScreen {
+  override val route: String
+    get() = "test1"
+
   override fun describeContents(): Int {
     throw NotImplementedError()
   }
@@ -44,6 +47,12 @@ private object TestScreen1 : Screen {
   }
 }
 
-private object TestScreen2 : Screen by TestScreen1
+private object TestScreen2 : NavigableScreen by TestScreen1 {
+  override val route: String
+    get() = "test2"
+}
 
-private object TestScreen3 : Screen by TestScreen2
+private object TestScreen3 : NavigableScreen by TestScreen1 {
+  override val route: String
+    get() = "test3"
+}

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Navigator.android.kt
@@ -43,9 +43,9 @@ internal class NavigatorImpl(
     check(!backstack.isEmpty) { "Backstack size must not be empty." }
   }
 
-  override fun goTo(screen: Screen) = backstack.push(screen)
+  override fun goTo(screen: NavigableScreen) = backstack.push(screen)
 
-  override fun pop(): Screen? {
+  override fun pop(): NavigableScreen? {
     if (backstack.isAtRoot) {
       onRootPop()
       return null
@@ -54,7 +54,7 @@ internal class NavigatorImpl(
     return backstack.pop()?.screen
   }
 
-  override fun resetRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: NavigableScreen): List<NavigableScreen> {
     return buildList(backstack.size) {
       backstack.popUntil { record ->
         add(record.screen)

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
@@ -7,7 +7,7 @@ import com.slack.circuit.backstack.SaveableBackStack
 public fun SaveableBackStack.push(screen: Screen) {
   push(
     SaveableBackStack.Record(
-      route = (screen as? RoutableScreen)?.route ?: "",
+      route = (screen as? NavigableScreen)?.route ?: "",
       args = mapOf("screen" to screen),
       key = screen.hashCode().toString()
     )

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
@@ -4,15 +4,15 @@ package com.slack.circuit
 
 import com.slack.circuit.backstack.SaveableBackStack
 
-public fun SaveableBackStack.push(screen: Screen) {
+public fun SaveableBackStack.push(screen: NavigableScreen) {
   push(
     SaveableBackStack.Record(
-      route = (screen as? NavigableScreen)?.route ?: "",
+      route = screen.route,
       args = mapOf("screen" to screen),
       key = screen.hashCode().toString()
     )
   )
 }
 
-public val SaveableBackStack.Record.screen: Screen
-  get() = args.getValue("screen") as Screen
+public val SaveableBackStack.Record.screen: NavigableScreen
+  get() = args.getValue("screen") as NavigableScreen

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/SaveableBackstack+Screen.kt
@@ -7,7 +7,7 @@ import com.slack.circuit.backstack.SaveableBackStack
 public fun SaveableBackStack.push(screen: Screen) {
   push(
     SaveableBackStack.Record(
-      route = screen.javaClass.simpleName,
+      route = (screen as? RoutableScreen)?.route ?: "",
       args = mapOf("screen" to screen),
       key = screen.hashCode().toString()
     )

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
@@ -6,3 +6,8 @@ import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen : Parcelable
+
+@Immutable
+public actual interface RoutableScreen : Screen {
+  public actual val route: String
+}

--- a/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/Screen.android.kt
@@ -8,6 +8,6 @@ import androidx.compose.runtime.Immutable
 @Immutable public actual interface Screen : Parcelable
 
 @Immutable
-public actual interface RoutableScreen : Screen {
+public actual interface NavigableScreen : Screen {
   public actual val route: String
 }

--- a/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
+++ b/circuit/src/androidTest/kotlin/com/slack/circuit/NavigatorTest.kt
@@ -11,7 +11,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-private object TestScreen : Screen {
+private object TestScreen1 : NavigableScreen {
+  override val route: String
+    get() = "test1"
+
   override fun describeContents(): Int {
     throw NotImplementedError()
   }
@@ -21,9 +24,15 @@ private object TestScreen : Screen {
   }
 }
 
-private object TestScreen2 : Screen by TestScreen
+private object TestScreen2 : NavigableScreen by TestScreen1 {
+  override val route: String
+    get() = "test2"
+}
 
-private object TestScreen3 : Screen by TestScreen
+private object TestScreen3 : NavigableScreen by TestScreen1 {
+  override val route: String
+    get() = "test2"
+}
 
 @RunWith(RobolectricTestRunner::class)
 class NavigatorTest {
@@ -37,8 +46,8 @@ class NavigatorTest {
   @Test
   fun popAtRoot() {
     val backstack = SaveableBackStack()
-    backstack.push(TestScreen)
-    backstack.push(TestScreen)
+    backstack.push(TestScreen1)
+    backstack.push(TestScreen1)
 
     var onRootPop = 0
     val navigator = NavigatorImpl(backstack) { onRootPop++ }
@@ -58,7 +67,7 @@ class NavigatorTest {
   @Test
   fun resetRoot() {
     val backStack = SaveableBackStack()
-    backStack.push(TestScreen)
+    backStack.push(TestScreen1)
     backStack.push(TestScreen2)
 
     val navigator = NavigatorImpl(backStack) { fail() }
@@ -70,6 +79,6 @@ class NavigatorTest {
     assertThat(backStack).hasSize(1)
     assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen3)
     assertThat(oldScreens).hasSize(2)
-    assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen))
+    assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen1))
   }
 }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/CircuitContent.kt
@@ -27,16 +27,16 @@ public fun CircuitContent(
   val navigator =
     remember(onNavEvent) {
       object : Navigator {
-        override fun goTo(screen: Screen) {
+        override fun goTo(screen: NavigableScreen) {
           onNavEvent(GoToNavEvent(screen))
         }
 
-        override fun resetRoot(newRoot: Screen): List<Screen> {
+        override fun resetRoot(newRoot: NavigableScreen): List<NavigableScreen> {
           onNavEvent(ResetRootNavEvent(newRoot))
           return emptyList()
         }
 
-        override fun pop(): Screen? {
+        override fun pop(): NavigableScreen? {
           onNavEvent(PopNavEvent)
           return null
         }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -4,15 +4,15 @@ package com.slack.circuit
 
 import androidx.compose.runtime.Stable
 
-/** A basic navigation interface for navigating between [screens][Screen]. */
+/** A basic navigation interface for navigating between [screens][NavigableScreen]. */
 @Stable
 public interface Navigator {
-  public fun goTo(screen: Screen)
+  public fun goTo(screen: NavigableScreen)
 
-  public fun pop(): Screen?
+  public fun pop(): NavigableScreen?
 
   /**
-   * Clear the existing backstack of [screens][Screen] and navigate to [newRoot].
+   * Clear the existing backstack of [screens][NavigableScreen] and navigate to [newRoot].
    *
    * This is useful in preventing the user from returning to a completed workflow, such as a
    * tutorial, wizard, or authentication flow.
@@ -28,12 +28,12 @@ public interface Navigator {
    * val loginScreens = navigator.resetRoot(HomeScreen)
    * ```
    */
-  public fun resetRoot(newRoot: Screen): List<Screen>
+  public fun resetRoot(newRoot: NavigableScreen): List<Screen>
 
   public object NoOp : Navigator {
-    override fun goTo(screen: Screen) {}
-    override fun pop(): Screen? = null
-    override fun resetRoot(newRoot: Screen): List<Screen> = emptyList()
+    override fun goTo(screen: NavigableScreen) {}
+    override fun pop(): NavigableScreen? = null
+    override fun resetRoot(newRoot: NavigableScreen): List<NavigableScreen> = emptyList()
   }
 }
 
@@ -54,12 +54,12 @@ public sealed interface NavEvent : CircuitUiEvent
 
 internal object PopNavEvent : NavEvent
 
-internal data class GoToNavEvent(internal val screen: Screen) : NavEvent
+internal data class GoToNavEvent(internal val screen: NavigableScreen) : NavEvent
 
-internal data class ResetRootNavEvent(internal val newRoot: Screen) : NavEvent
+internal data class ResetRootNavEvent(internal val newRoot: NavigableScreen) : NavEvent
 
 /** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
-public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
+public fun Navigator.popUntil(predicate: (NavigableScreen) -> Boolean) {
   while (true) {
     val screen = pop() ?: break
     if (predicate(screen)) {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
@@ -3,6 +3,7 @@
 package com.slack.circuit
 
 import androidx.compose.runtime.Immutable
+import com.slack.circuit.backstack.SaveableBackStack
 
 /**
  * Represents an individual screen, used as a key for [Presenter.Factory] and [Ui.Factory].
@@ -34,10 +35,14 @@ import androidx.compose.runtime.Immutable
 /**
  * Represents an individual screen with additional routing information.
  *
- * [Routing][route] can be useful when constructing rich navigation and/or routing DSLs (ex. Deep
+ * Instances of this interface are required when using [Navigator] with a [SaveableBackStack].
+ *
+ * [Routing][route] can be useful when constructing rich navigation and/or routing DSLs (eg. Deep
  * linking).
  *
  * @see Screen
+ * @see Navigator
+ * @see SaveableBackStack
  */
 @Immutable
 public expect interface NavigableScreen : Screen {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Immutable
  *
  * @see Screen
  */
-@Immutable public expect interface RoutableScreen : Screen {
+@Immutable
+public expect interface NavigableScreen : Screen {
   public val route: String
 }

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Screen.kt
@@ -30,3 +30,15 @@ import androidx.compose.runtime.Immutable
  * ```
  */
 @Immutable public expect interface Screen
+
+/**
+ * Represents an individual screen with additional routing information.
+ *
+ * [Routing][route] can be useful when constructing rich navigation and/or routing DSLs (ex. Deep
+ * linking).
+ *
+ * @see Screen
+ */
+@Immutable public expect interface RoutableScreen : Screen {
+  public val route: String
+}

--- a/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
+++ b/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
@@ -5,3 +5,8 @@ package com.slack.circuit
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
+
+@Immutable
+public actual interface RoutableScreen : Screen {
+  public actual val route: String
+}

--- a/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
+++ b/circuit/src/jvmMain/kotlin/com/slack/circuit/Screen.jvm.kt
@@ -7,6 +7,6 @@ import androidx.compose.runtime.Immutable
 @Immutable public actual interface Screen
 
 @Immutable
-public actual interface RoutableScreen : Screen {
+public actual interface NavigableScreen : Screen {
   public actual val route: String
 }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -18,7 +18,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.slack.circuit.CircuitCompositionLocals
 import com.slack.circuit.CircuitConfig
 import com.slack.circuit.NavigableCircuitContent
-import com.slack.circuit.Screen
+import com.slack.circuit.NavigableScreen
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.push
@@ -47,7 +47,7 @@ constructor(
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    var backStack: ImmutableList<Screen> = persistentListOf(HomeScreen)
+    var backStack: ImmutableList<NavigableScreen> = persistentListOf(HomeScreen)
     if (intent.data != null) {
       val httpUrl = intent.data.toString().toHttpUrl()
       val animalId = httpUrl.pathSegments[1].substringAfterLast("-").toLong()

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/home/AboutScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/home/AboutScreen.kt
@@ -21,14 +21,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.CircuitUiState
-import com.slack.circuit.Screen
+import com.slack.circuit.NavigableScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.star.R
 import com.slack.circuit.star.di.AppScope
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-object AboutScreen : Screen {
+object AboutScreen : NavigableScreen {
+  override val route: String
+    get() = "about"
+
   object State : CircuitUiState
 }
 

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/home/HomeScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/home/HomeScreen.kt
@@ -20,8 +20,8 @@ import com.slack.circuit.CircuitContent
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
 import com.slack.circuit.NavEvent
+import com.slack.circuit.NavigableScreen
 import com.slack.circuit.Navigator
-import com.slack.circuit.Screen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.onNavEvent
 import com.slack.circuit.star.di.AppScope
@@ -31,7 +31,10 @@ import com.slack.circuit.star.ui.StarTheme
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-object HomeScreen : Screen {
+object HomeScreen : NavigableScreen {
+  override val route: String
+    get() = "home"
+
   data class State(
     val homeNavState: HomeNavScreen.State,
     val eventSink: (Event) -> Unit,

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/navigator/AndroidSupportingNavigator.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/navigator/AndroidSupportingNavigator.kt
@@ -3,8 +3,8 @@
 package com.slack.circuit.star.navigator
 
 import android.content.Intent
+import com.slack.circuit.NavigableScreen
 import com.slack.circuit.Navigator
-import com.slack.circuit.Screen
 import kotlinx.parcelize.Parcelize
 
 /** Custom navigator that adds support for initiating navigation in standard Android. */
@@ -12,14 +12,17 @@ class AndroidSupportingNavigator(
   private val navigator: Navigator,
   private val onAndroidScreen: (AndroidScreen) -> Unit
 ) : Navigator by navigator {
-  override fun goTo(screen: Screen) =
+  override fun goTo(screen: NavigableScreen) =
     when (screen) {
       is AndroidScreen -> onAndroidScreen(screen)
       else -> navigator.goTo(screen)
     }
 }
 
-sealed interface AndroidScreen : Screen {
+sealed interface AndroidScreen : NavigableScreen {
+  override val route: String
+    get() = "AndroidScreen"
+
   @Parcelize data class CustomTabsIntentScreen(val url: String) : AndroidScreen
   @Parcelize data class IntentScreen(val intent: Intent) : AndroidScreen
 }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
@@ -42,9 +42,9 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.slack.circuit.CircuitContent
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
+import com.slack.circuit.NavigableScreen
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
-import com.slack.circuit.Screen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.star.R
 import com.slack.circuit.star.common.BackPressNavIcon
@@ -65,7 +65,10 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class PetDetailScreen(val petId: Long, val photoUrlMemoryCacheKey: String?) : Screen {
+data class PetDetailScreen(val petId: Long, val photoUrlMemoryCacheKey: String?) : NavigableScreen {
+  override val route: String
+    get() = "pet-detail"
+
   sealed interface State : CircuitUiState {
     object Loading : State
 

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -66,9 +66,9 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.slack.circuit.CircuitUiEvent
 import com.slack.circuit.CircuitUiState
+import com.slack.circuit.NavigableScreen
 import com.slack.circuit.Navigator
 import com.slack.circuit.Presenter
-import com.slack.circuit.Screen
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.overlay.LocalOverlayHost
 import com.slack.circuit.overlay.OverlayHost
@@ -117,7 +117,10 @@ enum class Size {
 data class Filters(val gender: Gender = Gender.ALL, val size: Size = Size.ALL) : Parcelable
 
 @Parcelize
-object PetListScreen : Screen {
+object PetListScreen : NavigableScreen {
+  override val route: String
+    get() = "pet-list"
+
   sealed interface State : CircuitUiState {
     val isRefreshing: Boolean
 


### PR DESCRIPTION
Introduce new `NavigableScreen` interface for use when constructing more complex navigation and routing solutions.

This PR updates `Navigator` and `SaveableBackStack.push` to require `NavigableScreen`. `Screen` can still be used when calling `CircuitContent` directly.
