### PR TITLE
Upstream some navigation improvements from Tivi

### DIFF
--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
         api(libs.compose.runtime)
         api(libs.compose.ui)
         api(libs.coroutines)
+        api(libs.kotlinx.immutable)
         api(projects.circuitRuntimeScreen)
         implementation(libs.compose.runtime.saveable)
         implementation(libs.uuid)

--- a/backstack/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/backstack/dependencies/androidReleaseRuntimeClasspath.txt
@@ -55,6 +55,8 @@ org.jetbrains.kotlin:kotlin-bom
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm

--- a/backstack/dependencies/jvmRuntimeClasspath.txt
+++ b/backstack/dependencies/jvmRuntimeClasspath.txt
@@ -22,6 +22,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
 org.jetbrains.kotlinx:atomicfu-jvm
 org.jetbrains.kotlinx:atomicfu
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm
 org.jetbrains.kotlinx:kotlinx-coroutines-core

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableStateRegistryBackStackRecordLocalProvider.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/SaveableStateRegistryBackStackRecordLocalProvider.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 /** A [BackStackRecordLocalProvider] that provides a [SaveableStateRegistry] for each record. */
 public object SaveableStateRegistryBackStackRecordLocalProvider :
@@ -46,10 +48,10 @@ public object SaveableStateRegistryBackStackRecordLocalProvider :
     childRegistry.parentRegistry = LocalSaveableStateRegistry.current
     return remember(childRegistry) {
       object : ProvidedValues {
-        val list = listOf(LocalSaveableStateRegistry provides childRegistry)
+        val list = persistentListOf(LocalSaveableStateRegistry provides childRegistry)
 
         @Composable
-        override fun provideValues(): List<ProvidedValue<*>> {
+        override fun provideValues(): ImmutableList<ProvidedValue<*>> {
           remember {
             object : RememberObserver {
               override fun onForgotten() {

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/ViewModelBackStackRecordLocalProvider.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/ViewModelBackStackRecordLocalProvider.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.collections.immutable.persistentListOf
 
 private fun Context.findActivity(): Activity? {
   var context = this
@@ -76,7 +77,7 @@ internal object ViewModelBackStackRecordLocalProvider :
     }
     return remember(viewModelStore) {
       val list =
-        listOf<ProvidedValue<*>>(
+        persistentListOf<ProvidedValue<*>>(
           LocalViewModelStoreOwner provides
             object : ViewModelStoreOwner {
               override val viewModelStore: ViewModelStore = viewModelStore

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/Navigation.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/Navigation.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Modifier
 public interface NavDecoration {
   @Composable
   public fun <T> DecoratedContent(
-    arg: T,
+    args: List<T>,
     backStackDepth: Int,
     modifier: Modifier,
     content: @Composable (T) -> Unit

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/Navigation.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/Navigation.kt
@@ -18,13 +18,14 @@ package com.slack.circuit.backstack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
+import kotlinx.collections.immutable.ImmutableList
 
 /** Presentation logic for currently visible routes of a navigable UI. */
 @Stable
 public interface NavDecoration {
   @Composable
   public fun <T> DecoratedContent(
-    args: List<T>,
+    args: ImmutableList<T>,
     backStackDepth: Int,
     modifier: Modifier,
     content: @Composable (T) -> Unit

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
       dependencies {
         api(libs.compose.runtime)
         api(libs.compose.foundation)
+        api(libs.kotlinx.immutable)
         api(libs.coroutines)
         api(projects.backstack)
         api(projects.circuitRuntime)

--- a/circuit-foundation/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuit-foundation/dependencies/androidReleaseRuntimeClasspath.txt
@@ -65,6 +65,8 @@ org.jetbrains.kotlin:kotlin-bom
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm

--- a/circuit-foundation/dependencies/jvmRuntimeClasspath.txt
+++ b/circuit-foundation/dependencies/jvmRuntimeClasspath.txt
@@ -30,6 +30,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
 org.jetbrains.kotlinx:atomicfu-jvm
 org.jetbrains.kotlinx:atomicfu
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm
 org.jetbrains.kotlinx:kotlinx-coroutines-core

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -3,7 +3,6 @@
 package com.slack.circuit.foundation
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -15,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,7 +48,7 @@ public fun NavigableCircuitContent(
 
   if (backstack.size > 0) {
     @Suppress("SpreadOperator")
-    decoration.DecoratedContent(activeContentProviders.first(), backstack.size, modifier) {
+    decoration.DecoratedContent(activeContentProviders, backstack.size, modifier) {
       (record, provider) ->
       val values = providedValues[record]?.provideValues()
       val providedLocals = remember(values) { values?.toTypedArray() ?: emptyArray() }
@@ -117,10 +115,9 @@ public object NavigatorDefaults {
 
   /** The default [NavDecoration] used in navigation. */
   public object DefaultDecoration : NavDecoration {
-    @OptIn(ExperimentalAnimationApi::class)
     @Composable
     override fun <T> DecoratedContent(
-      arg: T,
+      args: List<T>,
       backStackDepth: Int,
       modifier: Modifier,
       content: @Composable (T) -> Unit
@@ -130,7 +127,7 @@ public object NavigatorDefaults {
       val diff = backStackDepth - prevStackDepth.value
       prevStackDepth.value = backStackDepth
       AnimatedContent(
-        targetState = arg,
+        targetState = args,
         modifier = modifier,
         transitionSpec = {
           // Mirror the forward and backward transitions of activities in Android 33
@@ -154,7 +151,7 @@ public object NavigatorDefaults {
           )
         },
       ) {
-        content(it)
+        content(it.first())
       }
     }
   }
@@ -163,12 +160,12 @@ public object NavigatorDefaults {
   public object EmptyDecoration : NavDecoration {
     @Composable
     override fun <T> DecoratedContent(
-      arg: T,
+      args: List<T>,
       backStackDepth: Int,
       modifier: Modifier,
       content: @Composable (T) -> Unit
     ) {
-      content(arg)
+      content(args.first())
     }
   }
 }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -27,6 +27,9 @@ import com.slack.circuit.backstack.ProvidedValues
 import com.slack.circuit.backstack.providedValuesForBackStack
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 public fun NavigableCircuitContent(
@@ -34,7 +37,7 @@ public fun NavigableCircuitContent(
   backstack: BackStack<out Record>,
   modifier: Modifier = Modifier,
   circuit: Circuit = requireNotNull(LocalCircuit.current),
-  providedValues: Map<out Record, ProvidedValues> = providedValuesForBackStack(backstack),
+  providedValues: ImmutableMap<out Record, ProvidedValues> = providedValuesForBackStack(backstack),
   decoration: NavDecoration = circuit.defaultNavDecoration,
   unavailableRoute: (@Composable (screen: Screen, modifier: Modifier) -> Unit) =
     circuit.onUnavailableContent,
@@ -68,7 +71,7 @@ private fun BackStack<out Record>.buildCircuitContentProviders(
   navigator: Navigator,
   circuit: Circuit,
   unavailableRoute: @Composable (screen: Screen, modifier: Modifier) -> Unit,
-): List<RecordContentProvider> {
+): ImmutableList<RecordContentProvider> {
   val previousContentProviders = remember { mutableMapOf<String, RecordContentProvider>() }
 
   val lastNavigator by rememberUpdatedState(navigator)
@@ -96,7 +99,7 @@ private fun BackStack<out Record>.buildCircuitContentProviders(
         )
       }
     }
-    .toList()
+    .toImmutableList()
     .also { list ->
       // Update the previousContentProviders map so we can reference it on the next call
       previousContentProviders.clear()
@@ -117,7 +120,7 @@ public object NavigatorDefaults {
   public object DefaultDecoration : NavDecoration {
     @Composable
     override fun <T> DecoratedContent(
-      args: List<T>,
+      args: ImmutableList<T>,
       backStackDepth: Int,
       modifier: Modifier,
       content: @Composable (T) -> Unit
@@ -160,7 +163,7 @@ public object NavigatorDefaults {
   public object EmptyDecoration : NavDecoration {
     @Composable
     override fun <T> DecoratedContent(
-      args: List<T>,
+      args: ImmutableList<T>,
       backStackDepth: Int,
       modifier: Modifier,
       content: @Composable (T) -> Unit

--- a/circuit-test/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuit-test/dependencies/androidReleaseRuntimeClasspath.txt
@@ -71,6 +71,8 @@ org.jetbrains.kotlin:kotlin-parcelize-runtime
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm

--- a/circuit-test/dependencies/jvmRuntimeClasspath.txt
+++ b/circuit-test/dependencies/jvmRuntimeClasspath.txt
@@ -34,6 +34,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
 org.jetbrains.kotlinx:atomicfu-jvm
 org.jetbrains.kotlinx:atomicfu
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm
 org.jetbrains.kotlinx:kotlinx-coroutines-core

--- a/circuitx/overlays/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuitx/overlays/dependencies/androidReleaseRuntimeClasspath.txt
@@ -72,6 +72,8 @@ org.jetbrains.kotlin:kotlin-parcelize-runtime
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm

--- a/circuitx/overlays/dependencies/jvmRuntimeClasspath.txt
+++ b/circuitx/overlays/dependencies/jvmRuntimeClasspath.txt
@@ -36,6 +36,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
 org.jetbrains.kotlinx:atomicfu-jvm
 org.jetbrains.kotlinx:atomicfu
+org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
+org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-bom
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm
 org.jetbrains.kotlinx:kotlinx-coroutines-core

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
@@ -43,6 +43,7 @@ import com.slack.circuit.star.ui.StarTheme
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.parcelize.Parcelize
 import me.saket.telephoto.zoomable.ZoomSpec
 import me.saket.telephoto.zoomable.coil.ZoomableAsyncImage
@@ -173,7 +174,7 @@ object ImageViewerAwareNavDecoration : NavDecoration {
   @Suppress("UnstableCollections")
   @Composable
   override fun <T> DecoratedContent(
-    args: List<T>,
+    args: ImmutableList<T>,
     backStackDepth: Int,
     modifier: Modifier,
     content: @Composable (T) -> Unit

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
@@ -28,9 +28,9 @@ import androidx.core.view.WindowInsetsControllerCompat
 import coil.request.ImageRequest
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.slack.circuit.backstack.NavDecoration
-import com.slack.circuit.backstack.SaveableBackStack
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.foundation.NavigatorDefaults
+import com.slack.circuit.foundation.RecordContentProvider
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
@@ -181,11 +181,7 @@ object ImageViewerAwareNavDecoration : NavDecoration {
   ) {
     val firstArg = args.firstOrNull()
     val decoration =
-      if (
-        firstArg is Pair<*, *> &&
-          firstArg.first is SaveableBackStack.Record &&
-          (firstArg.first as SaveableBackStack.Record).screen is ImageViewerScreen
-      ) {
+      if (firstArg is RecordContentProvider && firstArg.record.screen is ImageViewerScreen) {
         NavigatorDefaults.EmptyDecoration
       } else {
         NavigatorDefaults.DefaultDecoration

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
@@ -170,23 +170,25 @@ fun ImageViewer(state: ImageViewerScreen.State, modifier: Modifier = Modifier) {
 //  generalize this when there's a factory pattern for it in Circuit
 //  shared element transitions?
 object ImageViewerAwareNavDecoration : NavDecoration {
+  @Suppress("UnstableCollections")
   @Composable
   override fun <T> DecoratedContent(
-    arg: T,
+    args: List<T>,
     backStackDepth: Int,
     modifier: Modifier,
     content: @Composable (T) -> Unit
   ) {
+    val firstArg = args.firstOrNull()
     val decoration =
       if (
-        arg is Pair<*, *> &&
-          arg.first is SaveableBackStack.Record &&
-          (arg.first as SaveableBackStack.Record).screen is ImageViewerScreen
+        firstArg is Pair<*, *> &&
+          firstArg.first is SaveableBackStack.Record &&
+          (firstArg.first as SaveableBackStack.Record).screen is ImageViewerScreen
       ) {
         NavigatorDefaults.EmptyDecoration
       } else {
         NavigatorDefaults.DefaultDecoration
       }
-    decoration.DecoratedContent(arg, backStackDepth, modifier, content)
+    decoration.DecoratedContent(args, backStackDepth, modifier, content)
   }
 }


### PR DESCRIPTION
Borrowing from https://github.com/chrisbanes/tivi/blob/main/ui/root/src/commonMain/kotlin/app/tivi/home/NavigableCircuitContentWithPrevious.kt after working with @chrisbanes

This brings in two important changes
- Pass the whole list of records to `DecoratedContent`, allowing more complex handling of back gestures (predictive back in android, drag gestures in iOS, etc)
- Refactor out a `buildCircuitContentProviders()`, which enables `movableContentOf` to work since it's reusing the same instance for records across changes.

Along the way this promotes immutable collections to the first part API for compose stability