### PR TITLE
Make events immutable again

### DIFF
--- a/circuit/src/commonMain/kotlin/com/slack/circuit/markers.kt
+++ b/circuit/src/commonMain/kotlin/com/slack/circuit/markers.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 
 /**
@@ -25,6 +26,7 @@ import androidx.compose.runtime.Stable
  * Events in Circuit should generally reflect user interactions with the UI. They are mediated by
  * [presenters][Presenter] and may or may not influence the current [state][CircuitUiState].
  *
- * **Circuit event types are annotated as [@Stable][Stable] and should only use stable properties.**
+ * **Circuit event types are annotated as [@Immutable][Immutable] and should only use immutable
+ * properties.**
  */
-@Stable public interface CircuitUiEvent
+@Immutable public interface CircuitUiEvent


### PR DESCRIPTION
Slight oversight from before, these _should_ be immutable as they're events the presenter should be reacting to and not treat as live data. We can revisit in the future if a good use case comes up, but feels like we should keep this in the box for now.