### PR TITLE
Demonstrate back handling for Compose Multiplatform

### DIFF
--- a/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
+++ b/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
@@ -17,10 +17,19 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
@@ -156,7 +165,32 @@ fun main() = application {
         .build()
 
     MaterialTheme {
-      CircuitCompositionLocals(circuit) { NavigableCircuitContent(navigator, backStack) }
+      CircuitCompositionLocals(circuit) {
+        NavigableCircuitContent(
+          navigator = navigator,
+          backstack = backStack,
+          modifier =
+            Modifier.backHandler(
+              enabled = backStack.size > 1,
+              onBack = { navigator.pop() },
+            )
+        )
+      }
     }
   }
+}
+
+@Composable
+private fun Modifier.backHandler(enabled: Boolean, onBack: () -> Unit): Modifier {
+  val focusRequester = remember { FocusRequester() }
+  return focusRequester(focusRequester)
+    .onPlaced { focusRequester.requestFocus() }
+    .onPreviewKeyEvent {
+      if (enabled && it.type == KeyEventType.KeyDown && it.key == Key.Escape) {
+        onBack()
+        true
+      } else {
+        false
+      }
+    }
 }


### PR DESCRIPTION
This change demonstrates the necessary behaviour to implement back handling on Compose Multiplatform (Desktop).

The provided `Modifier` is applied to each screen, thus requires focus to be requested on placement in order to capture key events.

Supersedes #491 