### PR TITLE
Use M3 WindowSizeClass for Star sample size handling

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,6 +101,7 @@ androidx-compose-material-icons = { module = "androidx.compose.material:material
 androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose-material" }
 androidx-compose-material-material = { module = "androidx.compose.material:material", version.ref = "compose-material" }
 androidx-compose-material-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" }
+androidx-compose-material-material3-windowSizeClass = { module = "androidx.compose.material3:material3-window-size-class", version.ref = "compose-material3" }
 # Runtime artifact, must be manually applied.
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose-runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose-runtime" }

--- a/samples/star/build.gradle.kts
+++ b/samples/star/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
   implementation(libs.androidx.compose.integration.materialThemeAdapter)
   implementation(libs.androidx.compose.material.icons)
   implementation(libs.androidx.compose.material.iconsExtended)
+  implementation(libs.androidx.compose.material.material3.windowSizeClass)
   implementation(libs.androidx.compose.accompanist.pager)
   implementation(libs.androidx.compose.accompanist.pager.indicators)
   implementation(libs.androidx.compose.accompanist.flowlayout)

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -13,6 +13,9 @@ import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_DARK
 import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_LIGHT
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.CircuitCompositionLocals
@@ -28,6 +31,7 @@ import com.slack.circuit.star.home.HomeScreen
 import com.slack.circuit.star.navigator.AndroidScreen
 import com.slack.circuit.star.navigator.AndroidSupportingNavigator
 import com.slack.circuit.star.petdetail.PetDetailScreen
+import com.slack.circuit.star.ui.LocalWindowWidthSizeClass
 import com.slack.circuit.star.ui.StarTheme
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -40,6 +44,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 class MainActivity @Inject constructor(private val circuitConfig: CircuitConfig) :
   AppCompatActivity() {
 
+  @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     var backStack: ImmutableList<Screen> = persistentListOf(HomeScreen)
@@ -58,8 +63,13 @@ class MainActivity @Inject constructor(private val circuitConfig: CircuitConfig)
           val circuitNavigator = rememberCircuitNavigator(backstack)
           val navigator =
             remember(circuitNavigator) { AndroidSupportingNavigator(circuitNavigator, this::goTo) }
-          CircuitCompositionLocals(circuitConfig) {
-            ContentWithOverlays { NavigableCircuitContent(navigator, backstack) }
+          val windowSizeClass = calculateWindowSizeClass(this)
+          CompositionLocalProvider(
+            LocalWindowWidthSizeClass provides windowSizeClass.widthSizeClass
+          ) {
+            CircuitCompositionLocals(circuitConfig) {
+              ContentWithOverlays { NavigableCircuitContent(navigator, backstack) }
+            }
           }
         }
       }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetDetail.kt
@@ -229,6 +229,7 @@ private fun ShowAnimalPortrait(state: PetDetailScreen.State.Success, padding: Pa
     modifier = Modifier.padding(padding).testTag(ANIMAL_CONTAINER_TAG),
     contentPadding = PaddingValues(16.dp),
     verticalArrangement = spacedBy(16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     item {
       CircuitContent(

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetPhotoCarousel.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetPhotoCarousel.kt
@@ -127,9 +127,10 @@ internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen.State, modifier: Mod
   val pagerState = rememberPagerState()
   val scope = rememberStableCoroutineScope()
   val requester = remember { FocusRequester() }
+  @Suppress("MagicNumber")
   val columnModifier =
     when (LocalWindowWidthSizeClass.current) {
-      @Suppress("MagicNumber") WindowWidthSizeClass.Medium,
+      WindowWidthSizeClass.Medium,
       WindowWidthSizeClass.Expanded -> modifier.fillMaxWidth(0.5f)
       else -> modifier.fillMaxSize()
     }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetPhotoCarousel.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petdetail/PetPhotoCarousel.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.star.petdetail
 
-import android.content.res.Configuration
 import android.view.KeyEvent
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.AnimationConstants
@@ -18,6 +17,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -28,7 +28,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -44,6 +43,7 @@ import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.star.common.ImmutableListParceler
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.petdetail.PetPhotoCarouselTestConstants.CAROUSEL_TAG
+import com.slack.circuit.star.ui.LocalWindowWidthSizeClass
 import com.slack.circuit.star.ui.rememberStableCoroutineScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -114,7 +114,6 @@ internal object PetPhotoCarouselTestConstants {
 internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen.State, modifier: Modifier = Modifier) {
   val (name, photoUrls, photoUrlMemoryCacheKey) = state
   val context = LocalContext.current
-  val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
   // Prefetch images
   LaunchedEffect(Unit) {
     for (url in photoUrls) {
@@ -128,8 +127,12 @@ internal fun PetPhotoCarousel(state: PetPhotoCarouselScreen.State, modifier: Mod
   val pagerState = rememberPagerState()
   val scope = rememberStableCoroutineScope()
   val requester = remember { FocusRequester() }
-  @Suppress("MagicNumber")
-  val columnModifier = if (isLandscape) modifier.fillMaxWidth(0.5f) else modifier.fillMaxSize()
+  val columnModifier =
+    when (LocalWindowWidthSizeClass.current) {
+      @Suppress("MagicNumber") WindowWidthSizeClass.Medium,
+      WindowWidthSizeClass.Expanded -> modifier.fillMaxWidth(0.5f)
+      else -> modifier.fillMaxSize()
+    }
   Column(
     columnModifier
       .testTag(CAROUSEL_TAG)

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -326,6 +326,7 @@ private fun PetListGrid(
       onRefresh = { eventSink(PetListScreen.Event.Refresh) }
     )
   Box(modifier = modifier.pullRefresh(pullRefreshState)) {
+    @Suppress("MagicNumber")
     val columnSpan =
       when (LocalWindowWidthSizeClass.current) {
         WindowWidthSizeClass.Medium -> 3

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.star.petlist
 
-import android.content.res.Configuration
 import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.core.AnimationConstants
@@ -45,6 +44,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -61,7 +61,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -95,6 +94,7 @@ import com.slack.circuit.star.petlist.PetListTestConstants.IMAGE_TAG
 import com.slack.circuit.star.petlist.PetListTestConstants.NO_ANIMALS_TAG
 import com.slack.circuit.star.petlist.PetListTestConstants.PROGRESS_TAG
 import com.slack.circuit.star.repo.PetRepository
+import com.slack.circuit.star.ui.LocalWindowWidthSizeClass
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -326,11 +326,17 @@ private fun PetListGrid(
       onRefresh = { eventSink(PetListScreen.Event.Refresh) }
     )
   Box(modifier = modifier.pullRefresh(pullRefreshState)) {
-    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val columnSpan =
+      when (LocalWindowWidthSizeClass.current) {
+        WindowWidthSizeClass.Medium -> 3
+        WindowWidthSizeClass.Expanded -> 4
+        // No exhausive whens available here
+        else -> 2
+      }
 
     @Suppress("MagicNumber")
     LazyVerticalStaggeredGrid(
-      columns = StaggeredGridCells.Fixed(if (isLandscape) 3 else 2),
+      columns = StaggeredGridCells.Fixed(columnSpan),
       modifier = Modifier.fillMaxSize().testTag(GRID_TAG),
       verticalItemSpacing = 16.dp,
       horizontalArrangement = spacedBy(16.dp),

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/ui/LocalWindowWidthSizeClass.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/ui/LocalWindowWidthSizeClass.kt
@@ -10,4 +10,5 @@ import androidx.compose.runtime.compositionLocalOf
  * activities, so this felt like the less bad option for exposing it to Circuit UIs that try not to
  * know anything about activities.
  */
+@Suppress("CompositionLocalAllowlist")
 val LocalWindowWidthSizeClass = compositionLocalOf { WindowWidthSizeClass.Compact }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/ui/LocalWindowWidthSizeClass.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/ui/LocalWindowWidthSizeClass.kt
@@ -1,0 +1,13 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.ui
+
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * A composition local for accessing [WindowWidthSizeClass]. This API is unfortunately tied to
+ * activities, so this felt like the less bad option for exposing it to Circuit UIs that try not to
+ * know anything about activities.
+ */
+val LocalWindowWidthSizeClass = compositionLocalOf { WindowWidthSizeClass.Compact }


### PR DESCRIPTION
This is a newer material API for adapting dynamically to window size changes. I opted to use a composition local because this API annoyingly relies on an `Activity` reference, which we don't have access to in Circuit.

https://developer.android.com/reference/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass

https://user-images.githubusercontent.com/1361086/236600412-5cc155d0-3da0-4da5-a91c-a6ae0339318b.mov


