### PR TITLE
Suppressing libs error which happens in Gradle 7.2 Version Catalog Pl…

### DIFF
--- a/samples/counter/desktop/build.gradle.kts
+++ b/samples/counter/desktop/build.gradle.kts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.jetbrains.compose.desktop.preview.tasks.AbstractConfigureDesktopPreviewTask
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
   kotlin("jvm")
   alias(libs.plugins.compose)


### PR DESCRIPTION
Suppressing libs error which happens in Gradle 7.2 Version Catalog Plugins that gives an IDE error "'val Project.libs: LibrariesForLibs' can't be called in this context by implicit receiver. Use the explicit one if necessary"