### PR TITLE
More benchmarking work

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  # Only run push on main
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+
+concurrency:
+  group: 'ci-${{ github.event.merge_group.head_ref || github.head_ref }}-${{ github.workflow }}'
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    runs-on: macOS-latest
+    # Don't run on merge_group events
+    if: github.event_name != 'merge_group'
+    env:
+      # Test on API 30 because that's the first version with ATDs
+      API_LEVEL: '30'
+      AVD_TARGET: 'aosp_atd'
+      AVD_ARCH: 'x86'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: 'true'
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Check LFS files
+        uses: actionsdesk/lfs-warning@v3.2
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '20'
+
+      - name: Build benchmark
+        id: gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':samples:star:apk:assembleBenchmarkRelease :samples:star:benchmark:compileBenchmarkReleaseSources'
+          gradle-home-cache-cleanup: true
+          cache-read-only: false
+
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.AVD_TARGET }}
+          arch: ${{ env.AVD_ARCH }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run benchmarks
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.AVD_TARGET }}
+          arch: ${{ env.AVD_ARCH }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew :samples:star:benchmark:connectedBenchmarkReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.slack.circuit.sample.star.benchmark.NestedContentListBenchmark
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: reports-benchmark
+          path: |
+            **/build/reports/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,48 @@ jobs:
       - name: Publish snapshot (main branch only)
         if: github.repository == 'slackhq/circuit' && github.ref == 'refs/heads/main'
         run: ./gradlew publish -PmavenCentralUsername=${{ secrets.SONATYPEUSERNAME }} -PmavenCentralPassword=${{ secrets.SONATYPEPASSWORD }} --no-configuration-cache
+
+  benchmarks:
+    runs-on: macOS-latest
+    env:
+      # Test on API 30 because that's the first version with ATDs
+      API_LEVEL: '30'
+      AVD_TARGET: 'aosp_atd'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: 'true'
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Check LFS files
+        uses: actionsdesk/lfs-warning@v3.2
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '20'
+
+      - name: Build benchmark
+        id: gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':samples:star:apk:assembleBenchmarkRelease :samples:star:benchmark:compileBenchmarkReleaseSources'
+          gradle-home-cache-cleanup: true
+          cache-read-only: false
+
+      - name: Run benchmarks
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          script: ./gradlew :samples:star:benchmark:connectedBenchmarkReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.slack.circuit.sample.star.benchmark.NestedContentListBenchmark
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: reports
+          path: |
+            **/build/reports/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       # Test on API 30 because that's the first version with ATDs
       API_LEVEL: '30'
       AVD_TARGET: 'aosp_atd'
+      AVD_ARCH: 'x86'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,6 +117,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.API_TARGET }}
+          arch: ${{ env.API_ARCH }}
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -125,6 +128,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.API_TARGET }}
+          arch: ${{ env.API_ARCH }}
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,32 @@ jobs:
           gradle-home-cache-cleanup: true
           cache-read-only: false
 
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Run benchmarks
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew :samples:star:benchmark:connectedBenchmarkReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.slack.circuit.sample.star.benchmark.NestedContentListBenchmark
 
       - name: Upload build reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
 
   benchmarks:
     runs-on: macOS-latest
+    # Don't run on merge_group events
+    if: github.event_name != 'merge_group'
     env:
       # Test on API 30 because that's the first version with ATDs
       API_LEVEL: '30'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
-          target: ${{ env.API_TARGET }}
-          arch: ${{ env.API_ARCH }}
+          target: ${{ env.AVD_TARGET }}
+          arch: ${{ env.AVD_ARCH }}
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -128,8 +128,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.API_LEVEL }}
-          target: ${{ env.API_TARGET }}
-          arch: ${{ env.API_ARCH }}
+          target: ${{ env.AVD_TARGET }}
+          arch: ${{ env.AVD_ARCH }}
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,6 @@ jobs:
       - name: Upload build reports
         uses: actions/upload-artifact@v3
         with:
-          name: reports
+          name: reports-benchmark
           path: |
             **/build/reports/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,22 +18,12 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macOS-latest
-    env:
-      # Test on API 30 because that's the first version with ATDs
-      API_LEVEL: '30'
-      AVD_TARGET: 'aosp_atd'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: 'true'
-
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Check LFS files
-        uses: actionsdesk/lfs-warning@v3.2
 
       - name: Install JDK
         uses: actions/setup-java@v3
@@ -45,48 +35,28 @@ jobs:
         id: gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check :samples:star:apk:assembleDebug detektMain detektTest --continue --no-configuration-cache
+          arguments: check :samples:star:apk:assembleDebug detektMain detektTest :samples:star:benchmark:compileBenchmarkReleaseKotlin --continue --no-configuration-cache
           gradle-home-cache-cleanup: true
           cache-read-only: false
 
-      - name: Verify Snapshots
-        id: gradle-snapshots
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: verifyRoborazzi
-          gradle-home-cache-cleanup: true
-          cache-read-only: false
-
-      - name: (Fail-only) Upload build reports
+      - name: (Fail-only) Upload reports
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: reports
+          name: reports-build
           path: |
             **/build/reports/**
-            **/src/test/snapshots/**/*_compare.png
 
       - name: Publish snapshot (main branch only)
         if: github.repository == 'slackhq/circuit' && github.ref == 'refs/heads/main'
         run: ./gradlew publish -PmavenCentralUsername=${{ secrets.SONATYPEUSERNAME }} -PmavenCentralPassword=${{ secrets.SONATYPEPASSWORD }} --no-configuration-cache
-
-  benchmarks:
-    runs-on: macOS-latest
-    # Don't run on merge_group events
-    if: github.event_name != 'merge_group'
-    env:
-      # Test on API 30 because that's the first version with ATDs
-      API_LEVEL: '30'
-      AVD_TARGET: 'aosp_atd'
-      AVD_ARCH: 'x86'
+  snapshots:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: 'true'
-
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
 
       - name: Check LFS files
         uses: actionsdesk/lfs-warning@v3.2
@@ -97,49 +67,19 @@ jobs:
           distribution: 'zulu'
           java-version: '20'
 
-      - name: Build benchmark
-        id: gradle
+      - name: Verify Snapshots
+        id: gradle-snapshots
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: ':samples:star:apk:assembleBenchmarkRelease :samples:star:benchmark:compileBenchmarkReleaseSources'
+          arguments: verifyRoborazzi
           gradle-home-cache-cleanup: true
           cache-read-only: false
 
-      - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}
-
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          target: ${{ env.AVD_TARGET }}
-          arch: ${{ env.AVD_ARCH }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Run benchmarks
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          target: ${{ env.AVD_TARGET }}
-          arch: ${{ env.AVD_ARCH }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew :samples:star:benchmark:connectedBenchmarkReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.slack.circuit.sample.star.benchmark.NestedContentListBenchmark
-
-      - name: Upload build reports
+      - name: (Fail-only) Upload reports
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: reports-benchmark
+          name: reports-snapshots
           path: |
             **/build/reports/**
+            **/src/test/snapshots/**/*_compare.png

--- a/.github/workflows/gradle-wrapper.yml
+++ b/.github/workflows/gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: gradle-wrapper
+
+on:
+  pull_request:
+    paths:
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'gradle/wrapper/'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/update-baseline-profiles.yml
+++ b/.github/workflows/update-baseline-profiles.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Install JDK
         uses: actions/setup-java@v3
         with:

--- a/samples/star/benchmark/build.gradle.kts
+++ b/samples/star/benchmark/build.gradle.kts
@@ -17,8 +17,7 @@ android {
     // TODO temporary until AGP 8.2, which no longer requires this.
     //  This is because when we update baseline profiles, we do them on emulators but they
     //  run all tests.
-    testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
-    testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "LOW-BATTERY"
+    testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR,LOW-BATTERY"
   }
 
   testOptions.managedDevices.devices {

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
@@ -50,7 +50,7 @@ class NestedContentListBenchmark(
           FrameTimingMetric(),
           MemoryUsageMetric(MemoryUsageMetric.Mode.Last),
         ),
-      iterations = 10,
+      iterations = 50,
       startupMode = StartupMode.WARM,
     ) {
       pressHome()

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
@@ -30,7 +30,7 @@ class NestedContentListBenchmark(private val useNestedContent: Boolean) {
   companion object {
     @Suppress("ArrayPrimitive") // Required for Parameterized to work
     @JvmStatic
-    @Parameters(name = "useNestedContent = {0}, iterations = {1}")
+    @Parameters(name = "useNestedContent = {0}")
     fun data() = listOf(arrayOf(false), arrayOf(true))
   }
 

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
@@ -28,6 +28,7 @@ class NestedContentListBenchmark(private val useNestedContent: Boolean) {
   @get:Rule val benchmarkRule = MacrobenchmarkRule()
 
   companion object {
+    @Suppress("ArrayPrimitive") // Required for Parameterized to work
     @JvmStatic
     @Parameters(name = "useNestedContent = {0}, iterations = {1}")
     fun data() = listOf(arrayOf(false), arrayOf(true))

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
@@ -24,24 +24,13 @@ import org.junit.runners.Parameterized.Parameters
  */
 @OptIn(ExperimentalMetricApi::class)
 @RunWith(Parameterized::class)
-class NestedContentListBenchmark(
-  private val useNestedContent: Boolean,
-  private val iterations: Int,
-) {
+class NestedContentListBenchmark(private val useNestedContent: Boolean) {
   @get:Rule val benchmarkRule = MacrobenchmarkRule()
 
   companion object {
     @JvmStatic
     @Parameters(name = "useNestedContent = {0}, iterations = {1}")
-    fun data() =
-      listOf(
-        arrayOf(false, 10),
-        arrayOf(true, 10),
-        arrayOf(false, 30),
-        arrayOf(true, 30),
-        arrayOf(false, 50),
-        arrayOf(true, 50),
-      )
+    fun data() = listOf(arrayOf(false), arrayOf(true))
   }
 
   @Test
@@ -55,7 +44,7 @@ class NestedContentListBenchmark(
           FrameTimingMetric(),
           MemoryUsageMetric(MemoryUsageMetric.Mode.Last),
         ),
-      iterations = iterations,
+      iterations = 10,
       startupMode = StartupMode.WARM,
     ) {
       pressHome()

--- a/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
+++ b/samples/star/benchmark/src/main/java/com/slack/circuit/sample/star/benchmark/NestedContentListBenchmark.kt
@@ -26,16 +26,21 @@ import org.junit.runners.Parameterized.Parameters
 @RunWith(Parameterized::class)
 class NestedContentListBenchmark(
   private val useNestedContent: Boolean,
+  private val iterations: Int,
 ) {
   @get:Rule val benchmarkRule = MacrobenchmarkRule()
 
   companion object {
     @JvmStatic
-    @Parameters(name = "useNestedContent = {0}")
+    @Parameters(name = "useNestedContent = {0}, iterations = {1}")
     fun data() =
       listOf(
-        booleanArrayOf(false),
-        booleanArrayOf(true),
+        arrayOf(false, 10),
+        arrayOf(true, 10),
+        arrayOf(false, 30),
+        arrayOf(true, 30),
+        arrayOf(false, 50),
+        arrayOf(true, 50),
       )
   }
 
@@ -50,7 +55,7 @@ class NestedContentListBenchmark(
           FrameTimingMetric(),
           MemoryUsageMetric(MemoryUsageMetric.Mode.Last),
         ),
-      iterations = 50,
+      iterations = iterations,
       startupMode = StartupMode.WARM,
     ) {
       pressHome()

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
@@ -30,6 +30,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
 
 @Parcelize
 data class ListBenchmarksScreen(val useNestedContent: Boolean) : Screen {
@@ -79,17 +80,24 @@ data class ListBenchmarksItemScreen(val index: Int) : Screen {
   data class State(val index: Int) : CircuitUiState
 }
 
+class IndexMultiplier @Inject constructor() {
+  fun multiply(index: Int) = index * 1
+}
+
 class ListBenchmarksItemPresenter
 @AssistedInject
-constructor(@Assisted private val screen: ListBenchmarksItemScreen) :
-  Presenter<ListBenchmarksItemScreen.State> {
+constructor(
+  @Assisted private val screen: ListBenchmarksItemScreen,
+  // Simulate injecting something that accumulates instances
+  private val indexMultiplier: IndexMultiplier,
+) : Presenter<ListBenchmarksItemScreen.State> {
   @CircuitInject(ListBenchmarksItemScreen::class, AppScope::class)
   @AssistedFactory
   fun interface Factory {
     fun create(screen: ListBenchmarksItemScreen): ListBenchmarksItemPresenter
   }
 
-  @Composable override fun present() = ListBenchmarksItemScreen.State(screen.index)
+  @Composable override fun present() = ListBenchmarksItemScreen.State(indexMultiplier.multiply(screen.index))
 }
 
 @CircuitInject(ListBenchmarksItemScreen::class, AppScope::class)

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/benchmark/ListBenchmarkScreens.kt
@@ -29,8 +29,8 @@ import com.slack.circuit.star.di.AppScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class ListBenchmarksScreen(val useNestedContent: Boolean) : Screen {
@@ -97,7 +97,8 @@ constructor(
     fun create(screen: ListBenchmarksItemScreen): ListBenchmarksItemPresenter
   }
 
-  @Composable override fun present() = ListBenchmarksItemScreen.State(indexMultiplier.multiply(screen.index))
+  @Composable
+  override fun present() = ListBenchmarksItemScreen.State(indexMultiplier.multiply(screen.index))
 }
 
 @CircuitInject(ListBenchmarksItemScreen::class, AppScope::class)


### PR DESCRIPTION
Per internal requests, this makes two changes
- Tested with 50 iterations. Will check separately with androidx.benchmark folks to see if they have a suggestion for the right number. My own testing found 10 is plenty (details below).
- Inject a non-scopped object into list item presenters to simulate instance accumulations.

Also setting up a build step on CI to run these on an emulator. This should be fine as we care about relative comparison between the two, not raw benchmarks on a device.

**TL;DR The results are unchanged**

## 50 iterations

- `memoryHeapSizeLastKb` is slightly higher when using nested content, but only 18.3Kb vs 19.1kB.
- Interestingly, `memoryRssFileLastKb` is slightly lower for nested content.
- Frame metrics nearly identical, actually slightly favoring nested content. P99 of `frameOverrunMs` without nested content is actually positive, but I'd put this down to one run happening at a busy time on the device.

### NestedContentListBenchmark_benchmarkStartup[useNestedContent = false, iterations = 50]

| Metric                | Min        | Median     | Max        |
|----------------------|------------|------------|------------|
| memoryGpuLastKb       | 56,140.0   | 67,304.0   | 78,596.0   |
| memoryHeapSizeLastKb  | 6,085.0    | 18,330.0   | 28,831.0   |
| memoryRssAnonLastKb   | 50,292.0   | 62,742.0   | 74,556.0   |
| memoryRssFileLastKb   | 105,952.0  | 118,144.0  | 129,692.0  |
| timeToFullDisplayMs   | 48.4       | 64.6       | 81.7       |
| timeToInitialDisplayMs| 46.5       | 61.2       | 76.0       |

| Metric            | P50      | P90      | P95      | P99      |
|------------------|----------|----------|----------|----------|
| frameDurationCpuMs| 4.6      | 5.7      | 6.1      | 7.3      |
| frameOverrunMs    |-11.0     |-9.8      |-9.2      | 9.8      |

### NestedContentListBenchmark_benchmarkStartup[useNestedContent = true, iterations = 50]

| Metric                | Min        | Median     | Max        |
|----------------------|------------|------------|------------|
| memoryGpuLastKb       | 56,076.0   | 67,304.0   | 78,596.0   |
| memoryHeapSizeLastKb  | 7,841.0    | 19,171.5   | 30,106.0   |
| memoryRssAnonLastKb   | 52,452.0   | 63,712.0   | 75,888.0   |
| memoryRssFileLastKb   | 104,520.0  | 116,236.0  | 128,492.0  |
| timeToFullDisplayMs   | 56.1       | 64.0       | 77.6       |
| timeToInitialDisplayMs| 53.5       | 60.8       | 73.6       |

| Metric            | P50      | P90      | P95      | P99      |
|------------------|----------|----------|----------|----------|
| frameDurationCpuMs| 4.6      | 5.8      | 6.2      | 7.4      |
| frameOverrunMs    |-11.0     |-9.7      |-9.1      |-3.9      |

## 10 iterations vs 50

Below are the results this round with 10 iterations. There's no statistically significant variance between 10 and 50.

### NestedContentListBenchmark_benchmarkStartup[useNestedContent = false, iterations = 10]

| Metric                | Min        | Median     | Max        |
|----------------------|------------|------------|------------|
| memoryGpuLastKb       | 67,300.0   | 67,432.0   | 78,596.0   |
| memoryHeapSizeLastKb  | 10,901.0   | 18,259.0   | 25,473.0   |
| memoryRssAnonLastKb   | 55,452.0   | 65,304.0   | 71,852.0   |
| memoryRssFileLastKb   | 112,684.0  | 124,140.0  | 135,324.0  |
| timeToFullDisplayMs   | 61.5       | 65.0       | 73.0       |
| timeToInitialDisplayMs| 59.1       | 61.0       | 71.0       |

| Metric            | P50      | P90      | P95      | P99      |
|------------------|----------|----------|----------|----------|
| frameDurationCpuMs| 4.6      | 5.8      | 6.2      | 7.3      |
| frameOverrunMs    |-11.1     |-9.7      |-9.2      |-6.0      |

### NestedContentListBenchmark_benchmarkStartup[useNestedContent = true, iterations = 10]

| Metric                | Min        | Median     | Max        |
|----------------------|------------|------------|------------|
| memoryGpuLastKb       | 67,304.0   | 72,948.0   | 78,596.0   |
| memoryHeapSizeLastKb  | 9,735.0    | 19,023.5   | 27,047.0   |
| memoryRssAnonLastKb   | 54,100.0   | 64,964.0   | 71,720.0   |
| memoryRssFileLastKb   | 111,620.0  | 123,716.0  | 134,932.0  |
| timeToFullDisplayMs   | 58.5       | 64.5       | 79.4       |
| timeToInitialDisplayMs| 56.0       | 62.2       | 76.3       |

| Metric            | P50      | P90      | P95      | P99      |
|------------------|----------|----------|----------|----------|
| frameDurationCpuMs| 4.5      | 5.7      | 6.1      | 7.3      |
| frameOverrunMs    |-11.1     |-9.8      |-9.1      | 4.2      |

## More iterations

Out of curiosity, I did some extra tests with 3/5/7/10 iterations to see if there was a sense of when variance more or less slows down and what the right sweet spot would be. From the below data, it seems variability levels out around 7. I'll keep it at 10 in this benchmark since they're relatively cheap though, just for clearance.

```
NestedContentListBenchmark_benchmarkStartup[useNestedContent = false, iterations = 3]
memoryGpuLastKb          min  56,140.0,   median  67,304.0,   max  67,428.0
memoryHeapSizeLastKb     min   6,720.0,   median  15,720.0,   max  23,052.0
memoryRssAnonLastKb      min  49,868.0,   median  58,856.0,   max  64,832.0
memoryRssFileLastKb      min 110,128.0,   median 110,456.0,   max 121,452.0
timeToFullDisplayMs      min      59.0,   median      62.2,   max      70.8
timeToInitialDisplayMs   min      56.7,   median      60.2,   max      68.0
frameDurationCpuMs       P50        4.8,   P90        5.9,   P95        6.4,   P99        7.9
frameOverrunMs           P50      -11.0,   P90       -9.6,   P95       -8.9,   P99       -0.0
Traces: Iteration 0 1 2

NestedContentListBenchmark_benchmarkStartup[useNestedContent = true, iterations = 3]
memoryGpuLastKb          min  67,300.0,   median  67,304.0,   max  78,596.0
memoryHeapSizeLastKb     min  15,150.0,   median  20,319.0,   max  25,745.0
memoryRssAnonLastKb      min  60,356.0,   median  63,428.0,   max  67,780.0
memoryRssFileLastKb      min 110,808.0,   median 121,884.0,   max 122,004.0
timeToFullDisplayMs      min      65.2,   median      65.3,   max      65.8
timeToInitialDisplayMs   min      60.0,   median      61.9,   max      62.2
frameDurationCpuMs       P50        4.6,   P90        5.9,   P95        6.4,   P99        7.6
frameOverrunMs           P50      -11.2,   P90       -9.6,   P95       -8.8,   P99       61.6
Traces: Iteration 0 1 2

NestedContentListBenchmark_benchmarkStartup[useNestedContent = false, iterations = 5]
memoryGpuLastKb          min  67,240.0,   median  67,364.0,   max  78,404.0
memoryHeapSizeLastKb     min  10,119.0,   median  20,081.0,   max  24,200.0
memoryRssAnonLastKb      min  54,104.0,   median  64,056.0,   max  70,048.0
memoryRssFileLastKb      min 110,756.0,   median 121,692.0,   max 133,464.0
timeToFullDisplayMs      min      62.9,   median      67.5,   max      69.0
timeToInitialDisplayMs   min      61.1,   median      64.4,   max      66.0
frameDurationCpuMs       P50        4.7,   P90        5.9,   P95        6.4,   P99        7.6
frameOverrunMs           P50      -11.1,   P90       -9.7,   P95       -9.1,   P99       -6.6
Traces: Iteration 0 1 2 3 4

NestedContentListBenchmark_benchmarkStartup[useNestedContent = true, iterations = 5]
memoryGpuLastKb          min  56,076.0,   median  67,240.0,   max  78,592.0
memoryHeapSizeLastKb     min   8,487.0,   median  22,112.0,   max  28,325.0
memoryRssAnonLastKb      min  52,852.0,   median  66,344.0,   max  70,600.0
memoryRssFileLastKb      min 109,316.0,   median 120,628.0,   max 120,892.0
timeToFullDisplayMs      min      59.8,   median      63.5,   max      68.6
timeToInitialDisplayMs   min      56.9,   median      61.3,   max      66.5
frameDurationCpuMs       P50        4.8,   P90        6.0,   P95        6.4,   P99        7.9
frameOverrunMs           P50      -11.0,   P90       -9.6,   P95       -8.9,   P99       -4.8
Traces: Iteration 0 1 2 3 4

NestedContentListBenchmark_benchmarkStartup[useNestedContent = false, iterations = 7]
memoryGpuLastKb          min  67,240.0,   median  67,364.0,   max  78,404.0
memoryHeapSizeLastKb     min  10,177.0,   median  18,413.0,   max  25,186.0
memoryRssAnonLastKb      min  54,128.0,   median  63,924.0,   max  71,032.0
memoryRssFileLastKb      min 121,700.0,   median 121,960.0,   max 133,080.0
timeToFullDisplayMs      min      62.3,   median      67.4,   max      73.9
timeToInitialDisplayMs   min      59.7,   median      64.5,   max      71.8
frameDurationCpuMs       P50        4.7,   P90        5.9,   P95        6.4,   P99        7.6
frameOverrunMs           P50      -11.1,   P90       -9.7,   P95       -9.0,   P99       55.1
Traces: Iteration 0 1 2 3 4 5 6

NestedContentListBenchmark_benchmarkStartup[useNestedContent = true, iterations = 7]
memoryGpuLastKb          min  67,240.0,   median  67,304.0,   max  78,592.0
memoryHeapSizeLastKb     min  11,731.0,   median  22,092.0,   max  28,820.0
memoryRssAnonLastKb      min  55,784.0,   median  65,032.0,   max  73,368.0
memoryRssFileLastKb      min 110,580.0,   median 121,628.0,   max 133,412.0
timeToFullDisplayMs      min      55.8,   median      70.6,   max     105.0
timeToInitialDisplayMs   min      53.4,   median      68.3,   max     102.5
frameDurationCpuMs       P50        4.8,   P90        6.0,   P95        6.4,   P99        7.8
frameOverrunMs           P50      -11.0,   P90       -9.6,   P95       -8.9,   P99       -3.9
Traces: Iteration 0 1 2 3 4 5 6

NestedContentListBenchmark_benchmarkStartup[useNestedContent = false, iterations = 10]
memoryGpuLastKb          min  56,140.0,   median  67,366.0,   max  78,596.0
memoryHeapSizeLastKb     min  10,623.0,   median  17,747.0,   max  26,654.0
memoryRssAnonLastKb      min  55,104.0,   median  63,406.0,   max  72,504.0
memoryRssFileLastKb      min 110,948.0,   median 122,124.0,   max 122,504.0
timeToFullDisplayMs      min      59.0,   median      63.3,   max      69.9
timeToInitialDisplayMs   min      56.3,   median      60.8,   max      67.2
frameDurationCpuMs       P50        4.7,   P90        5.9,   P95        6.5,   P99        7.8
frameOverrunMs           P50      -11.0,   P90       -9.6,   P95       -8.8,   P99       -3.4
Traces: Iteration 0 1 2 3 4 5 6 7 8 9

NestedContentListBenchmark_benchmarkStartup[useNestedContent = true, iterations = 10]
memoryGpuLastKb          min  56,140.0,   median  67,304.0,   max  78,596.0
memoryHeapSizeLastKb     min   9,933.0,   median  18,464.5,   max  29,031.0
memoryRssAnonLastKb      min  54,100.0,   median  63,528.0,   max  73,164.0
memoryRssFileLastKb      min 110,084.0,   median 121,814.0,   max 133,132.0
timeToFullDisplayMs      min      60.1,   median      68.9,   max      75.7
timeToInitialDisplayMs   min      57.9,   median      66.0,   max      73.8
frameDurationCpuMs       P50        4.7,   P90        5.9,   P95        6.4,   P99        7.9
frameOverrunMs           P50      -11.1,   P90       -9.6,   P95       -8.9,   P99       -4.6
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```
