### PR TITLE
Rename CircuitConfig -> Circuit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
           cache-read-only: false
 
       - name: Verify Snapshots
-        if: always()
         id: gradle-snapshots
         uses: gradle/gradle-build-action@v2
         with:

--- a/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.kt
+++ b/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.kt
@@ -3,7 +3,7 @@
 package com.slack.circuit.codegen.annotations
 
 import androidx.compose.runtime.Composable
-import com.slack.circuit.foundation.CircuitConfig
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.Screen
@@ -96,7 +96,7 @@ import kotlin.reflect.KClass
  * Types available for assisted injection are:
  * - [Screen] – the screen key used to create the [Presenter] or [Ui].
  * - [Navigator] – (presenters only)
- * - [CircuitConfig]
+ * - [Circuit]
  *
  * Each should only be defined at-most once.
  *

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
@@ -18,16 +18,16 @@ import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
 
 /**
- * [CircuitConfig] adapts [presenter factories][Presenter.Factory] to their corresponding
+ * [Circuit] adapts [presenter factories][Presenter.Factory] to their corresponding
  * [ui factories][Ui.Factory] using [screens][Screen]. Create instances using [the Builder]
  * [Builder] and create new [CircuitContent] with it to run presenter/UI pairings.
  *
  * ## Construction
  *
- * Construction of [CircuitConfig] instances is done using [the Builder] [Builder].
+ * Construction of [Circuit] instances is done using [the Builder] [Builder].
  *
  * ```kotlin
- * val circuitConfig = CircuitConfig.Builder()
+ * val circuit = Circuit.Builder()
  *     .addUiFactory(AddFavoritesUiFactory())
  *     .addPresenterFactory(AddFavoritesPresenterFactory())
  *     .build()
@@ -42,7 +42,7 @@ import com.slack.circuit.runtime.ui.Ui
  * [CircuitCompositionLocals] CompositionLocalProvider.
  *
  * ```kotlin
- * CircuitCompositionLocals(circuitConfig) {
+ * CircuitCompositionLocals(circuit) {
  *   CircuitContent(AddFavoritesScreen())
  * }
  * ```
@@ -52,7 +52,7 @@ import com.slack.circuit.runtime.ui.Ui
  * ```kotlin
  * val backstack = rememberSaveableBackStack { push(AddFavoritesScreen()) }
  * val navigator = rememberCircuitNavigator(backstack, ::onBackPressed)
- * CircuitCompositionLocals(circuitConfig) {
+ * CircuitCompositionLocals(circuit) {
  *   NavigableCircuitContent(navigator, backstack)
  * }
  * ```
@@ -62,7 +62,7 @@ import com.slack.circuit.runtime.ui.Ui
  * @see `NavigableCircuitContent`
  */
 @Immutable
-public class CircuitConfig private constructor(builder: Builder) {
+public class Circuit private constructor(builder: Builder) {
   private val uiFactories: List<Ui.Factory> = builder.uiFactories.toList()
   private val presenterFactories: List<Presenter.Factory> = builder.presenterFactories.toList()
   public val onUnavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
@@ -74,7 +74,7 @@ public class CircuitConfig private constructor(builder: Builder) {
   public fun presenter(
     screen: Screen,
     navigator: Navigator,
-    context: CircuitContext = CircuitContext(null).also { it.config = this }
+    context: CircuitContext = CircuitContext(null).also { it.circuit = this }
   ): Presenter<*>? {
     return nextPresenter(null, screen, navigator, context)
   }
@@ -99,7 +99,7 @@ public class CircuitConfig private constructor(builder: Builder) {
   @OptIn(InternalCircuitApi::class)
   public fun ui(
     screen: Screen,
-    context: CircuitContext = CircuitContext(null).also { it.config = this }
+    context: CircuitContext = CircuitContext(null).also { it.circuit = this }
   ): Ui<*>? {
     return nextUi(null, screen, context)
   }
@@ -131,10 +131,10 @@ public class CircuitConfig private constructor(builder: Builder) {
     public var eventListenerFactory: EventListener.Factory? = null
       private set
 
-    internal constructor(circuitConfig: CircuitConfig) : this() {
-      uiFactories.addAll(circuitConfig.uiFactories)
-      presenterFactories.addAll(circuitConfig.presenterFactories)
-      eventListenerFactory = circuitConfig.eventListenerFactory
+    internal constructor(circuit: Circuit) : this() {
+      uiFactories.addAll(circuit.uiFactories)
+      presenterFactories.addAll(circuit.presenterFactories)
+      eventListenerFactory = circuit.eventListenerFactory
     }
 
     public fun addUiFactory(factory: Ui.Factory): Builder = apply { uiFactories.add(factory) }
@@ -175,8 +175,8 @@ public class CircuitConfig private constructor(builder: Builder) {
       eventListenerFactory = factory
     }
 
-    public fun build(): CircuitConfig {
-      return CircuitConfig(this)
+    public fun build(): Circuit {
+      return Circuit(this)
     }
   }
 }
@@ -190,8 +190,8 @@ private val UnavailableContent: @Composable (screen: Screen, modifier: Modifier)
     )
   }
 
-/** The [CircuitConfig] used in this context. */
-public var CircuitContext.config: CircuitConfig
+/** The [Circuit] used in this context. */
+public var CircuitContext.circuit: Circuit
   get() = checkNotNull(tag())
   set(value) {
     putTag(value)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitCompositionLocals.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitCompositionLocals.kt
@@ -11,13 +11,13 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import com.slack.circuit.runtime.CircuitContext
 
 /**
- * Provides the given [circuitConfig] as a [CompositionLocal] to all composables within [content].
- * Also adds any other composition locals that Circuit needs.
+ * Provides the given [circuit] as a [CompositionLocal] to all composables within [content]. Also
+ * adds any other composition locals that Circuit needs.
  */
 @Composable
-public fun CircuitCompositionLocals(circuitConfig: CircuitConfig, content: @Composable () -> Unit) {
+public fun CircuitCompositionLocals(circuit: Circuit, content: @Composable () -> Unit) {
   CompositionLocalProvider(
-    LocalCircuitConfig provides circuitConfig,
+    LocalCircuit provides circuit,
   ) {
     content()
   }
@@ -25,8 +25,5 @@ public fun CircuitCompositionLocals(circuitConfig: CircuitConfig, content: @Comp
 
 internal val LocalCircuitContext = compositionLocalOf<CircuitContext?> { null }
 
-/** CompositionLocal with a current [CircuitConfig] instance. */
-public val LocalCircuitConfig: ProvidableCompositionLocal<CircuitConfig?> =
-  staticCompositionLocalOf {
-    null
-  }
+/** CompositionLocal with a current [Circuit] instance. */
+public val LocalCircuit: ProvidableCompositionLocal<Circuit?> = staticCompositionLocalOf { null }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitConfig.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitConfig.kt
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import com.slack.circuit.runtime.CircuitContext
+
+/*
+ * Deprecated type markers for ease of migration.
+ */
+
+@Deprecated("Use Circuit instead", ReplaceWith("Circuit", "com.slack.circuit.foundation.Circuit"))
+public typealias CircuitConfig = Circuit
+
+@Deprecated(
+    "Use CircuitContext.circuit instead",
+    ReplaceWith("circuit", "com.slack.circuit.foundation.circuit"))
+public var CircuitContext.config: Circuit
+  get() = circuit
+  set(value) {
+    circuit = value
+  }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitConfig.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitConfig.kt
@@ -12,8 +12,9 @@ import com.slack.circuit.runtime.CircuitContext
 public typealias CircuitConfig = Circuit
 
 @Deprecated(
-    "Use CircuitContext.circuit instead",
-    ReplaceWith("circuit", "com.slack.circuit.foundation.circuit"))
+  "Use CircuitContext.circuit instead",
+  ReplaceWith("circuit", "com.slack.circuit.foundation.circuit")
+)
 public var CircuitContext.config: Circuit
   get() = circuit
   set(value) {

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -70,7 +70,7 @@ public fun CircuitContent(
   @OptIn(InternalCircuitApi::class)
   val context =
     remember(screen, navigator, circuit, parent) {
-      CircuitContext(parent).also { it.config = circuit }
+      CircuitContext(parent).also { it.circuit = circuit }
     }
   CompositionLocalProvider(LocalCircuitContext provides context) {
     CircuitContent(screen, modifier, navigator, circuit, unavailableContent, context)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -20,11 +20,11 @@ import com.slack.circuit.runtime.ui.Ui
 public fun CircuitContent(
   screen: Screen,
   modifier: Modifier = Modifier,
-  circuitConfig: CircuitConfig = requireNotNull(LocalCircuitConfig.current),
+  circuit: Circuit = requireNotNull(LocalCircuit.current),
   unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
-    circuitConfig.onUnavailableContent,
+    circuit.onUnavailableContent,
 ) {
-  CircuitContent(screen, Navigator.NoOp, modifier, circuitConfig, unavailableContent)
+  CircuitContent(screen, Navigator.NoOp, modifier, circuit, unavailableContent)
 }
 
 @Composable
@@ -32,9 +32,9 @@ public fun CircuitContent(
   screen: Screen,
   modifier: Modifier = Modifier,
   onNavEvent: (event: NavEvent) -> Unit,
-  circuitConfig: CircuitConfig = requireNotNull(LocalCircuitConfig.current),
+  circuit: Circuit = requireNotNull(LocalCircuit.current),
   unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
-    circuitConfig.onUnavailableContent,
+    circuit.onUnavailableContent,
 ) {
   val navigator =
     remember(onNavEvent) {
@@ -54,7 +54,7 @@ public fun CircuitContent(
         }
       }
     }
-  CircuitContent(screen, navigator, modifier, circuitConfig, unavailableContent)
+  CircuitContent(screen, navigator, modifier, circuit, unavailableContent)
 }
 
 @Composable
@@ -62,18 +62,18 @@ public fun CircuitContent(
   screen: Screen,
   navigator: Navigator,
   modifier: Modifier = Modifier,
-  circuitConfig: CircuitConfig = requireNotNull(LocalCircuitConfig.current),
+  circuit: Circuit = requireNotNull(LocalCircuit.current),
   unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
-    circuitConfig.onUnavailableContent,
+    circuit.onUnavailableContent,
 ) {
   val parent = LocalCircuitContext.current
   @OptIn(InternalCircuitApi::class)
   val context =
-    remember(screen, navigator, circuitConfig, parent) {
-      CircuitContext(parent).also { it.config = circuitConfig }
+    remember(screen, navigator, circuit, parent) {
+      CircuitContext(parent).also { it.config = circuit }
     }
   CompositionLocalProvider(LocalCircuitContext provides context) {
-    CircuitContent(screen, modifier, navigator, circuitConfig, unavailableContent, context)
+    CircuitContent(screen, modifier, navigator, circuit, unavailableContent, context)
   }
 }
 
@@ -82,13 +82,13 @@ internal fun CircuitContent(
   screen: Screen,
   modifier: Modifier,
   navigator: Navigator,
-  circuitConfig: CircuitConfig,
+  circuit: Circuit,
   unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit),
   context: CircuitContext,
 ) {
   val eventListener =
     remember(screen, context) {
-      (circuitConfig.eventListenerFactory?.create(screen, context) ?: EventListener.NONE).also {
+      (circuit.eventListenerFactory?.create(screen, context) ?: EventListener.NONE).also {
         it.start()
       }
     }
@@ -98,7 +98,7 @@ internal fun CircuitContent(
     remember(eventListener, screen, navigator, context) {
       eventListener.onBeforeCreatePresenter(screen, navigator, context)
       @Suppress("UNCHECKED_CAST")
-      (circuitConfig.presenter(screen, navigator, context) as Presenter<CircuitUiState>?).also {
+      (circuit.presenter(screen, navigator, context) as Presenter<CircuitUiState>?).also {
         eventListener.onAfterCreatePresenter(screen, navigator, it, context)
       }
     }
@@ -106,9 +106,7 @@ internal fun CircuitContent(
   val ui =
     remember(eventListener, screen, context) {
       eventListener.onBeforeCreateUi(screen, context)
-      circuitConfig.ui(screen, context).also { ui ->
-        eventListener.onAfterCreateUi(screen, ui, context)
-      }
+      circuit.ui(screen, context).also { ui -> eventListener.onAfterCreateUi(screen, ui, context) }
     }
 
   if (ui != null && presenter != null) {

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -34,11 +34,11 @@ public fun NavigableCircuitContent(
   navigator: Navigator,
   backstack: SaveableBackStack,
   modifier: Modifier = Modifier,
-  circuitConfig: CircuitConfig = requireNotNull(LocalCircuitConfig.current),
+  circuit: Circuit = requireNotNull(LocalCircuit.current),
   providedValues: Map<out BackStack.Record, ProvidedValues> = providedValuesForBackStack(backstack),
-  decoration: NavDecoration = circuitConfig.defaultNavDecoration,
+  decoration: NavDecoration = circuit.defaultNavDecoration,
   unavailableRoute: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
-    circuitConfig.onUnavailableContent,
+    circuit.onUnavailableContent,
 ) {
   val activeContentProviders = buildList {
     for (record in backstack) {
@@ -47,7 +47,7 @@ public fun NavigableCircuitContent(
           val screen = record.screen
 
           val currentContent: (@Composable (SaveableBackStack.Record) -> Unit) = {
-            CircuitContent(screen, navigator, modifier, circuitConfig, unavailableRoute)
+            CircuitContent(screen, navigator, modifier, circuit, unavailableRoute)
           }
 
           val currentRouteContent by rememberUpdatedState(currentContent)

--- a/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/EventListenerTest.kt
+++ b/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/EventListenerTest.kt
@@ -39,15 +39,15 @@ class EventListenerTest {
 
     val presenter = StringPresenter(state)
     val ui = StringUi()
-    val circuitConfig =
-      CircuitConfig.Builder()
+    val circuit =
+      Circuit.Builder()
         .addPresenterFactory { _, _, _ -> presenter }
         .addUiFactory { _, _ -> ui }
         .eventListenerFactory(eventListenerFactory)
         .build()
 
     backgroundScope.launchMolecule(Immediate) {
-      CircuitContent(circuitConfig = circuitConfig, screen = TestScreen)
+      CircuitContent(circuit = circuit, screen = TestScreen)
     }
     val (screen, listener) = eventListenerFactory.listeners.entries.first()
     assertThat(screen).isEqualTo(TestScreen)

--- a/circuit-runtime-presenter/src/commonMain/kotlin/com/slack/circuit/runtime/presenter/Presenter.kt
+++ b/circuit-runtime-presenter/src/commonMain/kotlin/com/slack/circuit/runtime/presenter/Presenter.kt
@@ -95,8 +95,8 @@ public interface Presenter<UiState : CircuitUiState> {
   @Composable public fun present(): UiState
 
   /**
-   * A factory that produces [presenters][Presenter] for a given [Screen]. `CircuitConfig` instances
-   * use the created presenter and connects it to a given `Ui` for the same [Screen].
+   * A factory that produces [presenters][Presenter] for a given [Screen]. `Circuit` instances use
+   * the created presenter and connects it to a given `Ui` for the same [Screen].
    *
    * Factories should be simple aggregate multiple presenters for a canonical "whole screen". That
    * is to say, they should be hand-written and aggregate all the presenters responsible for the UI

--- a/docs/circuit-content.md
+++ b/docs/circuit-content.md
@@ -1,10 +1,10 @@
 CircuitContent
 ==============
 
-The simplest entry point of a circuit is the composable `CircuitContent` function. This function accepts a `Screen` and automatically finds and pairs corresponding `Presenter` and `Ui` instances to render in it.
+The simplest entry point of a Circuit screen is the composable `CircuitContent` function. This function accepts a `Screen` and automatically finds and pairs corresponding `Presenter` and `Ui` instances to render in it.
 
 ```kotlin
-CircuitCompositionLocals(circuitConfig) {
+CircuitCompositionLocals(circuit) {
   CircuitContent(HomeScreen)
 }
 ```

--- a/docs/code-gen.md
+++ b/docs/code-gen.md
@@ -96,7 +96,7 @@ injection to types using Dagger `AssistedInject`. For these cases, the `Assisted
 Types available for assisted injection are:
 - `Screen` – the screen key used to create the `Presenter` or `Ui`.
 - `Navigator` – (presenters only)
-- `CircuitConfig`
+- `Circuit`
 
 Each should only be defined at-most once.
 

--- a/docs/factories.md
+++ b/docs/factories.md
@@ -1,10 +1,10 @@
 Factories
 =========
 
-At its core, Circuit works on the Factory pattern. Every `Presenter` and `Ui` is contributed to a `CircuitConfig` instance by a corresponding factory that creates them for given `Screen`s. These are intended to be aggregated in the DI layer and added to a `CircuitConfig` instance during construction.
+At its core, Circuit works on the Factory pattern. Every `Presenter` and `Ui` is contributed to a `Circuit` instance by a corresponding factory that creates them for given `Screen`s. These are intended to be aggregated in the DI layer and added to a `Circuit` instance during construction.
 
 ```kotlin
-val circuitConfig = CircuitConfig.Builder()
+val circuit = Circuit.Builder()
   .addUiFactory(FavoritesUiFactory())
   .addPresenterFactory(FavoritesPresenterFactory())
   .build()

--- a/docs/screen.md
+++ b/docs/screen.md
@@ -50,11 +50,11 @@ constructor(
 }
 ```
 
-Screens are also used to look up those corresponding components in `CircuitConfig`.
+Screens are also used to look up those corresponding components in `Circuit`.
 
 ```kotlin
-val presenter: Presenter<*>? = circuitconfig.presenter(addFavoritesScreen, navigator)
-val ui: Ui<*>? = circuitconfig.ui(addFavoritesScreen)
+val presenter: Presenter<*>? = circuit.presenter(addFavoritesScreen, navigator)
+val ui: Ui<*>? = circuit.ui(addFavoritesScreen)
 ```
 
 !!! tip "Nomenclature"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,10 +15,10 @@ dependencies {
 
 ## Setup
 
-Create a `CircuitConfig` instance. This controls all your common configuration, Presenter/Ui factories, etc.
+Create a `Circuit` instance. This controls all your common configuration, Presenter/Ui factories, etc.
 
 ```kotlin
-val circuitConfig = CircuitConfig.Builder()
+val circuit = Circuit.Builder()
   .addUiFactory(AddFavoritesUiFactory())
   .addPresenterFactory(AddFavoritesPresenterFactory())
   .build()
@@ -29,7 +29,7 @@ This configuration can be rebuilt via `newBuilder()` and usually would live in y
 Once you have a configuration ready, the simplest way to get going with Circuit is via `CircuitCompositionLocals`. This automatically exposes the config to all child Circuit composables and allows you to get off the ground quickly with `CircuitContent`, `NavigableCircuitContent`, etc.
 
 ```kotlin
-CircuitCompositionLocals(circuitConfig) {
+CircuitCompositionLocals(circuit) {
   CircuitContent(AddFavoritesScreen())
 }
 ```
@@ -45,7 +45,7 @@ Circuit is split into a few different artifacts to allow for more granular contr
 | `circuit-runtime`           | Common runtime components like `Screen`, `Navigator`, etc.                                             |
 | `circuit-runtime-presenter` | The `Presenter` API, depends on `circuit-runtime`.                                                     |
 | `circuit-runtime-ui`        | The `Ui` API, depends on `circuit-runtime`.                                                            |
-| `circuit-foundation`        | The circuit foundational APIs like `CircuitConfig`, `CircuitContent`, etc. Depends on the first three. |
+| `circuit-foundation`        | The circuit foundational APIs like `Circuit`, `CircuitContent`, etc. Depends on the first three. |
 
 ## Platform Support
 

--- a/samples/counter/apps/src/androidMain/kotlin/com/slack/circuit/sample/counter/android/CounterActivity.kt
+++ b/samples/counter/apps/src/androidMain/kotlin/com/slack/circuit/sample/counter/android/CounterActivity.kt
@@ -11,15 +11,15 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.ui.platform.LocalContext
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.sample.counter.CounterPresenterFactory
 
 class CounterActivity : AppCompatActivity() {
 
-  private val circuitConfig: CircuitConfig =
-    CircuitConfig.Builder()
+  private val circuit: Circuit =
+    Circuit.Builder()
       .addPresenterFactory(CounterPresenterFactory())
       .addUiFactory(CounterUiFactory())
       .build()
@@ -37,7 +37,7 @@ class CounterActivity : AppCompatActivity() {
       val systemUiController = rememberSystemUiController()
       systemUiController.setSystemBarsColor(color = colorScheme.primaryContainer)
       MaterialTheme(colorScheme = colorScheme) {
-        CircuitCompositionLocals(circuitConfig) { CircuitContent(AndroidCounterScreen) }
+        CircuitCompositionLocals(circuit) { CircuitContent(AndroidCounterScreen) }
       }
     }
   }

--- a/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
+++ b/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
 import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.push
 import com.slack.circuit.foundation.rememberCircuitNavigator
@@ -148,14 +148,14 @@ fun main() = application {
     val backStack = rememberSaveableBackStack { initialBackStack.forEach(::push) }
     val navigator = rememberCircuitNavigator(backStack, ::exitApplication)
 
-    val circuitConfig: CircuitConfig =
-      CircuitConfig.Builder()
+    val circuit: Circuit =
+      Circuit.Builder()
         .addPresenterFactory(CounterPresenterFactory())
         .addUiFactory(CounterUiFactory())
         .build()
 
     MaterialTheme {
-      CircuitCompositionLocals(circuitConfig) { NavigableCircuitContent(navigator, backStack) }
+      CircuitCompositionLocals(circuit) { NavigableCircuitContent(navigator, backStack) }
     }
   }
 }

--- a/samples/counter/mosaic/src/commonMain/kotlin/com/slack/circuit/sample/counter/mosaic/MosaicCounter.kt
+++ b/samples/counter/mosaic/src/commonMain/kotlin/com/slack/circuit/sample/counter/mosaic/MosaicCounter.kt
@@ -11,8 +11,8 @@ import com.jakewharton.mosaic.MosaicScope
 import com.jakewharton.mosaic.runMosaic
 import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Text
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Screen
@@ -86,12 +86,12 @@ internal suspend fun runCounterScreen(useCircuit: Boolean) = runMosaic {
 
 internal fun MosaicScope.runCircuitCounterScreen() {
   setContent {
-    val circuitConfig =
-      CircuitConfig.Builder()
+    val circuit =
+      Circuit.Builder()
         .addPresenterFactory(CounterPresenterFactory())
         .addUiFactory(CounterUiFactory())
         .build()
-    CircuitCompositionLocals(circuitConfig) { CircuitContent(MosaicCounterScreen) }
+    CircuitCompositionLocals(circuit) { CircuitContent(MosaicCounterScreen) }
   }
 }
 

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
@@ -51,8 +51,8 @@ class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val circuitConfig =
-      CircuitConfig.Builder()
+    val circuit =
+      Circuit.Builder()
         .addPresenterFactory { screen, _, context ->
           when (screen) {
             is InteropCounterScreen -> screen.presenterSource.createPresenter(screen, context)
@@ -68,7 +68,7 @@ class MainActivity : AppCompatActivity() {
         .build()
 
     setContent {
-      CircuitCompositionLocals(circuitConfig) {
+      CircuitCompositionLocals(circuit) {
         var selectedPresenterIndex by remember { mutableStateOf(0) }
         var selectedUiIndex by remember { mutableStateOf(0) }
         val circuitScreen =

--- a/samples/star/src/androidTest/kotlin/com/slack/circuit/star/petdetail/PetDetailTest.kt
+++ b/samples/star/src/androidTest/kotlin/com/slack/circuit/star/petdetail/PetDetailTest.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
 import coil.annotation.ExperimentalCoilApi
 import com.google.common.truth.Truth.assertThat
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.sample.coil.test.CoilRule
 import com.slack.circuit.star.R
 import com.slack.circuit.star.petdetail.PetDetailTestConstants.ANIMAL_CONTAINER_TAG
@@ -76,8 +76,8 @@ class PetDetailTest {
       )
 
     var carouselScreen: PetPhotoCarouselScreen? = null
-    val circuitConfig =
-      CircuitConfig.Builder()
+    val circuit =
+      Circuit.Builder()
         .setOnUnavailableContent { screen, modifier ->
           carouselScreen = screen as PetPhotoCarouselScreen
           PetPhotoCarousel(PetPhotoCarouselScreen.State(screen), modifier)
@@ -92,7 +92,7 @@ class PetDetailTest {
       )
 
     composeTestRule.run {
-      setContent { CircuitCompositionLocals(circuitConfig) { PetDetail(success) } }
+      setContent { CircuitCompositionLocals(circuit) { PetDetail(success) } }
 
       onNodeWithTag(PROGRESS_TAG).assertDoesNotExist()
       onNodeWithTag(UNKNOWN_ANIMAL_TAG).assertDoesNotExist()
@@ -123,15 +123,15 @@ class PetDetailTest {
         eventSink = testSink
       )
 
-    val circuitConfig =
-      CircuitConfig.Builder()
+    val circuit =
+      Circuit.Builder()
         .setOnUnavailableContent { screen, modifier ->
           PetPhotoCarousel(PetPhotoCarouselScreen.State(screen as PetPhotoCarouselScreen), modifier)
         }
         .build()
 
     composeTestRule.run {
-      setContent { CircuitCompositionLocals(circuitConfig) { PetDetail(success) } }
+      setContent { CircuitCompositionLocals(circuit) { PetDetail(success) } }
 
       onNodeWithTag(CAROUSEL_TAG).assertIsDisplayed().performTouchInput { swipeUp() }
       onNodeWithTag(FULL_BIO_TAG, true).assertIsDisplayed().performClick()

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -19,8 +19,8 @@ import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.push
 import com.slack.circuit.foundation.rememberCircuitNavigator
@@ -42,8 +42,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 
 @ContributesMultibinding(AppScope::class, boundType = Activity::class)
 @ActivityKey(MainActivity::class)
-class MainActivity @Inject constructor(private val circuitConfig: CircuitConfig) :
-  AppCompatActivity() {
+class MainActivity @Inject constructor(private val circuit: Circuit) : AppCompatActivity() {
 
   @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -70,7 +69,7 @@ class MainActivity @Inject constructor(private val circuitConfig: CircuitConfig)
           CompositionLocalProvider(
             LocalWindowWidthSizeClass provides windowSizeClass.widthSizeClass
           ) {
-            CircuitCompositionLocals(circuitConfig) {
+            CircuitCompositionLocals(circuit) {
               ContentWithOverlays { NavigableCircuitContent(navigator, backstack) }
             }
           }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/di/CircuitModule.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/di/CircuitModule.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.star.di
 
-import com.slack.circuit.foundation.CircuitConfig
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.star.imageviewer.ImageViewerAwareNavDecoration
@@ -23,8 +23,8 @@ interface CircuitModule {
     fun provideCircuit(
       presenterFactories: @JvmSuppressWildcards Set<Presenter.Factory>,
       uiFactories: @JvmSuppressWildcards Set<Ui.Factory>,
-    ): CircuitConfig {
-      return CircuitConfig.Builder()
+    ): Circuit {
+      return Circuit.Builder()
         .addPresenterFactories(presenterFactories)
         .addUiFactories(uiFactories)
         .setDefaultNavDecoration(ImageViewerAwareNavDecoration)

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/petdetail/PetDetailUiTest.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/petdetail/PetDetailUiTest.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.test.swipeUp
 import androidx.test.platform.app.InstrumentationRegistry
 import coil.annotation.ExperimentalCoilApi
 import com.google.common.truth.Truth.assertThat
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.sample.coil.test.CoilRule
 import com.slack.circuit.star.R
@@ -40,8 +40,8 @@ class PetDetailUiTest {
   // TODO this seems like not the greatest test pattern, maybe something we can offer better
   //  solutions for via semantics.
   private var carouselScreen: PetPhotoCarouselScreen? = null
-  private val circuitConfig =
-    CircuitConfig.Builder()
+  private val circuit =
+    Circuit.Builder()
       .setOnUnavailableContent { screen, modifier ->
         when (screen) {
           is PetPhotoCarouselScreen -> {
@@ -55,9 +55,7 @@ class PetDetailUiTest {
   @Test
   fun petDetail_show_progress_indicator_for_loading_state() {
     composeTestRule.run {
-      setContent {
-        CircuitCompositionLocals(circuitConfig) { PetDetail(PetDetailScreen.State.Loading) }
-      }
+      setContent { CircuitCompositionLocals(circuit) { PetDetail(PetDetailScreen.State.Loading) } }
 
       onNodeWithTag(PROGRESS_TAG).assertIsDisplayed()
       onNodeWithTag(UNKNOWN_ANIMAL_TAG).assertDoesNotExist()
@@ -69,7 +67,7 @@ class PetDetailUiTest {
   fun petDetail_show_message_for_unknown_animal_state() {
     composeTestRule.run {
       setContent {
-        CircuitCompositionLocals(circuitConfig) { PetDetail(PetDetailScreen.State.UnknownAnimal) }
+        CircuitCompositionLocals(circuit) { PetDetail(PetDetailScreen.State.UnknownAnimal) }
       }
 
       onNodeWithTag(PROGRESS_TAG).assertDoesNotExist()
@@ -107,7 +105,7 @@ class PetDetailUiTest {
 
     composeTestRule.run {
       setContent {
-        CircuitCompositionLocals(circuitConfig) { ContentWithOverlays { PetDetail(success) } }
+        CircuitCompositionLocals(circuit) { ContentWithOverlays { PetDetail(success) } }
       }
 
       onNodeWithTag(PROGRESS_TAG).assertDoesNotExist()
@@ -139,8 +137,8 @@ class PetDetailUiTest {
         eventSink = testSink
       )
 
-    val circuitConfig =
-      CircuitConfig.Builder()
+    val circuit =
+      Circuit.Builder()
         .setOnUnavailableContent { screen, modifier ->
           PetPhotoCarousel(PetPhotoCarouselScreen.State(screen as PetPhotoCarouselScreen), modifier)
         }
@@ -148,7 +146,7 @@ class PetDetailUiTest {
 
     composeTestRule.run {
       setContent {
-        CircuitCompositionLocals(circuitConfig) { ContentWithOverlays { PetDetail(success) } }
+        CircuitCompositionLocals(circuit) { ContentWithOverlays { PetDetail(success) } }
       }
 
       onNodeWithTag(CAROUSEL_TAG).assertIsDisplayed().performTouchInput { swipeUp() }

--- a/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/MainActivity.kt
+++ b/samples/tacos/src/main/kotlin/com/slack/circuit/tacos/MainActivity.kt
@@ -7,8 +7,8 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
@@ -24,8 +24,8 @@ class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val circuitConfig: CircuitConfig =
-      CircuitConfig.Builder()
+    val circuit: Circuit =
+      Circuit.Builder()
         .addPresenterFactory(buildPresenterFactory())
         .addUiFactory(buildUiFactory())
         .build()
@@ -33,7 +33,7 @@ class MainActivity : AppCompatActivity() {
     setContent {
       TacoTheme {
         rememberSystemUiController().setStatusBarColor(MaterialTheme.colorScheme.background)
-        CircuitCompositionLocals(circuitConfig) { CircuitContent(OrderTacosScreen) }
+        CircuitCompositionLocals(circuit) { CircuitContent(OrderTacosScreen) }
       }
     }
   }


### PR DESCRIPTION
We initially did this but moved to `CircuitConfig` due to thinking we wanted to call individual screens "circuits". We no longer do this (they're "screens"), so now we're going back to this.