### PR TITLE
Integrate SqlDelight for Star sample repository and make it a more realistic and robust impl

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ paparazzi = "1.2.0"
 retrofit = "2.9.0"
 robolectric = "4.9.2"
 spotless = "6.18.0"
+sqldelight = "2.0.0-alpha05"
 turbine = "0.12.3"
 versionsPlugin = "0.46.0"
 
@@ -64,6 +65,7 @@ moshiGradlePlugin = { id = "dev.zacsweers.moshix", version.ref = "moshix" }
 # Using an early cut of this until a new version with API 33 is released
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 versionsPlugin = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]
@@ -184,6 +186,13 @@ retrofit-converters-moshi = { module = "com.squareup.retrofit2:converter-moshi",
 retrofit-converters-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref="robolectric" }
 rxjava = "io.reactivex.rxjava3:rxjava:3.1.6"
+
+sqldelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
+sqldelight-driver-jvm = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions-jvm", version.ref = "sqldelight" }
+sqldelight-paging = { module = "app.cash.sqldelight:androidx-paging3-extensions", version.ref = "sqldelight" }
+sqldelight-primitiveAdapters = { module = "app.cash.sqldelight:primitive-adapters", version.ref = "sqldelight" }
+
 testing-espresso-core = "androidx.test.espresso:espresso-core:3.5.1"
 # Robolectric/Espresso ship with an old and totally borked version of hamcrest dependency, force a newer one
 testing-hamcrest = "org.hamcrest:hamcrest:2.2"

--- a/samples/star/build.gradle.kts
+++ b/samples/star/build.gradle.kts
@@ -28,6 +28,15 @@ android {
   testBuildType = "release"
 }
 
+sqldelight {
+  databases {
+    create("StarDatabase") {
+      packageName.set("com.slack.circuit.star.db")
+      generateAsync.set(true)
+    }
+  }
+}
+
 tasks
   .withType<KotlinCompile>()
   .matching { it !is KaptGenerateStubsTask }

--- a/samples/star/build.gradle.kts
+++ b/samples/star/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
   alias(libs.plugins.anvil)
   alias(libs.plugins.paparazzi)
   alias(libs.plugins.ksp)
+  alias(libs.plugins.sqldelight)
 }
 
 android {
@@ -89,6 +90,9 @@ dependencies {
   implementation(libs.androidx.datastore.preferences)
   implementation(libs.kotlinx.immutable)
   implementation(libs.jsoup)
+  implementation(libs.sqldelight.driver.android)
+  implementation(libs.sqldelight.coroutines)
+  implementation(libs.sqldelight.primitiveAdapters)
 
   testImplementation(libs.androidx.compose.ui.testing.junit)
   testImplementation(libs.junit)

--- a/samples/star/build.gradle.kts
+++ b/samples/star/build.gradle.kts
@@ -28,14 +28,7 @@ android {
   testBuildType = "release"
 }
 
-sqldelight {
-  databases {
-    create("StarDatabase") {
-      packageName.set("com.slack.circuit.star.db")
-      generateAsync.set(true)
-    }
-  }
-}
+sqldelight { databases { create("StarDatabase") { packageName.set("com.slack.circuit.star.db") } } }
 
 tasks
   .withType<KotlinCompile>()

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/db/Gender.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/db/Gender.kt
@@ -1,0 +1,8 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.db
+
+enum class Gender {
+  MALE,
+  FEMALE
+}

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/db/ImmutableListAdapter.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/db/ImmutableListAdapter.kt
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.db
+
+import app.cash.sqldelight.ColumnAdapter
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+
+class ImmutableListAdapter(private val delimiter: String) :
+  ColumnAdapter<ImmutableList<String>, String> {
+  override fun decode(databaseValue: String) =
+    if (databaseValue.isEmpty()) {
+      persistentListOf()
+    } else {
+      databaseValue.split(delimiter).toImmutableList()
+    }
+  override fun encode(value: ImmutableList<String>) = value.joinToString(separator = delimiter)
+}

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/db/Size.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/db/Size.kt
@@ -1,0 +1,9 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.db
+
+enum class Size {
+  SMALL,
+  MEDIUM,
+  LARGE
+}

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
@@ -61,6 +61,8 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -115,8 +117,7 @@ constructor(
     val state by
       produceState<PetDetailScreen.State>(PetDetailScreen.State.Loading) {
         val animal = petRepository.getAnimal(screen.petId)
-        println("animal: $animal")
-        val bioText = petRepository.getAnimalBio(screen.petId)
+        val bioText = withContext(Dispatchers.IO) { petRepository.getAnimalBio(screen.petId) }
         value =
           when (animal) {
             null -> PetDetailScreen.State.UnknownAnimal

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
@@ -48,7 +48,7 @@ import com.slack.circuit.runtime.Screen
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.star.R
 import com.slack.circuit.star.common.BackPressNavIcon
-import com.slack.circuit.star.data.Animal
+import com.slack.circuit.star.db.GetAnimal
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.navigator.AndroidScreen
 import com.slack.circuit.star.petdetail.PetDetailTestConstants.ANIMAL_CONTAINER_TAG
@@ -61,7 +61,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -87,28 +86,18 @@ data class PetDetailScreen(val petId: Long, val photoUrlMemoryCacheKey: String?)
   }
 }
 
-internal fun Animal.toPetDetailState(
+internal fun GetAnimal.toPetDetailState(
   photoUrlMemoryCacheKey: String?,
   description: String = this.description,
   eventSink: (PetDetailScreen.Event) -> Unit
 ): PetDetailScreen.State {
   return PetDetailScreen.State.Success(
     url = url,
-    photoUrls = photos.map { it.large }.toImmutableList(),
+    photoUrls = photoUrls,
     photoUrlMemoryCacheKey = photoUrlMemoryCacheKey,
     name = name,
     description = description,
-    tags =
-      listOfNotNull(
-          colors.primary,
-          colors.secondary,
-          breeds.primary,
-          breeds.secondary,
-          gender,
-          size,
-          status
-        )
-        .toImmutableList(),
+    tags = tags,
     eventSink
   )
 }
@@ -126,6 +115,7 @@ constructor(
     val state by
       produceState<PetDetailScreen.State>(PetDetailScreen.State.Loading) {
         val animal = petRepository.getAnimal(screen.petId)
+        println("animal: $animal")
         val bioText = petRepository.getAnimalBio(screen.petId)
         value =
           when (animal) {

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/repo/PetRepository.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/repo/PetRepository.kt
@@ -2,49 +2,182 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.star.repo
 
-import com.slack.circuit.star.data.Animal
+import android.content.Context
+import app.cash.sqldelight.EnumColumnAdapter
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.slack.circuit.star.Database
 import com.slack.circuit.star.data.PetfinderApi
+import com.slack.circuit.star.db.AnimalBio
+import com.slack.circuit.star.db.Gender
+import com.slack.circuit.star.db.GetAllAnimalsForList
+import com.slack.circuit.star.db.GetAnimal
+import com.slack.circuit.star.db.ImmutableListAdapter
+import com.slack.circuit.star.db.OpJournal
+import com.slack.circuit.star.db.Size
 import com.slack.circuit.star.di.AppScope
+import com.slack.circuit.star.di.ApplicationContext
 import com.slack.circuit.star.di.SingleIn
 import com.squareup.anvil.annotations.ContributesBinding
-import javax.inject.Inject
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import retrofit2.HttpException
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.LazyThreadSafetyMode.NONE
+import com.slack.circuit.star.db.Animal as DbAnimal
 
 interface PetRepository {
-  suspend fun getAnimals(forceRefresh: Boolean): List<Animal>
-  suspend fun getAnimal(id: Long): Animal?
+  suspend fun refreshData()
+  fun animalsFlow(): Flow<List<GetAllAnimalsForList>>
+  suspend fun getAnimal(id: Long): GetAnimal?
   suspend fun getAnimalBio(id: Long): String?
 }
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-class PetRepositoryImpl @Inject constructor(private val petFinderApi: PetfinderApi) :
-  PetRepository {
-  private lateinit var animals: List<Animal>
+class PetRepositoryImpl
+@Inject
+constructor(
+  @ApplicationContext private val appContext: Context,
+  private val petFinderApi: PetfinderApi,
+) : PetRepository {
 
-  override suspend fun getAnimals(forceRefresh: Boolean): List<Animal> {
-    if (!this::animals.isInitialized || forceRefresh) fetchAnimals()
-    return animals
+  private val backgroundScope = CoroutineScope(Job() + Dispatchers.IO)
+  private val driver = AndroidSqliteDriver(Database.Schema, appContext, "star.db")
+  private val starDb =
+    Database(
+      driver,
+      DbAnimal.Adapter(
+        ImmutableListAdapter(","),
+        ImmutableListAdapter(":"),
+        EnumColumnAdapter(),
+        EnumColumnAdapter(),
+      )
+    )
+
+  override suspend fun refreshData() {
+    fetchAnimals()
+    // Clear the existing bios but lazily repopulate them
+    starDb.starQueries.transaction { starDb.starQueries.deleteAllBios() }
   }
 
-  override suspend fun getAnimal(id: Long): Animal? {
-    if (!this::animals.isInitialized) fetchAnimals()
-    return animals.find { it.id == id }
+  override fun animalsFlow(): Flow<List<GetAllAnimalsForList>> {
+    starDb.transaction {
+      if (isOperationStale("animals")) {
+        // Fetch new data
+        backgroundScope.launch { fetchAnimals() }
+      }
+    }
+    return starDb.starQueries
+      .getAllAnimalsForList()
+      .asFlow()
+      .mapToList(backgroundScope.coroutineContext)
+  }
+
+  override suspend fun getAnimal(id: Long): GetAnimal? {
+    return starDb.transactionWithResult { starDb.starQueries.getAnimal(id).executeAsOneOrNull() }
   }
 
   @Suppress("SwallowedException")
   private suspend fun fetchAnimals() {
-    animals =
-      try {
-        petFinderApi.animals(limit = 100).animals
-      } catch (e: HttpException) {
-        // Sometimes petfinder's API throws 429s for no reason.
-        emptyList()
+    try {
+      val animals = petFinderApi.animals(limit = 100).animals
+      starDb.transaction {
+        val allIds = animals.map { it.id }.toSet()
+        val storedIds = starDb.starQueries.getAllIds().executeAsList().toSet()
+        // Delete any not present
+        for (id in storedIds - allIds) {
+          starDb.starQueries.deleteAnimal(id)
+        }
+
+        // Re-populate the DB
+        for ((index, animal) in animals.withIndex()) {
+          starDb.starQueries.updateAnimal(
+            DbAnimal(
+              id = animal.id,
+              sort = index.toLong(),
+              // Names are sometimes all caps
+              name =
+                animal.name.lowercase().replaceFirstChar {
+                  if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString()
+                },
+              url = animal.url,
+              photoUrls = animal.photos.map { it.full }.toImmutableList(),
+              primaryPhotoUrl = animal.photos.firstOrNull()?.medium,
+              tags =
+                listOfNotNull(
+                    animal.colors.primary,
+                    animal.colors.secondary,
+                    animal.breeds.primary,
+                    animal.breeds.secondary,
+                    animal.gender,
+                    animal.size,
+                    animal.status
+                  )
+                  .toImmutableList(),
+              description = animal.description,
+              primaryBreed = animal.breeds.primary,
+              gender = Gender.valueOf(animal.gender.uppercase(Locale.US)),
+              size = Size.valueOf(animal.size.uppercase(Locale.US)),
+              age = animal.age,
+            )
+          )
+        }
+
+        logUpdate("animals")
       }
+    } catch (e: HttpException) {
+      // Sometimes petfinder's API throws 429s for no reason.
+      // TODO retry?
+    }
   }
 
   override suspend fun getAnimalBio(id: Long): String? {
     val animal = getAnimal(id) ?: return null
-    return petFinderApi.animalBio(animal.url)
+    val opId = "bio:$id"
+    val isStale = isOperationStale(opId)
+    val dbBio by lazy(NONE) { starDb.starQueries.getAnimalBio(id).executeAsOneOrNull() }
+    return if (isStale || dbBio == null) {
+      petFinderApi.animalBio(animal.url).also { bio ->
+        starDb.transactionWithResult {
+          logUpdate(opId)
+          starDb.starQueries.putAnimalBio(AnimalBio(id, bio))
+        }
+      }
+    } else {
+      dbBio?.description
+    }
+  }
+
+  private fun logUpdate(operation: String) {
+    val timestamp = currentTimestamp()
+    starDb.starQueries.putUpdate(OpJournal(timestamp = timestamp, operation = operation))
+  }
+
+  /**
+   * Returns whether or not it's been more than one day since the last update to the given
+   * [operation].
+   */
+  private fun isOperationStale(operation: String): Boolean {
+    val timestamp = currentTimestamp()
+    val lastUpdate = starDb.starQueries.lastUpdate(operation).executeAsOneOrNull()?.timestamp
+    return Duration.between(
+        Instant.ofEpochSecond(timestamp),
+        Instant.ofEpochSecond(lastUpdate ?: 0)
+      )
+      .toDays() > 1
+  }
+
+  private fun currentTimestamp(): Long {
+    return Instant.now().atZone(ZoneOffset.UTC).toEpochSecond()
   }
 }

--- a/samples/star/src/main/sqldelight/com/slack/circuit/star/db/star.sq
+++ b/samples/star/src/main/sqldelight/com/slack/circuit/star/db/star.sq
@@ -8,13 +8,6 @@ CREATE TABLE IF NOT EXISTS opJournal (
     PRIMARY KEY(timestamp)
 );
 
-lastUpdate:
-SELECT * FROM opJournal WHERE operation = ? ORDER BY timestamp DESC LIMIT 1;
-
-putUpdate:
-INSERT INTO opJournal
-VALUES ?;
-
 CREATE TABLE IF NOT EXISTS animal (
   id INTEGER NOT NULL,
   sort INTEGER NOT NULL,
@@ -68,3 +61,10 @@ DELETE FROM animal WHERE id = ?;
 
 getAllIds:
 SELECT id FROM animal;
+
+lastUpdate:
+SELECT * FROM opJournal WHERE operation = ? ORDER BY timestamp DESC LIMIT 1;
+
+putUpdate:
+INSERT INTO opJournal
+VALUES ?;

--- a/samples/star/src/main/sqldelight/com/slack/circuit/star/db/star.sq
+++ b/samples/star/src/main/sqldelight/com/slack/circuit/star/db/star.sq
@@ -1,0 +1,70 @@
+import com.slack.circuit.star.db.Gender;
+import com.slack.circuit.star.db.Size;
+import kotlinx.collections.immutable.ImmutableList;
+
+CREATE TABLE IF NOT EXISTS opJournal (
+    timestamp INTEGER NOT NULL,
+    operation TEXT NOT NULL,
+    PRIMARY KEY(timestamp)
+);
+
+lastUpdate:
+SELECT * FROM opJournal WHERE operation = ? ORDER BY timestamp DESC LIMIT 1;
+
+putUpdate:
+INSERT INTO opJournal
+VALUES ?;
+
+CREATE TABLE IF NOT EXISTS animal (
+  id INTEGER NOT NULL,
+  sort INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL,
+  photoUrls TEXT AS ImmutableList<String> NOT NULL,
+  primaryPhotoUrl TEXT,
+  tags TEXT AS ImmutableList<String> NOT NULL,
+  description TEXT NOT NULL,
+  primaryBreed TEXT,
+  gender TEXT AS Gender NOT NULL,
+  size TEXT AS Size NOT NULL,
+  age TEXT NOT NULL,
+  PRIMARY KEY(id)
+);
+
+CREATE TABLE IF NOT EXISTS animalBio (
+  id INTEGER NOT NULL,
+  description TEXT NOT NULL,
+  PRIMARY KEY(id)
+);
+
+updateAnimal:
+INSERT OR REPLACE INTO animal
+VALUES ?;
+
+getAllAnimals:
+SELECT * FROM animal;
+
+getAllAnimalsForList:
+SELECT id, name, primaryPhotoUrl, primaryBreed, gender, size, age FROM animal ORDER BY sort ASC;
+
+getAnimal:
+SELECT url, photoUrls, name, description, tags FROM animal WHERE id = ?;
+
+getAnimalUrl:
+SELECT url FROM animal WHERE id = ?;
+
+getAnimalBio:
+SELECT id, description FROM animalBio WHERE id = ?;
+
+deleteAllBios:
+DELETE FROM animalBio;
+
+putAnimalBio:
+INSERT INTO animalBio
+VALUES ?;
+
+deleteAnimal:
+DELETE FROM animal WHERE id = ?;
+
+getAllIds:
+SELECT id FROM animal;


### PR DESCRIPTION
This adds SqlDelight as a DB layer for the Star sample's repository.

High level features
- DB caching for animals list, preserving order from the API and refreshing data on-demand or after one day.
- Live `Flow` view from the presenter, so DB updates propagate automatically to the UI
- Added caching of scraped detail bios