### PR TITLE
Implement `NestedContentListBenchmark`

### DIFF
--- a/samples/star/benchmark/build.gradle.kts
+++ b/samples/star/benchmark/build.gradle.kts
@@ -18,6 +18,7 @@ android {
     //  This is because when we update baseline profiles, we do them on emulators but they
     //  run all tests.
     testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
+    testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "LOW-BATTERY"
   }
 
   testOptions.managedDevices.devices {

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/ListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/ListBenchmark.kt
@@ -1,0 +1,81 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.sample.star.benchmark
+
+import android.content.Intent
+import androidx.benchmark.macro.ExperimentalMetricApi
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.MemoryUsageMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.Until
+import junit.framework.TestCase
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+/**
+ * Macrobenchmark that measures performance in a list with simple items and nested CircuitContents.
+ */
+@OptIn(ExperimentalMetricApi::class)
+@RunWith(Parameterized::class)
+class ComposeListInteropBenchmark(
+  private val useNestedContent: Boolean,
+) {
+  @get:Rule val benchmarkRule = MacrobenchmarkRule()
+
+  companion object {
+    @JvmStatic
+    @Parameters(name = "useNestedContent = {0}")
+    fun data() =
+      listOf(
+        arrayOf(false),
+        arrayOf(true),
+      )
+  }
+
+  @Test
+  @Suppress("MagicNumber")
+  fun benchmarkStartup() {
+    benchmarkRule.measureRepeated(
+      packageName = "com.slack.circuit.sample.star.apk",
+      metrics =
+        listOf(
+          StartupTimingMetric(),
+          FrameTimingMetric(),
+          MemoryUsageMetric(MemoryUsageMetric.Mode.Last),
+        ),
+      iterations = 10,
+      startupMode = StartupMode.WARM,
+    ) {
+      pressHome()
+      startActivityAndWait(
+        Intent()
+          .setClassName("com.slack.circuit.sample.star.apk", "com.slack.circuit.star.MainActivity")
+          .putExtra("benchmark", true)
+          .putExtra("scenario", "list")
+          .putExtra("useNestedContent", useNestedContent)
+      )
+
+      device.wait(Until.hasObject(By.scrollable(true)), 5_000)
+
+      val scrollableObject = device.findObject(By.scrollable(true))
+      if (scrollableObject == null) {
+        TestCase.fail("No scrollable view found in hierarchy")
+      }
+      scrollableObject.setGestureMargin(device.displayWidth / 10)
+      scrollableObject.wait(Until.hasObject(By.textContains("Item 99")), 5_000)
+
+      scrollableObject?.apply {
+        repeat(2) { fling(Direction.DOWN) }
+        repeat(2) { fling(Direction.UP) }
+      }
+      device.waitForIdle()
+    }
+  }
+}

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
@@ -24,7 +24,7 @@ import org.junit.runners.Parameterized.Parameters
  */
 @OptIn(ExperimentalMetricApi::class)
 @RunWith(Parameterized::class)
-class ComposeListInteropBenchmark(
+class NestedContentListBenchmark(
   private val useNestedContent: Boolean,
 ) {
   @get:Rule val benchmarkRule = MacrobenchmarkRule()

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
@@ -34,8 +34,8 @@ class NestedContentListBenchmark(
     @Parameters(name = "useNestedContent = {0}")
     fun data() =
       listOf(
-        arrayOf(false),
-        arrayOf(true),
+        booleanArrayOf(false),
+        booleanArrayOf(true),
       )
   }
 

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -23,6 +23,7 @@ import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.overlay.ContentWithOverlays
+import com.slack.circuit.star.benchmark.ListBenchmarksScreen
 import com.slack.circuit.star.di.ActivityKey
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.home.HomeScreen
@@ -50,7 +51,16 @@ class MainActivity @Inject constructor(private val circuit: Circuit) : AppCompat
     enableEdgeToEdge()
 
     val initialBackstack =
-      if (intent.data == null) {
+      if (intent.getBooleanExtra("benchmark", false)) {
+        val scenario = intent.getStringExtra("scenario") ?: error("Missing scenario")
+        when (scenario) {
+          "list" -> {
+            val useNestedContent = intent.getBooleanExtra("useNestedContent", false)
+            persistentListOf(ListBenchmarksScreen(useNestedContent))
+          }
+          else -> error("Unknown scenario: $scenario")
+        }
+      } else if (intent.data == null) {
         persistentListOf(HomeScreen)
       } else {
         val httpUrl = intent.data.toString().toHttpUrl()

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
@@ -49,6 +49,8 @@ constructor(@Assisted private val screen: ListBenchmarksScreen) :
   @Composable override fun present() = ListBenchmarksScreen.State(screen.useNestedContent)
 }
 
+private const val ITEM_COUNT = 100
+
 @CircuitInject(ListBenchmarksScreen::class, AppScope::class)
 @Composable
 fun ListBenchmarks(
@@ -58,13 +60,15 @@ fun ListBenchmarks(
   var contentComposed by rememberRetained { mutableStateOf(false) }
   if (state.useNestedContent) {
     LazyColumn(modifier.systemBarsPadding()) {
-      items(100) { index ->
+      items(ITEM_COUNT) { index ->
         val itemScreen = remember { ListBenchmarksItemScreen(index) }
         CircuitContent(itemScreen)
       }
     }
   } else {
-    LazyColumn(modifier.systemBarsPadding()) { items(100) { index -> ListBenchmarksItem(index) } }
+    LazyColumn(modifier.systemBarsPadding()) {
+      items(ITEM_COUNT) { index -> ListBenchmarksItem(index) }
+    }
   }
   contentComposed = true
   ReportDrawnWhen { contentComposed }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
@@ -1,0 +1,125 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.benchmark
+
+import androidx.activity.compose.ReportDrawnWhen
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.foundation.CircuitContent
+import com.slack.circuit.retained.rememberRetained
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.star.di.AppScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ListBenchmarksScreen(val useNestedContent: Boolean) : Screen {
+  data class State(val useNestedContent: Boolean) : CircuitUiState
+}
+
+class ListBenchmarksPresenter
+@AssistedInject
+constructor(@Assisted private val screen: ListBenchmarksScreen) :
+  Presenter<ListBenchmarksScreen.State> {
+  @CircuitInject(ListBenchmarksScreen::class, AppScope::class)
+  @AssistedFactory
+  fun interface Factory {
+    fun create(screen: ListBenchmarksScreen): ListBenchmarksPresenter
+  }
+
+  @Composable override fun present() = ListBenchmarksScreen.State(screen.useNestedContent)
+}
+
+@CircuitInject(ListBenchmarksScreen::class, AppScope::class)
+@Composable
+fun ListBenchmarks(
+  state: ListBenchmarksScreen.State,
+  modifier: Modifier = Modifier,
+) {
+  var contentComposed by rememberRetained { mutableStateOf(false) }
+  if (state.useNestedContent) {
+    LazyColumn(modifier.systemBarsPadding()) {
+      items(100) { index ->
+        val itemScreen = remember { ListBenchmarksItemScreen(index) }
+        CircuitContent(itemScreen)
+      }
+    }
+  } else {
+    LazyColumn(modifier.systemBarsPadding()) { items(100) { index -> ListBenchmarksItem(index) } }
+  }
+  contentComposed = true
+  ReportDrawnWhen { contentComposed }
+}
+
+@Parcelize
+data class ListBenchmarksItemScreen(val index: Int) : Screen {
+  data class State(val index: Int) : CircuitUiState
+}
+
+class ListBenchmarksItemPresenter
+@AssistedInject
+constructor(@Assisted private val screen: ListBenchmarksItemScreen) :
+  Presenter<ListBenchmarksItemScreen.State> {
+  @CircuitInject(ListBenchmarksItemScreen::class, AppScope::class)
+  @AssistedFactory
+  fun interface Factory {
+    fun create(screen: ListBenchmarksItemScreen): ListBenchmarksItemPresenter
+  }
+
+  @Composable override fun present() = ListBenchmarksItemScreen.State(screen.index)
+}
+
+@CircuitInject(ListBenchmarksItemScreen::class, AppScope::class)
+@Composable
+fun ListBenchmarksItem(
+  state: ListBenchmarksItemScreen.State,
+  modifier: Modifier = Modifier,
+) {
+  ListBenchmarksItem(state.index, modifier)
+}
+
+@Composable
+fun ListBenchmarksItem(
+  index: Int,
+  modifier: Modifier = Modifier,
+) {
+  ListItem(
+    headlineContent = { Text("Item $index") },
+    leadingContent = {
+      Text(
+        modifier =
+          Modifier.padding(16.dp).drawBehind {
+            drawCircle(color = Color.Blue, radius = this.size.maxDimension)
+          },
+        color = Color.White,
+        text = index.toString(),
+      )
+    },
+    modifier = modifier
+  )
+}
+
+@Preview
+@Composable
+fun ListBenchmarksItemPreview() {
+  Box { ListBenchmarksItem(ListBenchmarksItemScreen.State(0)) }
+}


### PR DESCRIPTION
**Overview**
- Created a list benchmark screen that displays a `LazyColumn` of 100 `ListItem` composables, each showing its index as a text and a leading number drawable.
- `ListBenchmarkScreen` takes a `useNestedContent` boolean parameter that it receives from the parameterized test.
  - When `useNestedContent` is false, it renders `BenchmarkListItem` directly in each item
  - When it's true, it renders a `CircuitContent` for a nested `BenchmarkListItemScreen`
- To really stress this, this makes it a pathological case where every item in the "true" path is a nested content, which differs from the examples we discussed/explored above where only one item would be "expanded" to nested content at a time.
- Each test starts the app into the list, then swipes all the way down to the list + 2x swipes back up and down
- Used androidx.benchmark's new `MemoryUsageMetric`
- Thoroughly exercises circuit's internals in a nontrivial, multi-screen sample app.

**Results**
TL;DR – there is negligible runtime performance impact in this scenario.

Memory – the primary metric of interest is `memoryHeapSizeLastKb`, which is the heap size at the end of the test. This was surprisingly slightly lower on average when using nested content, with a nested/non-nested median of 17Kb/19Kb. I would categorize these as probably within margin of device variance of each other, though androidx.benchmark doesn't offer that kind of detail. Other metrics' details attached below.

Startup – threw this one in out of curiosity since we do this test on startup, but obviously this probably isn't a common case. This was where there was a more meaningful difference in `timeToFullDisplayMs` (61.8ms vs. 65.4ms for the medians), but I again think this is within margin of variance. I initially did a separate test without swiping, and when I checked those values they were 65.1ms vs. 66.5ms, more or less confirming this suspicion.

Frame metrics – this is the canonical performance metric as it's sort of a yard stick for jank. Explanations for the two values are attached, but TL;DR the numbers were nearly identical across the board.

```
ComposeListInteropBenchmark_benchmarkStartup[useNestedContent = false]
memoryGpuLastKb          min  67,236.0,   median  67,240.0,   max  78,532.0
memoryHeapSizeLastKb     min  11,502.0,   median  19,747.5,   max  28,726.0
memoryRssAnonLastKb      min  62,884.0,   median  71,152.0,   max  79,496.0
memoryRssFileLastKb      min 106,992.0,   median 118,088.0,   max 129,888.0
timeToFullDisplayMs      min      56.6,   median      61.8,   max      72.7
timeToInitialDisplayMs   min      54.0,   median      59.5,   max      68.3
frameDurationCpuMs       P50        4.6,   P90        5.7,   P95        6.3,   P99        7.5
frameOverrunMs           P50      -11.2,   P90       -9.9,   P95       -9.2,   P99       -6.7
Traces: Iteration 0 1 2 3 4 5 6 7 8 9

ComposeListInteropBenchmark_benchmarkStartup[useNestedContent = true]
memoryGpuLastKb          min  67,240.0,   median  72,884.0,   max  78,404.0
memoryHeapSizeLastKb     min  10,858.0,   median  17,542.0,   max  28,358.0
memoryRssAnonLastKb      min  61,792.0,   median  68,090.0,   max  79,868.0
memoryRssFileLastKb      min 106,488.0,   median 117,878.0,   max 129,636.0
timeToFullDisplayMs      min      55.2,   median      65.4,   max      75.8
timeToInitialDisplayMs   min      53.1,   median      61.9,   max      71.0
frameDurationCpuMs       P50        4.6,   P90        5.7,   P95        6.2,   P99        7.4
frameOverrunMs           P50      -11.2,   P90       -9.9,   P95       -9.2,   P99       -6.7
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```