### PR TITLE
Remember Presenter and UI in CircuitContent

### DIFF
--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -94,14 +94,22 @@ internal fun CircuitContent(
     onDispose { eventListener.dispose() }
   }
 
-  eventListener.onBeforeCreatePresenter(screen, navigator, context)
-  @Suppress("UNCHECKED_CAST")
-  val presenter = circuitConfig.presenter(screen, navigator, context) as Presenter<CircuitUiState>?
-  eventListener.onAfterCreatePresenter(screen, navigator, presenter, context)
+  val presenter =
+    remember(eventListener, screen, navigator, context) {
+      eventListener.onBeforeCreatePresenter(screen, navigator, context)
+      @Suppress("UNCHECKED_CAST")
+      (circuitConfig.presenter(screen, navigator, context) as Presenter<CircuitUiState>?).also {
+        eventListener.onAfterCreatePresenter(screen, navigator, it, context)
+      }
+    }
 
-  eventListener.onBeforeCreateUi(screen, context)
-  val ui = circuitConfig.ui(screen, context)
-  eventListener.onAfterCreateUi(screen, ui, context)
+  val ui =
+    remember(eventListener, screen, context) {
+      eventListener.onBeforeCreateUi(screen, context)
+      circuitConfig.ui(screen, context).also { ui ->
+        eventListener.onAfterCreateUi(screen, ui, context)
+      }
+    }
 
   if (ui != null && presenter != null) {
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Currently the `Presenter` and `Ui` are created every time `CircuitContent` recomposes, this causes flashes of content each time it is called.

For most use cases this won't cause an issue, since `CircuitContent`'s inputs don't change meaning no recompositions, but it is an issue for use-cases which need to recall `CircuitContent`.

A use-case I'm playing with at the moment is putting `CircuitContent` within a `movableContentOf`, so `CircuitContent` will be called multiple times. This PR changes CircuitContent to remember the Presenter and Ui, and thus moving CircuitContent composables now works as expected.