### PR TITLE
Small STAR sample preview fixes

### DIFF
--- a/samples/star/build.gradle.kts
+++ b/samples/star/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
   implementation(libs.androidx.compose.accompanist.flowlayout)
   implementation(libs.androidx.compose.accompanist.swiperefresh)
   implementation(libs.androidx.compose.accompanist.systemUi)
-  debugImplementation(libs.androidx.compose.ui.tooling)
+  implementation(libs.androidx.compose.ui.tooling)
   implementation(libs.bundles.androidx.activity)
   implementation(libs.coil)
   implementation(libs.coil.compose)

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/home/AboutScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/home/AboutScreen.kt
@@ -19,12 +19,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Screen
 import com.slack.circuit.star.R
 import com.slack.circuit.star.di.AppScope
+import com.slack.circuit.star.ui.StarTheme
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -58,4 +60,10 @@ fun About(modifier: Modifier = Modifier) {
       }
     }
   )
+}
+
+@Preview
+@Composable
+private fun AboutPreview() {
+  StarTheme { About() }
 }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.star.petlist
 
+import android.content.res.Configuration
 import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.core.AnimationConstants
@@ -432,6 +433,7 @@ private suspend fun OverlayHost.updateFilters(currentFilters: Filters): Filters 
 }
 
 @Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PreviewUpdateFiltersSheet() {
   StarTheme {

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -95,11 +95,13 @@ import com.slack.circuit.star.petlist.PetListTestConstants.NO_ANIMALS_TAG
 import com.slack.circuit.star.petlist.PetListTestConstants.PROGRESS_TAG
 import com.slack.circuit.star.repo.PetRepository
 import com.slack.circuit.star.ui.LocalWindowWidthSizeClass
+import com.slack.circuit.star.ui.StarTheme
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.map
@@ -432,7 +434,14 @@ private suspend fun OverlayHost.updateFilters(currentFilters: Filters): Filters 
 @Preview
 @Composable
 private fun PreviewUpdateFiltersSheet() {
-  Surface { UpdateFiltersSheet(initialFilters = Filters()) }
+  StarTheme {
+    Surface {
+      UpdateFiltersSheet(
+        initialFilters = Filters(persistentSetOf(Gender.FEMALE)),
+        modifier = Modifier.padding(16.dp),
+      )
+    }
+  }
 }
 
 @VisibleForTesting


### PR DESCRIPTION
This fixes previews and adds another one for the about screen. Nothing crazy, just sprucing them up a bit

<img width="508" alt="Screenshot 2023-05-12 at 6 01 08 PM" src="https://github.com/slackhq/circuit/assets/1361086/5a8c1923-680b-4b54-ac5d-55e4f722d9f6">
<img width="441" alt="Screenshot 2023-05-12 at 6 01 18 PM" src="https://github.com/slackhq/circuit/assets/1361086/a6116a3e-3546-4ffb-afcc-b1da08d18d08">
