### PR TITLE
Add bi-directional flow/circuit interop to samples

### DIFF
--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
@@ -2,39 +2,76 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.sample.interop
 
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.launchMolecule
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.presenter.presenterOf
 import com.slack.circuit.sample.counter.CounterScreen
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 
-/** An [Flow] presenter that exposes a [StateFlow] of count changes. */
-class FlowCounterPresenter {
-  private val count = MutableStateFlow(0)
-
-  fun increment() {
-    count.tryEmit(count.value + 1)
-  }
-
-  fun decrement() {
-    count.tryEmit(count.value - 1)
-  }
-
-  fun countStateFlow(): StateFlow<Int> = count
+/** A basic [Flow]-based presenter interface. */
+fun interface FlowPresenter<T : Any, E : Any> {
+  fun present(scope: CoroutineScope, events: Flow<E>): StateFlow<T>
 }
 
-fun FlowCounterPresenter.asCircuitPresenter(): Presenter<CounterScreen.State> {
-  return presenterOf {
-    val count by countStateFlow().collectAsState()
-    CounterScreen.State(count) { event ->
-      when (event) {
-        is CounterScreen.Event.Increment -> increment()
-        is CounterScreen.Event.Decrement -> decrement()
-        else -> Unit
+/** An [Flow] presenter that exposes a [StateFlow] of count changes. */
+class FlowCounterPresenter : FlowPresenter<Int, CounterScreen.Event> {
+  private val count = MutableStateFlow(0)
+
+  override fun present(
+    scope: CoroutineScope,
+    events: Flow<CounterScreen.Event>,
+  ): StateFlow<Int> {
+    scope.launch {
+      events.collect {
+        when (it) {
+          is CounterScreen.Event.Increment -> {
+            count.emit(count.value + 1)
+          }
+          is CounterScreen.Event.Decrement -> {
+            count.emit(count.value - 1)
+          }
+          else -> Unit
+        }
       }
+    }
+    return count
+  }
+}
+
+/** Interop from a [FlowPresenter] to a Circuit [Presenter]. */
+fun FlowPresenter<Int, CounterScreen.Event>.asCircuitPresenter(): Presenter<CounterScreen.State> {
+  return presenterOf {
+    val channel = remember { Channel<CounterScreen.Event>(Channel.BUFFERED) }
+    val eventsFlow = remember { channel.receiveAsFlow() }
+    val scope = rememberCoroutineScope()
+    val state by present(scope, eventsFlow).collectAsState()
+    CounterScreen.State(state, channel::trySend)
+  }
+}
+
+/**
+ * Interop from a Circuit [Presenter] to a [FlowPresenter].
+ *
+ * Nuance here is that this needs to know how to access the underlying event sink.
+ */
+fun Presenter<CounterScreen.State>.asFlowPresenter(): FlowPresenter<Int, CounterScreen.Event> {
+  return FlowPresenter { scope, events ->
+    scope.launchMolecule(RecompositionClock.Immediate) {
+      val (count, eventSink) = present()
+      LaunchedEffect(eventSink) { events.collect(eventSink) }
+      count
     }
   }
 }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 /** A basic [Flow]-based presenter interface. */
-fun interface FlowPresenter<T : Any, E : Any> {
-  fun present(scope: CoroutineScope, events: Flow<E>): StateFlow<T>
+fun interface FlowPresenter<UiState : Any, UiEvent : Any> {
+  fun present(scope: CoroutineScope, events: Flow<UiEvent>): StateFlow<UiState>
 }
 
 /** An [Flow] presenter that exposes a [StateFlow] of count changes. */

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -41,7 +42,6 @@ import com.slack.circuit.sample.counter.CounterScreen
 import kotlinx.parcelize.Parcelize
 
 class MainActivity : AppCompatActivity() {
-  @OptIn(ExperimentalMaterial3Api::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
@@ -104,12 +104,12 @@ class MainActivity : AppCompatActivity() {
 private fun SourceMenu(
   label: String,
   selectedIndex: Int,
-  sourceValues: Array<out Enum<*>>,
+  sourceValues: Array<out Displayable>,
   onSelected: (Int) -> Unit,
 ) {
   var expanded by remember { mutableStateOf(false) }
   val selectedName: String by
-    remember(selectedIndex) { mutableStateOf(sourceValues[selectedIndex].name) }
+    remember(selectedIndex) { mutableStateOf(sourceValues[selectedIndex].presentationName) }
   ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
     TextField(
       readOnly = true,
@@ -122,7 +122,10 @@ private fun SourceMenu(
     )
     ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
       for (source in sourceValues) {
-        SourceMenuItem(source, selectedIndex, onSelected)
+        SourceMenuItem(source, selectedIndex) {
+          expanded = false
+          onSelected(it)
+        }
       }
     }
   }
@@ -130,11 +133,11 @@ private fun SourceMenu(
 
 @Composable
 private fun SourceMenuItem(
-  source: Enum<*>,
+  source: Displayable,
   selectedIndex: Int,
   onSelected: (Int) -> Unit,
 ) {
-  val isSelected = selectedIndex == source.ordinal
+  val isSelected = selectedIndex == source.index
   val style =
     if (isSelected) {
       MaterialTheme.typography.labelLarge.copy(
@@ -151,11 +154,11 @@ private fun SourceMenuItem(
     text = {
       Text(
         modifier = Modifier.padding(8.dp),
-        text = source.name,
+        text = source.presentationName,
         style = style,
       )
     },
-    onClick = { onSelected(source.ordinal) },
+    onClick = { onSelected(source.index) },
   )
 }
 
@@ -165,8 +168,14 @@ private data class InteropCounterScreen(
   val uiSource: UiSource
 ) : CounterScreen, Parcelable
 
+@Stable
+private interface Displayable {
+  val index: Int
+  val presentationName: String
+}
+
 @Suppress("UNCHECKED_CAST")
-private enum class PresenterSource {
+private enum class PresenterSource : Displayable {
   Circuit {
     override fun createPresenter(
       screen: InteropCounterScreen,
@@ -175,6 +184,9 @@ private enum class PresenterSource {
       return CounterPresenterFactory().create(screen, Navigator.NoOp, context)
         as Presenter<CounterScreen.State>
     }
+
+    override val presentationName
+      get() = "Circuit"
   },
   Flow {
     override fun createPresenter(
@@ -183,6 +195,21 @@ private enum class PresenterSource {
     ): Presenter<CounterScreen.State> {
       return FlowCounterPresenter().asCircuitPresenter()
     }
+
+    override val presentationName
+      get() = "Flow -> Circuit"
+  },
+  CircuitToFlow {
+    override fun createPresenter(
+      screen: InteropCounterScreen,
+      context: CircuitContext,
+    ): Presenter<CounterScreen.State> {
+      // Two layers of interop!
+      return Flow.createPresenter(screen, context).asFlowPresenter().asCircuitPresenter()
+    }
+
+    override val presentationName
+      get() = "Circuit -> Flow -> Circuit"
   },
   RxJava {
     override fun createPresenter(
@@ -191,6 +218,9 @@ private enum class PresenterSource {
     ): Presenter<CounterScreen.State> {
       return RxCounterPresenter().asCircuitPresenter()
     }
+
+    override val presentationName
+      get() = "RxJava -> Circuit"
   },
   Simple {
     override fun createPresenter(
@@ -199,25 +229,43 @@ private enum class PresenterSource {
     ): Presenter<CounterScreen.State> {
       return SimpleCounterPresenter().asCircuitPresenter()
     }
+
+    override val presentationName
+      get() = "Simple -> Circuit"
   };
 
   abstract fun createPresenter(
     screen: InteropCounterScreen,
     context: CircuitContext,
   ): Presenter<CounterScreen.State>
+
+  open override val index: Int
+    get() = ordinal
+  open override val presentationName: String
+    get() = name
 }
 
-enum class UiSource {
+enum class UiSource : Displayable {
   Circuit {
     override fun createUi(): Ui<CounterScreen.State> {
       return ui { state, modifier -> Counter(state, modifier) }
     }
+
+    override val presentationName
+      get() = "Circuit"
   },
   View {
     override fun createUi(): Ui<CounterScreen.State> {
       return ui { state, modifier -> CounterViewComposable(state, modifier) }
     }
+
+    override val presentationName
+      get() = "View -> Circuit"
   };
 
   abstract fun createUi(): Ui<CounterScreen.State>
+  open override val index: Int
+    get() = ordinal
+  open override val presentationName: String
+    get() = name
 }


### PR DESCRIPTION
Did this while working on kotlinconf slides. Biggest change is this adds a new bi-directional interop sample for Flow <-> Circuit.


https://user-images.githubusercontent.com/1361086/231465899-fbea761c-eb2b-49b3-af6d-e8d5228ad526.mp4

