### PR TITLE
Remove intermediate event sinks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,14 +80,13 @@ fun Counter(state: CounterState) {
         style = MaterialTheme.typography.displayLarge
       )
       Spacer(modifier = Modifier.height(16.dp))
-      val eventSink = state.eventSink
       Button(
         modifier = Modifier.align(CenterHorizontally),
-        onClick = { eventSink(CounterEvent.Increment) }
+        onClick = { state.eventSink(CounterEvent.Increment) }
       ) { Icon(rememberVectorPainter(Icons.Filled.Add), "Increment") }
       Button(
         modifier = Modifier.align(CenterHorizontally),
-        onClick = { eventSink(CounterEvent.Decrement) }
+        onClick = { state.eventSink(CounterEvent.Decrement) }
       ) { Icon(rememberVectorPainter(Icons.Filled.Remove), "Decrement") }
     }
   }

--- a/docs/states-and-events.md
+++ b/docs/states-and-events.md
@@ -18,9 +18,6 @@ Yep! This may feel like a departure from how you’ve written UDF patterns in th
 * No internal ceremony around setting up a `Channel` and multicasting event streams.
 * No risk of dropping events (unlike `Flow`).
 
-!!! warning
-    Due to this [issue](https://issuetracker.google.com/issues/256100927), you need to extract the `eventSink` into local variables first.
-
 !!! note
     Currently, while functions are treated as implicitly `Stable` by the compose compiler, they're not skippable when they're non-composable Unit-returning lambdas with equal-but-unstable captures. This may change though, and would be another free benefit for this case.
 

--- a/samples/counter/apps/src/androidMain/kotlin/com/slack/circuit/sample/counter/android/AndroidCounterCircuit.kt
+++ b/samples/counter/apps/src/androidMain/kotlin/com/slack/circuit/sample/counter/android/AndroidCounterCircuit.kt
@@ -45,16 +45,15 @@ fun Counter(state: CounterScreen.State, modifier: Modifier = Modifier) {
         color = color
       )
       Spacer(modifier = Modifier.height(16.dp))
-      val sink = state.eventSink
       Button(
         modifier = Modifier.align(CenterHorizontally),
-        onClick = { sink(CounterScreen.Event.Increment) }
+        onClick = { state.eventSink(CounterScreen.Event.Increment) }
       ) {
         Icon(rememberVectorPainter(Icons.Filled.Add), "Increment")
       }
       Button(
         modifier = Modifier.align(CenterHorizontally),
-        onClick = { sink(CounterScreen.Event.Decrement) }
+        onClick = { state.eventSink(CounterScreen.Event.Decrement) }
       ) {
         Icon(rememberVectorPainter(Icons.Filled.Remove), "Decrement")
       }

--- a/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
+++ b/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
@@ -56,16 +56,15 @@ fun Counter(state: CounterScreen.State, modifier: Modifier = Modifier) {
         color = color
       )
       Spacer(modifier = Modifier.height(16.dp))
-      val sink = state.eventSink
       Row {
         Button(
           modifier = Modifier.padding(2.dp),
-          onClick = { sink(CounterScreen.Event.Decrement) },
+          onClick = { state.eventSink(CounterScreen.Event.Decrement) },
         ) {
           Icon(rememberVectorPainter(Remove), "Decrement")
         }
         Button(
-          onClick = { sink(CounterScreen.Event.GoTo(DesktopPrimeScreen(state.count))) },
+          onClick = { state.eventSink(CounterScreen.Event.GoTo(DesktopPrimeScreen(state.count))) },
           modifier = Modifier.padding(2.dp)
         ) {
           Text(
@@ -75,7 +74,7 @@ fun Counter(state: CounterScreen.State, modifier: Modifier = Modifier) {
         }
         Button(
           modifier = Modifier.padding(2.dp),
-          onClick = { sink(CounterScreen.Event.Increment) },
+          onClick = { state.eventSink(CounterScreen.Event.Increment) },
         ) {
           Icon(rememberVectorPainter(Icons.Filled.Add), "Increment")
         }
@@ -94,7 +93,6 @@ fun Prime(state: PrimeScreen.State, modifier: Modifier = Modifier) {
         text = "${state.number}",
       )
       Spacer(modifier = Modifier.height(16.dp))
-      val sink = state.eventSink
       if (state.isPrime) {
         Text(
           modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -109,7 +107,7 @@ fun Prime(state: PrimeScreen.State, modifier: Modifier = Modifier) {
       Spacer(modifier = Modifier.height(16.dp))
       Button(
         modifier = Modifier.align(Alignment.CenterHorizontally),
-        onClick = { sink(PrimeScreen.Event.Pop) },
+        onClick = { state.eventSink(PrimeScreen.Event.Pop) },
       ) {
         Text("Back")
       }

--- a/samples/counter/mosaic/src/commonMain/kotlin/com/slack/circuit/sample/counter/mosaic/MosaicCounter.kt
+++ b/samples/counter/mosaic/src/commonMain/kotlin/com/slack/circuit/sample/counter/mosaic/MosaicCounter.kt
@@ -46,7 +46,6 @@ private fun Counter(state: CounterScreen.State) {
 
   // TODO THIS DOES NOT WORK! Needs https://github.com/JakeWharton/mosaic/issues/3
   //  This is left as a toe-hold for the future.
-  val eventSink = state.eventSink
   LaunchedEffect(Unit) {
     withContext(IO) {
       val terminal = TerminalBuilder.terminal()
@@ -65,8 +64,8 @@ private fun Counter(state: CounterScreen.State) {
             when (reader.read()) {
               91 -> {
                 when (reader.read()) {
-                  65 -> eventSink(CounterScreen.Event.Increment)
-                  66 -> eventSink(CounterScreen.Event.Decrement)
+                  65 -> state.eventSink(CounterScreen.Event.Increment)
+                  66 -> state.eventSink(CounterScreen.Event.Decrement)
                 }
               }
             }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/ComposeCounterUi.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/ComposeCounterUi.kt
@@ -35,16 +35,15 @@ fun Counter(state: CounterScreen.State, modifier: Modifier = Modifier) {
         color = color
       )
       Spacer(modifier = Modifier.height(16.dp))
-      val sink = state.eventSink
       Button(
         modifier = Modifier.align(Alignment.CenterHorizontally),
-        onClick = { sink(CounterScreen.Event.Increment) }
+        onClick = { state.eventSink(CounterScreen.Event.Increment) }
       ) {
         Icon(rememberVectorPainter(Icons.Filled.Add), "Increment")
       }
       Button(
         modifier = Modifier.align(Alignment.CenterHorizontally),
-        onClick = { sink(CounterScreen.Event.Decrement) }
+        onClick = { state.eventSink(CounterScreen.Event.Decrement) }
       ) {
         Icon(rememberVectorPainter(Icons.Filled.Remove), "Decrement")
       }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
@@ -62,13 +62,12 @@ constructor(
 /** An interop compose function that renders [CounterView] as a Circuit-powered [AndroidView]. */
 @Composable
 fun CounterViewComposable(state: CounterScreen.State, modifier: Modifier = Modifier) {
-  val eventSink = state.eventSink
   AndroidView(
     modifier = modifier.fillMaxSize(),
     factory = { context ->
       CounterView(context).apply {
-        setOnIncrementClickListener { eventSink(CounterScreen.Event.Increment) }
-        setOnDecrementClickListener { eventSink(CounterScreen.Event.Decrement) }
+        setOnIncrementClickListener { state.eventSink(CounterScreen.Event.Increment) }
+        setOnDecrementClickListener { state.eventSink(CounterScreen.Event.Decrement) }
       }
     },
     update = { view -> view.setState(state.count) }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/home/HomeScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/home/HomeScreen.kt
@@ -68,7 +68,6 @@ fun HomePresenter(navigator: Navigator): HomeScreen.State {
 @CircuitInject(screen = HomeScreen::class, scope = AppScope::class)
 @Composable
 fun HomeContent(state: HomeScreen.State, modifier: Modifier = Modifier) {
-  val eventSink = state.eventSink
   Scaffold(
     modifier = modifier.fillMaxWidth(),
     contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -76,7 +75,7 @@ fun HomeContent(state: HomeScreen.State, modifier: Modifier = Modifier) {
     bottomBar = {
       StarTheme(useDarkTheme = true) {
         BottomNavigationBar(selectedIndex = state.selectedIndex) { index ->
-          eventSink(ClickNavItem(index))
+          state.eventSink(ClickNavItem(index))
         }
       }
     }
@@ -85,7 +84,7 @@ fun HomeContent(state: HomeScreen.State, modifier: Modifier = Modifier) {
     CircuitContent(
       screen,
       modifier = Modifier.padding(paddingValues),
-      onNavEvent = { event -> eventSink(ChildNav(event)) }
+      onNavEvent = { event -> state.eventSink(ChildNav(event)) }
     )
   }
 }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
@@ -103,7 +103,6 @@ constructor(
 @CircuitInject(ImageViewerScreen::class, AppScope::class)
 @Composable
 fun ImageViewer(state: ImageViewerScreen.State, modifier: Modifier = Modifier) {
-  val sink = state.eventSink
   var showChrome by remember { mutableStateOf(true) }
   val systemUiController = rememberSystemUiController()
   systemUiController.isSystemBarsVisible = showChrome
@@ -132,7 +131,7 @@ fun ImageViewer(state: ImageViewerScreen.State, modifier: Modifier = Modifier) {
 
         val dismissState = rememberFlickToDismissState()
         if (dismissState.gestureState is Dismissed) {
-          sink(ImageViewerScreen.Event.Close)
+          state.eventSink(ImageViewerScreen.Event.Close)
         }
         // TODO bind scrim with flick. animate scrim out after flick finishes? Or with flick?
         FlickToDismiss(state = dismissState) {
@@ -160,7 +159,7 @@ fun ImageViewer(state: ImageViewerScreen.State, modifier: Modifier = Modifier) {
         ) {
           BackPressNavIcon(
             Modifier.align(Alignment.TopStart).padding(8.dp).statusBarsPadding(),
-            onClick = { sink(ImageViewerScreen.Event.Close) }
+            onClick = { state.eventSink(ImageViewerScreen.Event.Close) }
           )
         }
       }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -254,11 +254,10 @@ internal fun PetList(
   modifier: Modifier = Modifier,
 ) {
   if (state is PetListScreen.State.Success && state.isUpdateFiltersModalShowing) {
-    val eventSink = state.eventSink
     val overlayHost = LocalOverlayHost.current
     LaunchedEffect(state) {
       val result = overlayHost.updateFilters(state.filters)
-      eventSink(PetListScreen.Event.UpdatedFilters(result))
+      state.eventSink(PetListScreen.Event.UpdatedFilters(result))
     }
   }
 
@@ -278,8 +277,7 @@ internal fun PetList(
         scrollBehavior = scrollBehavior,
         actions = {
           if (state is PetListScreen.State.Success) {
-            val eventSink = state.eventSink
-            IconButton(onClick = { eventSink(PetListScreen.Event.UpdateFilters) }) {
+            IconButton(onClick = { state.eventSink(PetListScreen.Event.UpdateFilters) }) {
               Icon(
                 imageVector = Icons.Default.FilterList,
                 contentDescription = "Filter pet list",

--- a/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/OrderTacosCircuit.kt
+++ b/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/OrderTacosCircuit.kt
@@ -201,9 +201,9 @@ private fun calculateIngredientsCost(filling: Ingredient?, toppings: Set<Ingredi
 
 @Composable
 internal fun OrderTacosUi(state: OrderTacosScreen.State, modifier: Modifier = Modifier) {
-  val sink = state.eventSink
-
-  BackHandler(enabled = state.isPreviousVisible) { sink(OrderTacosScreen.Event.Previous) }
+  BackHandler(enabled = state.isPreviousVisible) {
+    state.eventSink(OrderTacosScreen.Event.Previous)
+  }
 
   Scaffold(
     modifier = modifier.padding(4.dp),
@@ -216,7 +216,7 @@ internal fun OrderTacosUi(state: OrderTacosScreen.State, modifier: Modifier = Mo
             direction = Direction.LEFT,
             visible = state.isPreviousVisible,
           ) {
-            sink(OrderTacosScreen.Event.Previous)
+            state.eventSink(OrderTacosScreen.Event.Previous)
           }
         },
         actions = {
@@ -225,7 +225,7 @@ internal fun OrderTacosUi(state: OrderTacosScreen.State, modifier: Modifier = Mo
             enabled = state.isNextEnabled,
             visible = state.isNextVisible,
           ) {
-            sink(OrderTacosScreen.Event.Next)
+            state.eventSink(OrderTacosScreen.Event.Next)
           }
         }
       )
@@ -236,7 +236,7 @@ internal fun OrderTacosUi(state: OrderTacosScreen.State, modifier: Modifier = Mo
         onConfirmationStep = state.stepState is ConfirmationOrderStep.OrderState,
         isVisible = state.isFooterVisible,
       ) {
-        sink(OrderTacosScreen.Event.ProcessOrder)
+        state.eventSink(OrderTacosScreen.Event.ProcessOrder)
       }
     }
   ) { padding ->

--- a/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/step/FillingsOrderStep.kt
+++ b/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/step/FillingsOrderStep.kt
@@ -95,7 +95,6 @@ private fun FillingsList(
   state: FillingsOrderStep.State.AvailableFillings,
   modifier: Modifier = Modifier
 ) {
-  val sink = state.eventSink
   val scrollState = rememberScrollState()
   Column(modifier = modifier.verticalScroll(scrollState).fillMaxWidth()) {
     Instructions(resId = R.string.fillings_step_instructions)
@@ -103,7 +102,7 @@ private fun FillingsList(
       Filling(
         ingredient = ingredient,
         isSelected = state.selected == ingredient,
-        onSelect = { sink(FillingsOrderStep.Event.SelectFilling(ingredient)) },
+        onSelect = { state.eventSink(FillingsOrderStep.Event.SelectFilling(ingredient)) },
       )
     }
   }

--- a/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/step/SummaryOrderStep.kt
+++ b/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/step/SummaryOrderStep.kt
@@ -25,8 +25,7 @@ internal fun summaryProducer(eventSink: (OrderStep.Event) -> Unit) =
 
 @Composable
 internal fun SummaryUi(state: SummaryOrderStep.SummaryState, modifier: Modifier = Modifier) {
-  val sink = state.eventSink
   Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-    Button(onClick = sink) { Text(stringResource(R.string.summary_step_order_again)) }
+    Button(onClick = state.eventSink) { Text(stringResource(R.string.summary_step_order_again)) }
   }
 }

--- a/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/step/ToppingsOrderStep.kt
+++ b/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/step/ToppingsOrderStep.kt
@@ -123,7 +123,6 @@ private fun ToppingsList(
   state: ToppingsOrderStep.State.AvailableToppings,
   modifier: Modifier = Modifier
 ) {
-  val sink = state.eventSink
   val scrollState = rememberScrollState()
   Column(modifier = modifier.verticalScroll(scrollState).fillMaxWidth()) {
     Instructions(resId = R.string.toppings_step_instructions)
@@ -137,7 +136,7 @@ private fun ToppingsList(
               selected -> ToppingsOrderStep.Event::AddTopping
               else -> ToppingsOrderStep.Event::RemoveTopping
             }
-          sink(event(ingredient))
+          state.eventSink(event(ingredient))
         },
       )
     }


### PR DESCRIPTION
I can no longer reproduce the original issue. While the recomposition factor does come into play, this seems more or less acceptable that the recomposition can happen when the state updates. This simplifies our usage a fair bit, and I kind of wonder if the original bug was something else wrong with the compose code we'd written at the time. I think we should run ahead with this until/unless we see reproducible issues with it.