### PR TITLE
Add StableCoroutineScope

### DIFF
--- a/samples/star/src/main/kotlin/com/slack/circuit/star/overlay/BottomSheetOverlay.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/overlay/BottomSheetOverlay.kt
@@ -11,11 +11,11 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.overlay.Overlay
 import com.slack.circuit.overlay.OverlayNavigator
+import com.slack.circuit.star.ui.rememberStableCoroutineScope
 import kotlinx.coroutines.launch
 
 class BottomSheetOverlay<Model : Any, Result : Any>(
@@ -51,7 +51,7 @@ class BottomSheetOverlay<Model : Any, Result : Any>(
         Box(Modifier.padding(32.dp)) {
           @Suppress("MagicNumber") Box(Modifier.fillMaxSize(0.51f))
           // Delay setting the result until we've finished dismissing
-          val coroutineScope = rememberCoroutineScope()
+          val coroutineScope = rememberStableCoroutineScope()
           content(model) { result ->
             // This is the OverlayNavigator.finish() callback
             coroutineScope.launch {

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetPhotoCarousel.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetPhotoCarousel.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -45,6 +44,7 @@ import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.star.common.ImmutableListParceler
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.petdetail.PetPhotoCarouselTestConstants.CAROUSEL_TAG
+import com.slack.circuit.star.ui.rememberStableCoroutineScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -125,7 +125,7 @@ internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen.State, modifier: Mod
 
   val totalPhotos = photoUrls.size
   val pagerState = rememberPagerState()
-  val scope = rememberCoroutineScope()
+  val scope = rememberStableCoroutineScope()
   val requester = remember { FocusRequester() }
   @Suppress("MagicNumber")
   val columnModifier = if (isLandscape) modifier.fillMaxWidth(0.5f) else modifier.fillMaxSize()

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/ui/StableCoroutineScope.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/ui/StableCoroutineScope.kt
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Returns a [StableCoroutineScope] around a [rememberCoroutineScope]. This is useful for event
+ * callback lambdas that capture a local scope variable to launch new coroutines, as it allows them
+ * to be stable.
+ */
+@Composable
+fun rememberStableCoroutineScope(): StableCoroutineScope {
+  val scope = rememberCoroutineScope()
+  return remember { StableCoroutineScope(scope) }
+}
+
+/** @see rememberStableCoroutineScope */
+@Stable class StableCoroutineScope(scope: CoroutineScope) : CoroutineScope by scope


### PR DESCRIPTION
`CoroutineScope` is not actually considered implicitly stable by the compose-compiler, so the result is that event lambdas that capture them end up being unstable in the eyes of compose at runtime.