### PR TITLE
Allow creation of multiple RetainedStateRegistry instances

### DIFF
--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
@@ -65,8 +65,8 @@ internal class Continuity : ViewModel(), RetainedStateRegistry {
  */
 @Composable
 public fun continuityRetainedStateRegistry(
-  factory: ViewModelProvider.Factory = Continuity.Factory,
   key: String = Continuity.KEY,
+  factory: ViewModelProvider.Factory = Continuity.Factory,
 ): RetainedStateRegistry {
   val vm = viewModel<Continuity>(key = key, factory = factory)
   val canRetain = rememberCanRetainChecker()

--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
@@ -65,9 +65,10 @@ internal class Continuity : ViewModel(), RetainedStateRegistry {
  */
 @Composable
 public fun continuityRetainedStateRegistry(
-  factory: ViewModelProvider.Factory = Continuity.Factory
+  factory: ViewModelProvider.Factory = Continuity.Factory,
+  key: String = Continuity.KEY,
 ): RetainedStateRegistry {
-  val vm = viewModel<Continuity>(key = Continuity.KEY, factory = factory)
+  val vm = viewModel<Continuity>(key = key, factory = factory)
   val canRetain = rememberCanRetainChecker()
   remember(canRetain) {
     object : RememberObserver {


### PR DESCRIPTION
Currently the shared key would prevent multiple instances from being used, so allowing this to be customized can enable more granular registry instance management.