### PR TITLE
Updated processor to generate classes with uppercase first letter

### DIFF
--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -141,12 +141,11 @@ private class CircuitSymbolProcessor(
       computeFactoryData(annotatedElement, symbols, screenKSType, instantiationType, logger)
         ?: return
 
-    val className = factoryData.className.replaceFirstChar { char ->
-      char
-        .takeIf { char.isLowerCase() }
-        ?.run { uppercase(Locale.getDefault()) }
-        ?: char.toString()
-    }
+    val className =
+      factoryData.className.replaceFirstChar { char ->
+        char.takeIf { char.isLowerCase() }?.run { uppercase(Locale.getDefault()) }
+          ?: char.toString()
+      }
 
     val builder =
       TypeSpec.classBuilder(className + FACTORY)

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -44,6 +44,7 @@ import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import dagger.assisted.AssistedFactory
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -140,8 +141,15 @@ private class CircuitSymbolProcessor(
       computeFactoryData(annotatedElement, symbols, screenKSType, instantiationType, logger)
         ?: return
 
+    val className = factoryData.className.replaceFirstChar { char ->
+      char
+        .takeIf { char.isLowerCase() }
+        ?.run { uppercase(Locale.getDefault()) }
+        ?: char.toString()
+    }
+
     val builder =
-      TypeSpec.classBuilder(factoryData.className + FACTORY)
+      TypeSpec.classBuilder(className + FACTORY)
         .addAnnotation(
           AnnotationSpec.builder(ContributesMultibinding::class)
             .addMember("%T::class", scope)


### PR DESCRIPTION
When generating factories for function presenters, we're using the function name which - if following Compose coding standards - starts with a lower case letter.  For example:
```kotlin
@Composable
fun fooPresenter(): FooState {
  // ...
}
```
This leads to factory objects that don't follow Kotlin naming standards: `fooPresenterFactory` instead of `FooPresenterFactory`.

Updated symbol processor to ensure that it always constructs objects that follow Kotlin naming standards.