### PR TITLE
Make CircuitContent overload with Navigator public

### DIFF
--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -24,7 +24,7 @@ public fun CircuitContent(
   unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
     circuitConfig.onUnavailableContent,
 ) {
-  CircuitContent(screen, modifier, Navigator.NoOp, circuitConfig, unavailableContent)
+  CircuitContent(screen, Navigator.NoOp, modifier, circuitConfig, unavailableContent)
 }
 
 @Composable
@@ -54,16 +54,17 @@ public fun CircuitContent(
         }
       }
     }
-  CircuitContent(screen, modifier, navigator, circuitConfig, unavailableContent)
+  CircuitContent(screen, navigator, modifier, circuitConfig, unavailableContent)
 }
 
 @Composable
-internal fun CircuitContent(
+public fun CircuitContent(
   screen: Screen,
-  modifier: Modifier,
   navigator: Navigator,
-  circuitConfig: CircuitConfig,
-  unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit),
+  modifier: Modifier = Modifier,
+  circuitConfig: CircuitConfig = requireNotNull(LocalCircuitConfig.current),
+  unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
+    circuitConfig.onUnavailableContent,
 ) {
   val parent = LocalCircuitContext.current
   @OptIn(InternalCircuitApi::class)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -47,7 +47,7 @@ public fun NavigableCircuitContent(
           val screen = record.screen
 
           val currentContent: (@Composable (SaveableBackStack.Record) -> Unit) = {
-            CircuitContent(screen, modifier, navigator, circuitConfig, unavailableRoute)
+            CircuitContent(screen, navigator, modifier, circuitConfig, unavailableRoute)
           }
 
           val currentRouteContent by rememberUpdatedState(currentContent)


### PR DESCRIPTION
Not sure if there's a reason why this overload is internal, but it's useful for custom animations and wrapping CircuitContent in movableContentOf.

My use case is a custom `NavigableCircuitContent` which provides animation and gesture support. The only public overload which kinda supports this is via `onNavEvent`. 
I could proxy events to the host navigator, but some of the NavEvent subtypes are internal too.

I'm open to this change, or making the NavEvent subtypes public.