### PR TITLE
Use the default target hierarchy for source sets

### DIFF
--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -30,14 +34,14 @@ kotlin {
         implementation(libs.compose.runtime.saveable)
       }
     }
-    maybeCreate("androidMain").apply {
+    val androidMain by getting {
       dependencies {
         implementation(libs.androidx.lifecycle.viewModel.compose)
         api(libs.androidx.lifecycle.viewModel)
         api(libs.androidx.compose.runtime)
       }
     }
-    maybeCreate("commonTest").apply { dependencies { implementation(libs.kotlin.test) } }
+    val commonTest by getting { dependencies { implementation(libs.kotlin.test) } }
     val commonJvmTest =
       maybeCreate("commonJvmTest").apply {
         dependencies {
@@ -45,9 +49,7 @@ kotlin {
           implementation(libs.truth)
         }
       }
-    maybeCreate("jvmTest").apply { dependsOn(commonJvmTest) }
-    val iosMain by getting
-    val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+    val jvmTest by getting { dependsOn(commonJvmTest) }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -403,9 +403,13 @@ subprojects {
     // Enforce Kotlin BOM
     configure<KotlinMultiplatformExtension> {
       sourceSets {
-        maybeCreate("commonMain").dependencies {
-          // KGP doesn't support catalogs https://youtrack.jetbrains.com/issue/KT-55351
-          implementation(platform("org.jetbrains.kotlin:kotlin-bom:${libs.versions.kotlin.get()}"))
+        val commonMain by getting {
+          dependencies {
+            // KGP doesn't support catalogs https://youtrack.jetbrains.com/issue/KT-55351
+            implementation(
+              platform("org.jetbrains.kotlin:kotlin-bom:${libs.versions.kotlin.get()}")
+            )
+          }
         }
       }
     }

--- a/circuit-codegen-annotations/build.gradle.kts
+++ b/circuit-codegen-annotations/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
@@ -12,6 +14,8 @@ kotlin {
   jvm()
   // Anvil/Dagger does not support iOS targets
   // endregion
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
 
   sourceSets {
     commonMain {
@@ -28,8 +32,8 @@ kotlin {
           api(libs.dagger)
         }
       }
-    maybeCreate("androidMain").apply { dependsOn(commonJvm) }
-    maybeCreate("jvmMain").apply { dependsOn(commonJvm) }
+    val androidMain by getting { dependsOn(commonJvm) }
+    val jvmMain by getting { dependsOn(commonJvm) }
   }
 }
 

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -1,5 +1,6 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -23,6 +24,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -36,14 +39,14 @@ kotlin {
         api(libs.compose.ui)
       }
     }
-    maybeCreate("androidMain").apply {
+    val androidMain by getting {
       dependencies {
         api(libs.androidx.compose.runtime)
         api(libs.androidx.compose.animation)
         implementation(libs.androidx.compose.integration.activity)
       }
     }
-    maybeCreate("commonTest").apply {
+    val commonTest by getting {
       dependencies {
         implementation(libs.kotlin.test)
         implementation(libs.molecule.runtime)
@@ -58,8 +61,8 @@ kotlin {
           implementation(libs.truth)
         }
       }
-    maybeCreate("jvmTest").apply { dependsOn(commonJvmTest) }
-    maybeCreate("androidUnitTest").apply {
+    val jvmTest by getting { dependsOn(commonJvmTest) }
+    val androidUnitTest by getting {
       dependsOn(commonJvmTest)
       dependencies {
         implementation(libs.robolectric)
@@ -68,8 +71,6 @@ kotlin {
         implementation(libs.androidx.compose.ui.testing.manifest)
       }
     }
-    val iosMain by getting
-    val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
   }
 }
 

--- a/circuit-overlay/build.gradle.kts
+++ b/circuit-overlay/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -28,7 +32,7 @@ kotlin {
         implementation(libs.coroutines)
       }
     }
-    maybeCreate("commonTest").apply {
+    val commonTest by getting {
       dependencies {
         implementation(libs.kotlin.test)
         implementation(libs.molecule.runtime)
@@ -43,7 +47,7 @@ kotlin {
           implementation(libs.truth)
         }
       }
-    maybeCreate("jvmTest").apply { dependsOn(commonJvmTest) }
+    val jvmTest by getting { dependsOn(commonJvmTest) }
   }
 }
 

--- a/circuit-retained/build.gradle.kts
+++ b/circuit-retained/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -27,16 +31,18 @@ kotlin {
         api(libs.coroutines)
       }
     }
-    val androidMain =
-      maybeCreate("androidMain").apply {
-        dependencies {
-          api(libs.androidx.lifecycle.viewModel.compose)
-          api(libs.androidx.lifecycle.viewModel)
-          api(libs.androidx.compose.runtime)
-          implementation(libs.androidx.compose.ui.ui)
-        }
+
+    val androidMain by getting {
+      dependencies {
+        api(libs.androidx.lifecycle.viewModel.compose)
+        api(libs.androidx.lifecycle.viewModel)
+        api(libs.androidx.compose.runtime)
+        implementation(libs.androidx.compose.ui.ui)
       }
-    maybeCreate("commonTest").apply { dependencies { implementation(libs.kotlin.test) } }
+    }
+
+    val commonTest by getting { dependencies { implementation(libs.kotlin.test) } }
+
     val commonJvmTest =
       maybeCreate("commonJvmTest").apply {
         dependencies {
@@ -44,11 +50,13 @@ kotlin {
           implementation(libs.truth)
         }
       }
-    maybeCreate("jvmTest").apply { dependsOn(commonJvmTest) }
+
+    val jvmTest by getting { dependsOn(commonJvmTest) }
+
     // TODO export this in Android too when it's supported in kotlin projects
-    maybeCreate("jvmMain").apply { dependencies.add("testFixturesApi", projects.circuitTest) }
-    maybeCreate("androidInstrumentedTest").apply {
-      dependsOn(androidMain)
+    val jvmMain by getting { dependencies.add("testFixturesApi", projects.circuitTest) }
+
+    val androidInstrumentedTest by getting {
       dependsOn(commonJvmTest)
       dependencies {
         implementation(libs.coroutines)
@@ -64,8 +72,6 @@ kotlin {
         implementation(libs.truth)
       }
     }
-    val iosMain by getting
-    val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
   }
 }
 

--- a/circuit-runtime/build.gradle.kts
+++ b/circuit-runtime/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -27,8 +31,6 @@ kotlin {
         api(libs.coroutines)
       }
     }
-    val iosMain by getting
-    val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
   }
 }
 

--- a/circuit-test/build.gradle.kts
+++ b/circuit-test/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
@@ -19,6 +21,8 @@ kotlin {
     nodejs()
   }
   // endregion
+
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
 
   sourceSets {
     commonMain {
@@ -40,9 +44,7 @@ kotlin {
         implementation(libs.testing.testParameterInjector)
       }
     }
-    with(getByName("androidUnitTest")) { dependsOn(jvmTest) }
-    val iosMain by getting
-    val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+    val androidUnitTest by getting { dependsOn(jvmTest) }
   }
 }
 

--- a/circuitx/overlays/build.gradle.kts
+++ b/circuitx/overlays/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
@@ -19,6 +21,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -30,15 +34,12 @@ kotlin {
       }
     }
 
-    with(getByName("androidMain")) {
+    val androidMain by getting {
       dependencies {
         api(libs.androidx.compose.material.material3)
         implementation(libs.androidx.compose.accompanist.systemUi)
       }
     }
-
-    val iosMain by getting
-    val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
   }
 }
 

--- a/samples/counter/apps/build.gradle.kts
+++ b/samples/counter/apps/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.compose)
@@ -35,6 +37,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -43,9 +47,9 @@ kotlin {
         api(projects.circuitFoundation)
       }
     }
-    maybeCreate("commonTest").apply { dependencies { implementation(libs.kotlin.test) } }
-    maybeCreate("jvmMain").apply { dependencies { implementation(compose.desktop.currentOs) } }
-    maybeCreate("androidMain").apply {
+    val commonTest by getting { dependencies { implementation(libs.kotlin.test) } }
+    val jvmMain by getting { dependencies { implementation(compose.desktop.currentOs) } }
+    val androidMain by getting {
       dependencies {
         implementation(libs.androidx.appCompat)
         implementation(libs.bundles.compose.ui)
@@ -56,7 +60,7 @@ kotlin {
         implementation(libs.androidx.compose.accompanist.systemUi)
       }
     }
-    maybeCreate("jsMain").apply {
+    val jsMain by getting {
       dependencies {
         @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
         implementation(compose.components.resources)

--- a/samples/counter/build.gradle.kts
+++ b/samples/counter/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.compose)
@@ -39,6 +41,8 @@ kotlin {
   }
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -48,11 +52,9 @@ kotlin {
         implementation(libs.molecule.runtime)
       }
     }
-    maybeCreate("commonTest").apply { dependencies { implementation(libs.kotlin.test) } }
+    val commonTest by getting { dependencies { implementation(libs.kotlin.test) } }
     val iosMain by sourceSets.getting { dependencies { api(libs.coroutines) } }
     val iosSimulatorArm64Main by sourceSets.getting
-    // Set up dependencies between the source sets
-    iosSimulatorArm64Main.dependsOn(iosMain)
 
     configureEach { languageSettings.optIn("kotlin.experimental.ExperimentalObjCName") }
   }

--- a/samples/counter/mosaic/build.gradle.kts
+++ b/samples/counter/mosaic/build.gradle.kts
@@ -1,5 +1,6 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 plugins {
@@ -18,6 +19,8 @@ kotlin {
   jvm()
   // endregion
 
+  @OptIn(ExperimentalKotlinGradlePluginApi::class) targetHierarchy.default()
+
   sourceSets {
     commonMain {
       dependencies {
@@ -26,7 +29,7 @@ kotlin {
       }
     }
     // TODO is there a multiplatform way to do this?
-    maybeCreate("jvmMain").apply { dependencies { implementation(libs.jline) } }
+    val jvmMain by getting { dependencies { implementation(libs.jline) } }
   }
 
   targets.withType<KotlinJvmTarget> {


### PR DESCRIPTION
See https://kotlinlang.org/docs/multiplatform-hierarchy.html#default-hierarchy

This drastically simplifies all of the source sets management required for KMP, and means that you only need to 'declare' source sets if you're mutating them (adding deps, etc).