### PR TITLE
Collapse NavigableCircuitContent functions

### DIFF
--- a/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.android.kt
+++ b/circuit/src/androidMain/kotlin/com/slack/circuit/NavigableCircuitContent.android.kt
@@ -25,7 +25,7 @@ public fun NavigableCircuitContent(
 ) {
   BackHandler(enabled = enableBackHandler && backstack.size > 1, onBack = navigator::pop)
 
-  BasicNavigableCircuitContent(
+  NavigableCircuitContent(
     navigator = navigator,
     backstack = backstack,
     providedValues = providedValues,

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/NavigableCircuitContent.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/NavigableCircuitContent.kt
@@ -25,15 +25,16 @@ import com.slack.circuit.backstack.BackStack
 import com.slack.circuit.backstack.NavDecoration
 import com.slack.circuit.backstack.ProvidedValues
 import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.backstack.providedValuesForBackStack
 
 @Composable
-public fun BasicNavigableCircuitContent(
+public fun NavigableCircuitContent(
   navigator: Navigator,
   backstack: SaveableBackStack,
-  providedValues: Map<out BackStack.Record, ProvidedValues>,
   modifier: Modifier = Modifier,
   circuitConfig: CircuitConfig = requireNotNull(LocalCircuitConfig.current),
-  decoration: NavDecoration = NavigatorDefaults.EmptyDecoration,
+  providedValues: Map<out BackStack.Record, ProvidedValues> = providedValuesForBackStack(backstack),
+  decoration: NavDecoration = NavigatorDefaults.DefaultDecoration,
   unavailableRoute: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
     circuitConfig.onUnavailableContent,
 ) {

--- a/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/Navigator.kt
@@ -80,7 +80,7 @@ public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
  * @param backstack The backing [SaveableBackStack] to navigate.
  * @param onRootPop Invoked when the backstack is at root (size 1) and the user presses the back
  *   button.
- * @see BasicNavigableCircuitContent
+ * @see NavigableCircuitContent
  */
 @Composable
 public fun rememberCircuitNavigator(

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,7 +46,7 @@ Circuit is a multiplatform library, but not all features are available on all pl
 | `Backstack`               | ✅ | ✅ | |
 | `CircuitContent`          | ✅ | ✅ | |
 | `ContentWithOverlays` | ✅ | ✅ | |
-| `NavigableCircuitContent` | ✅ | ✅ | `BasicNavigableCircuitContent` is multiplatform. |
+| `NavigableCircuitContent` | ✅ | ✅ | |
 | `Navigator`               | ✅ | ✅ | |
 | `SaveableBackstack`       | ✅ | ✅ | Saveable is a no-op on desktop. |
 | `rememberCircuitNavigator` | ✅ | ✅ | |


### PR DESCRIPTION
Now that the features are available in common code, `BasicNavigableCircuitContent` doesn't serve much purpose besides alternative defaults, which can by their very nature be changed.