### PR TITLE
Make CanRetainChecker API more customizable

### DIFF
--- a/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
@@ -239,7 +239,8 @@ class RetainedTest {
     scenario.onActivity { activity ->
       activity.setContent {
         CompositionLocalProvider(
-          LocalRetainedStateRegistry provides continuityRetainedStateRegistry(vmFactory),
+          LocalRetainedStateRegistry provides
+            continuityRetainedStateRegistry(Continuity.KEY, vmFactory)
         ) {
           content()
         }

--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
@@ -60,17 +60,19 @@ internal class Continuity : ViewModel(), RetainedStateRegistry {
 /**
  * Provides a [RetainedStateRegistry].
  *
+ * @param key the key to use when creating the [Continuity] instance.
  * @param factory an optional [ViewModelProvider.Factory] to use when creating the [Continuity]
  *   instance.
+ * @param canRetainChecker an optional [CanRetainChecker] to use when determining whether to retain.
  */
 @Composable
 public fun continuityRetainedStateRegistry(
   key: String = Continuity.KEY,
   factory: ViewModelProvider.Factory = Continuity.Factory,
+  canRetainChecker: CanRetainChecker = LocalCanRetainChecker.current ?: rememberCanRetainChecker()
 ): RetainedStateRegistry {
   val vm = viewModel<Continuity>(key = key, factory = factory)
-  val canRetain = rememberCanRetainChecker()
-  remember(canRetain) {
+  remember(canRetainChecker) {
     object : RememberObserver {
       override fun onAbandoned() = unregisterIfNotRetainable()
 
@@ -81,7 +83,7 @@ public fun continuityRetainedStateRegistry(
       }
 
       fun unregisterIfNotRetainable() {
-        if (canRetain()) {
+        if (canRetainChecker.canRetain()) {
           vm.performSave()
         }
       }

--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/CanRetainChecker.android.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/CanRetainChecker.android.kt
@@ -11,10 +11,10 @@ import androidx.compose.ui.platform.LocalContext
 
 /** On Android, we retain only if the activity is changing configurations. */
 @Composable
-internal actual fun rememberCanRetainChecker(): () -> Boolean {
+public actual fun rememberCanRetainChecker(): CanRetainChecker {
   val context = LocalContext.current
   val activity = remember(context) { context.findActivity() }
-  return remember { { activity?.isChangingConfigurations == true } }
+  return remember { CanRetainChecker { activity?.isChangingConfigurations == true } }
 }
 
 private fun Context.findActivity(): Activity? {

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CanRetainChecker.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CanRetainChecker.kt
@@ -3,6 +3,19 @@
 package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
 
-/** Checks whether or not we can retain in the current composable context. */
-@Composable internal expect fun rememberCanRetainChecker(): () -> Boolean
+/** Checks whether or not we can retain, usually derived from the current composable context. */
+@Stable
+public fun interface CanRetainChecker {
+  public fun canRetain(): Boolean
+}
+
+public val LocalCanRetainChecker: ProvidableCompositionLocal<CanRetainChecker?> =
+  staticCompositionLocalOf {
+    null
+  }
+
+@Composable public expect fun rememberCanRetainChecker(): CanRetainChecker

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -99,7 +99,7 @@ public fun <T : Any> rememberRetained(vararg inputs: Any?, key: String? = null, 
   // the different order. so we use rememberUpdatedState.
   val valueState = rememberUpdatedState(value)
 
-  val canRetain = rememberCanRetainChecker()
+  val canRetainChecker = LocalCanRetainChecker.current ?: rememberCanRetainChecker()
   remember(registry, finalKey) {
     val entry = registry.registerValue(finalKey) { valueState.value }
     object : RememberObserver {
@@ -112,7 +112,7 @@ public fun <T : Any> rememberRetained(vararg inputs: Any?, key: String? = null, 
       }
 
       fun unregisterIfNotRetainable() {
-        if (!canRetain()) {
+        if (!canRetainChecker.canRetain()) {
           entry.unregister()
         }
       }

--- a/circuit-retained/src/iosMain/kotlin/com/slack/circuit/retained/CanRetainChecker.ios.kt
+++ b/circuit-retained/src/iosMain/kotlin/com/slack/circuit/retained/CanRetainChecker.ios.kt
@@ -7,6 +7,6 @@ import androidx.compose.runtime.remember
 
 /** Checks whether or not we can retain in the current composable context. */
 @Composable
-internal actual fun rememberCanRetainChecker(): () -> Boolean {
-  return remember { { false } }
+public actual fun rememberCanRetainChecker(): CanRetainChecker {
+  return remember { CanRetainChecker { false } }
 }

--- a/circuit-retained/src/jsMain/kotlin/com/slack/circuit/retained/CanRetainChecker.js.kt
+++ b/circuit-retained/src/jsMain/kotlin/com/slack/circuit/retained/CanRetainChecker.js.kt
@@ -7,6 +7,6 @@ import androidx.compose.runtime.remember
 
 /** Checks whether or not we can retain in the current composable context. */
 @Composable
-internal actual fun rememberCanRetainChecker(): () -> Boolean {
-  return remember { { false } }
+public actual fun rememberCanRetainChecker(): CanRetainChecker {
+  return remember { CanRetainChecker { false } }
 }

--- a/circuit-retained/src/jvmMain/kotlin/com/slack/circuit/retained/CanRetainChecker.jvm.kt
+++ b/circuit-retained/src/jvmMain/kotlin/com/slack/circuit/retained/CanRetainChecker.jvm.kt
@@ -5,8 +5,8 @@ package com.slack.circuit.retained
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 
-/** No-op on the JVM! */
+/** Checks whether or not we can retain in the current composable context. */
 @Composable
-internal actual fun rememberCanRetainChecker(): () -> Boolean {
-  return remember { { false } }
+public actual fun rememberCanRetainChecker(): CanRetainChecker {
+  return remember { CanRetainChecker { false } }
 }


### PR DESCRIPTION
This opens up the `canRetain` API within circuit-retained a bit more to allow some external users easier prototyping for #826.

Two primary changes:
- Expose a top-level `CanRetainChecker` fun interface and expose it as an input on `continuityRetainedStateRegistry`.
- Expose a `LocalCanRetainChecker` composition local that is given priority (if present) in places that normally just used `rememberCanRetainChecker()` before.

CC @chrisbanes 