### PR TITLE
Duplicated modifier for decorated content

### DIFF
--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -47,7 +47,12 @@ public fun NavigableCircuitContent(
           val screen = record.screen
 
           val currentContent: (@Composable (SaveableBackStack.Record) -> Unit) = {
-            CircuitContent(screen, navigator, modifier, circuit, unavailableRoute)
+            CircuitContent(
+              screen = screen,
+              navigator = navigator,
+              circuit = circuit,
+              unavailableContent = unavailableRoute,
+            )
           }
 
           val currentRouteContent by rememberUpdatedState(currentContent)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -60,11 +60,8 @@ public fun NavigableCircuitContent(
 
   if (backstack.size > 0) {
     @Suppress("SpreadOperator")
-    decoration.DecoratedContent(
-      arg = activeContentProviders.first(),
-      backStackDepth = backstack.size,
-      modifier = Modifier,
-    ) { (record, provider) ->
+    decoration.DecoratedContent(activeContentProviders.first(), backstack.size, modifier) {
+      (record, provider) ->
       val values = providedValues[record]?.provideValues()
       val providedLocals = remember(values) { values?.toTypedArray() ?: emptyArray() }
       CompositionLocalProvider(*providedLocals) { provider() }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -60,8 +60,11 @@ public fun NavigableCircuitContent(
 
   if (backstack.size > 0) {
     @Suppress("SpreadOperator")
-    decoration.DecoratedContent(activeContentProviders.first(), backstack.size, modifier) {
-      (record, provider) ->
+    decoration.DecoratedContent(
+      arg = activeContentProviders.first(),
+      backStackDepth = backstack.size,
+      modifier = Modifier,
+    ) { (record, provider) ->
       val values = providedValues[record]?.provideValues()
       val providedLocals = remember(values) { values?.toTypedArray() ?: emptyArray() }
       CompositionLocalProvider(*providedLocals) { provider() }


### PR DESCRIPTION
Decorated content probably shouldn't take the user supplied modifier, as this will result in the modifier being applied twice (once to `Layout` in decorated `AnimatedVisibility.Layout` and again in the user supplied content)