### PR TITLE
Allow retained state to be retained whilst UIs and Presenters are on the back stack

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -319,7 +319,10 @@ subprojects {
   pluginManager.withPlugin("com.android.library") {
     with(extensions.getByType<LibraryExtension>()) {
       commonAndroidConfig()
-      defaultConfig { minSdk = 21 }
+      defaultConfig {
+        minSdk = 21
+        targetSdk = 34
+      }
     }
 
     // Single-variant libraries

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -319,10 +319,7 @@ subprojects {
   pluginManager.withPlugin("com.android.library") {
     with(extensions.getByType<LibraryExtension>()) {
       commonAndroidConfig()
-      defaultConfig {
-        minSdk = 21
-        targetSdk = 34
-      }
+      defaultConfig { minSdk = 21 }
     }
 
     // Single-variant libraries

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -86,6 +86,12 @@ tasks
 
 android {
   namespace = "com.slack.circuit.foundation"
+
+  defaultConfig {
+    // Needed for Robolectric tests to run
+    targetSdk = 33
+  }
+
   testOptions { unitTests { isIncludeAndroidResources = true } }
 }
 

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -86,12 +86,6 @@ tasks
 
 android {
   namespace = "com.slack.circuit.foundation"
-
-  defaultConfig {
-    // Needed for Robolectric tests to run
-    targetSdk = 33
-  }
-
   testOptions { unitTests { isIncludeAndroidResources = true } }
 }
 

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -38,6 +38,8 @@ kotlin {
         api(projects.circuitRuntimePresenter)
         api(projects.circuitRuntimeUi)
         api(libs.compose.ui)
+
+        implementation(projects.circuitRetained)
       }
     }
     val androidMain by getting {

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -1,0 +1,196 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.retained.LocalRetainedStateRegistry
+import com.slack.circuit.retained.continuityRetainedStateRegistry
+import com.slack.circuit.retained.rememberRetained
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.runtime.ui.ui
+import kotlinx.parcelize.Parcelize
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+private const val TAG_GO_NEXT = "go"
+private const val TAG_POP = "pop"
+private const val TAG_INCREASE_COUNT = "inc"
+private const val TAG_COUNT = "count"
+private const val TAG_LABEL = "label"
+
+@RunWith(RobolectricTestRunner::class)
+class NavigableCircuitRetainedStateTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test fun retainedStateScopedToBackstackWithKeys() = retainedStateScopedToBackstack(true)
+
+  @Test fun retainedStateScopedToBackstackWithoutKeys() = retainedStateScopedToBackstack(false)
+
+  private fun retainedStateScopedToBackstack(useKeys: Boolean) {
+    composeTestRule.run {
+      val circuit =
+        Circuit.Builder()
+          .addPresenterFactory { screen, navigator, _ ->
+            TestCountPresenter(screen as TestScreen, navigator, useKeys)
+          }
+          .addUiFactory { _, _ ->
+            ui<TestState> { state, modifier -> TestContent(state, modifier) }
+          }
+          .build()
+
+      setContent {
+        CompositionLocalProvider(
+          LocalRetainedStateRegistry provides continuityRetainedStateRegistry()
+        ) {
+          CircuitCompositionLocals(circuit) {
+            val backstack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+            val navigator = rememberCircuitNavigator(backstack = backstack)
+            NavigableCircuitContent(navigator = navigator, backstack = backstack)
+          }
+        }
+      }
+
+      // Current: Screen A. Increase count to 1
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen C. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Pop to Screen B. Increase count from 1 to 2.
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Navigate to Screen C. Assert that it's state was not retained
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Pop to Screen B. Assert that it's state was retained
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Pop to Screen A. Assert that it's state was retained
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Assert that it's state was not retained
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+
+  private sealed class TestScreen(val label: String) : Screen {
+
+    @Parcelize data object ScreenA : TestScreen("A")
+
+    @Parcelize data object ScreenB : TestScreen("B")
+
+    @Parcelize data object ScreenC : TestScreen("C")
+  }
+
+  @Composable
+  private fun TestContent(state: TestState, modifier: Modifier) {
+    Column(modifier = modifier) {
+      BasicText(text = state.label, modifier = Modifier.testTag(TAG_LABEL))
+
+      BasicText(text = "${state.count}", modifier = Modifier.testTag(TAG_COUNT))
+
+      BasicText(
+        text = "Increase count",
+        modifier =
+          Modifier.testTag(TAG_INCREASE_COUNT).clickable {
+            state.eventSink(TestEvent.IncreaseCount)
+          }
+      )
+
+      BasicText(
+        text = "Pop",
+        modifier = Modifier.testTag(TAG_POP).clickable { state.eventSink(TestEvent.PopNavigation) }
+      )
+      BasicText(
+        text = "Go to next",
+        modifier =
+          Modifier.testTag(TAG_GO_NEXT).clickable { state.eventSink(TestEvent.GoToNextScreen) }
+      )
+    }
+  }
+
+  private class TestCountPresenter(
+    private val screen: TestScreen,
+    private val navigator: Navigator,
+    private val useKeys: Boolean,
+  ) : Presenter<TestState> {
+    @Composable
+    override fun present(): TestState {
+      var launchCount by rememberRetained(key = "count".takeIf { useKeys }) { mutableIntStateOf(0) }
+
+      return TestState(launchCount, screen.label) { event ->
+        when (event) {
+          TestEvent.IncreaseCount -> launchCount++
+          TestEvent.PopNavigation -> navigator.pop()
+          TestEvent.GoToNextScreen -> {
+            when (screen) {
+              is TestScreen.ScreenA -> navigator.goTo(TestScreen.ScreenB)
+              is TestScreen.ScreenB -> navigator.goTo(TestScreen.ScreenC)
+              else -> error("Can't navigate from $screen")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private data class TestState(
+    val count: Int,
+    val label: String,
+    val eventSink: (TestEvent) -> Unit
+  ) : CircuitUiState
+
+  private sealed interface TestEvent {
+    data object GoToNextScreen : TestEvent
+
+    data object PopNavigation : TestEvent
+
+    data object IncreaseCount : TestEvent
+  }
+}

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -138,7 +138,7 @@ private fun <UiState : CircuitUiState> CircuitContent(
   // case of this is when you have code that calls CircuitContent with a common screen with
   // different inputs (but thus same presenter instance type) and you need this to recompose with a
   // different presenter.
-  val state = key(presenter) { presenter.present() }
+  val state = key(screen) { presenter.present() }
 
   // TODO not sure why stateFlow + LaunchedEffect + distinctUntilChanged doesn't work here
   SideEffect { eventListener.onState(state) }

--- a/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -30,7 +31,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.test.core.app.ActivityScenario
 import com.google.common.truth.Truth.assertThat
 import com.slack.circuit.retained.Continuity
+import com.slack.circuit.retained.ContinuityViewModel
 import com.slack.circuit.retained.LocalRetainedStateRegistry
+import com.slack.circuit.retained.RetainedStateRegistry
 import com.slack.circuit.retained.continuityRetainedStateRegistry
 import com.slack.circuit.retained.rememberRetained
 import leakcanary.DetectLeaksAfterTestSuccess.Companion.detectLeaksAfterTestSuccessWrapping
@@ -42,6 +45,8 @@ private const val TAG_REMEMBER = "remember"
 private const val TAG_RETAINED_1 = "retained1"
 private const val TAG_RETAINED_2 = "retained2"
 private const val TAG_RETAINED_3 = "retained3"
+private const val TAG_BUTTON_SHOW = "btn_show"
+private const val TAG_BUTTON_HIDE = "btn_hide"
 
 class RetainedTest {
   private val composeTestRule = createAndroidComposeRule<ComponentActivity>()
@@ -56,10 +61,10 @@ class RetainedTest {
     get() = composeTestRule.activityRule.scenario
 
   private class RecordingContinuityVmFactory : ViewModelProvider.Factory {
-    var continuity: Continuity? = null
+    var continuity: ContinuityViewModel? = null
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-      @Suppress("UNCHECKED_CAST") return Continuity().also { continuity = it } as T
+      @Suppress("UNCHECKED_CAST") return ContinuityViewModel().also { continuity = it } as T
     }
   }
 
@@ -193,38 +198,55 @@ class RetainedTest {
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained")
   }
 
-  @Test
-  fun multipleKeys() {
-    val content = @Composable { MultipleRetains(useKeys = true) }
-    setActivityContent(content)
-    composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained1")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_2).performTextInput("Text_Retained2")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_3).performTextInput("2")
-    // Check that our input worked
-    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2")
-    // Restart the activity
-    scenario.recreate()
-    // Compose our content
-    setActivityContent(content)
-    // Was the text saved
-    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2")
-  }
+  @Test fun multipleKeys() = testMultipleRetainedContent { MultipleRetains(useKeys = true) }
+
+  @Test fun multipleNoKeys() = testMultipleRetainedContent { MultipleRetains(useKeys = false) }
+
+  @Test fun nestedRegistries() = testMultipleRetainedContent { NestedRetains(useKeys = true) }
 
   @Test
-  fun multipleNoKeys() {
-    val content = @Composable { MultipleRetains(useKeys = false) }
+  fun nestedRegistriesNoKeys() = testMultipleRetainedContent { NestedRetains(useKeys = false) }
+
+  @Test fun nestedRegistriesWithPopAndPushWithKeys() = nestedRegistriesWithPopAndPush(true)
+
+  @Test fun nestedRegistriesWithPopAndPushNoKeys() = nestedRegistriesWithPopAndPush(false)
+
+  private fun nestedRegistriesWithPopAndPush(useKeys: Boolean) {
+    val content = @Composable { NestedRetainWithPushAndPop(useKeys = useKeys) }
     setActivityContent(content)
+
+    // Assert that Retained 1 is visible & Retained 2 does not exist
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertDoesNotExist()
+
+    // Now click the button to show the child content
+    composeTestRule.onNodeWithTag(TAG_BUTTON_SHOW).performClick()
+
+    // Perform our initial text input
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained1")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_2).performTextInput("Text_Retained2")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_3).performTextInput("2")
+    composeTestRule
+      .onNodeWithTag(TAG_RETAINED_2)
+      .assertIsDisplayed()
+      .performTextInput("Text_Retained2")
+
     // Check that our input worked
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
     composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2")
+
+    // Now click the button to hide the nested content (aka a pop)
+    composeTestRule.onNodeWithTag(TAG_BUTTON_HIDE).performClick()
+
+    // Assert that Retained 1 is visible & Retained 2 does not exist
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertDoesNotExist()
+
+    // Now click the button to show the nested content again (aka a push)
+    composeTestRule.onNodeWithTag(TAG_BUTTON_SHOW).performClick()
+
+    // Assert that the child content is using the retained content
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
+
     // Restart the activity
     scenario.recreate()
     // Compose our content
@@ -232,7 +254,6 @@ class RetainedTest {
     // Was the text saved
     composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
     composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
-    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2")
   }
 
   private fun setActivityContent(content: @Composable () -> Unit) {
@@ -246,6 +267,26 @@ class RetainedTest {
         }
       }
     }
+  }
+
+  private fun testMultipleRetainedContent(content: @Composable () -> Unit) {
+    setActivityContent(content)
+
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).performTextInput("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).performTextInput("Text_Retained2")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_3).performTextInput("2")
+    // Check that our input worked
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2", substring = true)
+    // Restart the activity
+    scenario.recreate()
+    // Compose our content
+    setActivityContent(content)
+    // Was the text saved
+    composeTestRule.onNodeWithTag(TAG_RETAINED_1).assertTextContains("Text_Retained1")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_2).assertTextContains("Text_Retained2")
+    composeTestRule.onNodeWithTag(TAG_RETAINED_3).assertTextContains("2", substring = true)
   }
 }
 
@@ -298,5 +339,95 @@ private fun MultipleRetains(useKeys: Boolean) {
       onValueChange = { retainedInt = it.toInt() },
       label = {}
     )
+  }
+}
+
+@Composable
+private fun NestedRetains(useKeys: Boolean) {
+  var retainedText1: String by
+    rememberRetained(key = "retained1".takeIf { useKeys }) { mutableStateOf("") }
+
+  Column {
+    TextField(
+      modifier = Modifier.testTag(TAG_RETAINED_1),
+      value = retainedText1,
+      onValueChange = { retainedText1 = it },
+      label = {}
+    )
+
+    val nestedRegistryLevel1 = rememberRetained { RetainedStateRegistry() }
+    CompositionLocalProvider(LocalRetainedStateRegistry provides nestedRegistryLevel1) {
+      NestedRetainLevel1(useKeys)
+    }
+  }
+}
+
+@Composable
+private fun NestedRetainLevel1(useKeys: Boolean) {
+  var retainedText2: String by
+    rememberRetained(key = "retained2".takeIf { useKeys }) { mutableStateOf("") }
+
+  TextField(
+    modifier = Modifier.testTag(TAG_RETAINED_2),
+    value = retainedText2,
+    onValueChange = { retainedText2 = it },
+    label = {}
+  )
+
+  val nestedRegistry = rememberRetained { RetainedStateRegistry() }
+  CompositionLocalProvider(LocalRetainedStateRegistry provides nestedRegistry) {
+    NestedRetainLevel2(useKeys)
+  }
+}
+
+@Composable
+private fun NestedRetainLevel2(useKeys: Boolean) {
+  var retainedInt: Int by
+    rememberRetained(key = "retainedInt".takeIf { useKeys }) { mutableStateOf(0) }
+
+  TextField(
+    modifier = Modifier.testTag(TAG_RETAINED_3),
+    value = retainedInt.toString(),
+    onValueChange = { retainedInt = it.toInt() },
+    label = {}
+  )
+}
+
+@Composable
+private fun NestedRetainWithPushAndPop(useKeys: Boolean) {
+  var retainedText1: String by
+    rememberRetained(key = "retained1".takeIf { useKeys }) { mutableStateOf("") }
+
+  Column {
+    TextField(
+      modifier = Modifier.testTag(TAG_RETAINED_1),
+      value = retainedText1,
+      onValueChange = { retainedText1 = it },
+      label = {}
+    )
+
+    val showNestedContent = rememberRetained { mutableStateOf(false) }
+
+    Button(
+      onClick = { showNestedContent.value = false },
+      modifier = Modifier.testTag(TAG_BUTTON_HIDE)
+    ) {
+      Text(text = "Hide child")
+    }
+
+    Button(
+      onClick = { showNestedContent.value = true },
+      modifier = Modifier.testTag(TAG_BUTTON_SHOW)
+    ) {
+      Text(text = "Show child")
+    }
+
+    if (showNestedContent.value) {
+      val nestedRegistry = rememberRetained { RetainedStateRegistry() }
+
+      CompositionLocalProvider(LocalRetainedStateRegistry provides nestedRegistry) {
+        NestedRetainLevel1(useKeys)
+      }
+    }
   }
 }

--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/AndroidContinuity.kt
@@ -79,7 +79,7 @@ public actual fun continuityRetainedStateRegistry(
 @Composable
 public fun continuityRetainedStateRegistry(
   key: String = Continuity.KEY,
-  factory: ViewModelProvider.Factory,
+  factory: ViewModelProvider.Factory = ContinuityViewModel.Factory,
   canRetainChecker: CanRetainChecker = LocalCanRetainChecker.current ?: rememberCanRetainChecker()
 ): RetainedStateRegistry {
   val vm = viewModel<ContinuityViewModel>(key = key, factory = factory)

--- a/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/CanRetainChecker.android.kt
+++ b/circuit-retained/src/androidMain/kotlin/com/slack/circuit/retained/CanRetainChecker.android.kt
@@ -14,7 +14,18 @@ import androidx.compose.ui.platform.LocalContext
 public actual fun rememberCanRetainChecker(): CanRetainChecker {
   val context = LocalContext.current
   val activity = remember(context) { context.findActivity() }
-  return remember { CanRetainChecker { activity?.isChangingConfigurations == true } }
+  return remember {
+    CanRetainChecker { registry ->
+      if (registry is ContinuityViewModel) {
+        // If this is the root Continuity registry, only retain if the Activity is changing
+        // configuration
+        activity?.isChangingConfigurations == true
+      } else {
+        // Otherwise we always allow retaining for 'child' registries
+        true
+      }
+    }
+  }
 }
 
 private fun Context.findActivity(): Activity? {

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CanRetainChecker.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CanRetainChecker.kt
@@ -10,7 +10,11 @@ import androidx.compose.runtime.staticCompositionLocalOf
 /** Checks whether or not we can retain, usually derived from the current composable context. */
 @Stable
 public fun interface CanRetainChecker {
-  public fun canRetain(): Boolean
+  public fun canRetain(registry: RetainedStateRegistry): Boolean
+
+  public companion object {
+    public val Always: CanRetainChecker = CanRetainChecker { _ -> true }
+  }
 }
 
 public val LocalCanRetainChecker: ProvidableCompositionLocal<CanRetainChecker?> =

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CollectRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CollectRetained.kt
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.retained
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+
+/**
+ * Collects values from this [StateFlow] and represents its latest value via a retained [State]. The
+ * [StateFlow.value] is used as an initial value. Every time there would be new value posted into
+ * the [StateFlow] the returned [State] will be updated causing recomposition of every [State.value]
+ * usage.
+ *
+ * @param context [CoroutineContext] to use for collecting.
+ */
+@Composable
+public fun <T> StateFlow<T>.collectAsRetainedState(
+  context: CoroutineContext = EmptyCoroutineContext
+): State<T> = collectAsRetainedState(value, context)
+
+/**
+ * Collects values from this [Flow] and represents its latest value via retained [State]. Every time
+ * there would be new value posted into the [Flow] the returned [State] will be updated causing
+ * recomposition of every [State.value] usage.
+ *
+ * @param context [CoroutineContext] to use for collecting.
+ */
+@Composable
+public fun <T : R, R> Flow<T>.collectAsRetainedState(
+  initial: R,
+  context: CoroutineContext = EmptyCoroutineContext
+): State<R> =
+  produceRetainedState(initial, this, context) {
+    if (context == EmptyCoroutineContext) {
+      collect { value = it }
+    } else withContext(context) { collect { value = it } }
+  }

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/Continuity.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/Continuity.kt
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.retained
+
+import androidx.compose.runtime.Composable
+
+/** Provides a [RetainedStateRegistry]. */
+@Composable
+public expect fun continuityRetainedStateRegistry(
+  key: String = Continuity.KEY,
+  canRetainChecker: CanRetainChecker = LocalCanRetainChecker.current ?: rememberCanRetainChecker(),
+): RetainedStateRegistry
+
+public object Continuity {
+  public const val KEY: String = "CircuitContinuity"
+}

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -145,7 +145,7 @@ private class RetainableHolder<T>(
 
   fun unregisterIfNotRetainable() {
     // If the value is a RetainedStateRegistry, we need to take care to retain it.
-    // First we tell it to performSave, to retain it's values. Then we need to tell the host
+    // First we tell it to saveAll, to retain it's values. Then we need to tell the host
     // registry to retain the child registry.
     if (value is RetainedStateRegistry) {
       (value as RetainedStateRegistry).saveAll()

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
@@ -109,7 +109,7 @@ internal class RetainedStateRegistryImpl(retained: MutableMap<String, List<Any?>
   }
 
   override fun saveAll() {
-    val map =
+    val values =
       valueProviders.mapValues { (_, list) ->
         // If we have multiple providers we should store null values as well to preserve
         // the order in which providers were registered. Say there were two providers.
@@ -126,11 +126,12 @@ internal class RetainedStateRegistryImpl(retained: MutableMap<String, List<Any?>
           }
       }
 
-    valueProviders.clear()
-
-    if (map.isNotEmpty()) {
-      retained.putAll(map)
+    if (values.isNotEmpty()) {
+      // Store the values in our retained map
+      retained.putAll(values)
     }
+    // Clear the value providers now that we've stored the values
+    valueProviders.clear()
   }
 
   override fun saveValue(key: String) {

--- a/circuit-retained/src/iosMain/kotlin/com/slack/circuit/retained/Continuity.ios.kt
+++ b/circuit-retained/src/iosMain/kotlin/com/slack/circuit/retained/Continuity.ios.kt
@@ -4,8 +4,10 @@ package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
 
-/** Checks whether or not we can retain in the current composable context. */
 @Composable
-public actual fun rememberCanRetainChecker(): CanRetainChecker {
-  return CanRetainChecker.Always
+public actual fun continuityRetainedStateRegistry(
+  key: String,
+  canRetainChecker: CanRetainChecker
+): RetainedStateRegistry {
+  return RetainedStateRegistryImpl(null)
 }

--- a/circuit-retained/src/jsMain/kotlin/com/slack/circuit/retained/CanRetainChecker.js.kt
+++ b/circuit-retained/src/jsMain/kotlin/com/slack/circuit/retained/CanRetainChecker.js.kt
@@ -3,10 +3,9 @@
 package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 
 /** Checks whether or not we can retain in the current composable context. */
 @Composable
 public actual fun rememberCanRetainChecker(): CanRetainChecker {
-  return remember { CanRetainChecker { false } }
+  return CanRetainChecker.Always
 }

--- a/circuit-retained/src/jsMain/kotlin/com/slack/circuit/retained/Continuity.js.kt
+++ b/circuit-retained/src/jsMain/kotlin/com/slack/circuit/retained/Continuity.js.kt
@@ -4,8 +4,10 @@ package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
 
-/** Checks whether or not we can retain in the current composable context. */
 @Composable
-public actual fun rememberCanRetainChecker(): CanRetainChecker {
-  return CanRetainChecker.Always
+public actual fun continuityRetainedStateRegistry(
+  key: String,
+  canRetainChecker: CanRetainChecker,
+): RetainedStateRegistry {
+  return RetainedStateRegistryImpl(null)
 }

--- a/circuit-retained/src/jvmMain/kotlin/com/slack/circuit/retained/CanRetainChecker.jvm.kt
+++ b/circuit-retained/src/jvmMain/kotlin/com/slack/circuit/retained/CanRetainChecker.jvm.kt
@@ -3,10 +3,9 @@
 package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 
 /** Checks whether or not we can retain in the current composable context. */
 @Composable
 public actual fun rememberCanRetainChecker(): CanRetainChecker {
-  return remember { CanRetainChecker { false } }
+  return CanRetainChecker.Always
 }

--- a/circuit-retained/src/jvmMain/kotlin/com/slack/circuit/retained/Continuity.jvm.kt
+++ b/circuit-retained/src/jvmMain/kotlin/com/slack/circuit/retained/Continuity.jvm.kt
@@ -4,8 +4,10 @@ package com.slack.circuit.retained
 
 import androidx.compose.runtime.Composable
 
-/** Checks whether or not we can retain in the current composable context. */
 @Composable
-public actual fun rememberCanRetainChecker(): CanRetainChecker {
-  return CanRetainChecker.Always
+public actual fun continuityRetainedStateRegistry(
+  key: String,
+  canRetainChecker: CanRetainChecker,
+): RetainedStateRegistry {
+  return RetainedStateRegistryImpl(null)
 }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -23,6 +23,8 @@ import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.overlay.ContentWithOverlays
+import com.slack.circuit.retained.LocalRetainedStateRegistry
+import com.slack.circuit.retained.continuityRetainedStateRegistry
 import com.slack.circuit.star.benchmark.ListBenchmarksScreen
 import com.slack.circuit.star.di.ActivityKey
 import com.slack.circuit.star.di.AppScope
@@ -80,7 +82,8 @@ class MainActivity @Inject constructor(private val circuit: Circuit) : AppCompat
           val navigator = rememberAndroidScreenAwareNavigator(circuitNavigator, this::goTo)
           val windowSizeClass = calculateWindowSizeClass(this)
           CompositionLocalProvider(
-            LocalWindowWidthSizeClass provides windowSizeClass.widthSizeClass
+            LocalWindowWidthSizeClass provides windowSizeClass.widthSizeClass,
+            LocalRetainedStateRegistry provides continuityRetainedStateRegistry()
           ) {
             CircuitCompositionLocals(circuit) {
               ContentWithOverlays {


### PR DESCRIPTION
This PR contains a bunch of subtle changes, to enable retained state to be retained whilst UIs and Presenters are on the back stack. To see this in action, you can see this [draft PR](https://github.com/chrisbanes/tivi/pull/1551) on Tivi. The videos attached to it highlight the benefits pretty clearly  🎉.

This follows on from a big discussion on Slack about the best way to keep state around so that presenter cold starts don't mean that we're showing empty states when coming back from the back stack.

## So what are the changes?

### Nested RetainedStateRegistry

Currently `RetainedStateRegistry` is designed to be used single-y, having a global registry used at the root of the content. Since we need to manage the lifecycle of retained state differently per back stack entry, we need a way to be able to 'save' retained state at different times. This PR implements this by making `RetainedStateRegistry` nested-aware, such that registries practically become a tree structure. In practice, this just means a small change to `RetainedStateRegistry` so as `saveAll()` is proxied to any child registries.

### CanRetainChecker changes

We use `CanRetainChecker` as the way to control the lifecycle of retained state. This PR changes the default checker to either `CanRetainChecker.Always` (on non-Android platforms), or makes it nested registry aware on Android.

### collectAsRetainedState

I found this super useful in Tivi. I initially thought about retaining the `Presenter`s last emitted `CircuitUiState` (a bit like `rememberUpdatedState`), but the UI state typically contains some transient properties (`isLoading`, `errorMessage`, etc) which don't make sense to retain. Using `rememberRetainedState` or `collectAsRetainedState` allows retaining of the more long-lived properties only.

### Other

- `continuityRetainedStateRegistry()`. Moved this to `commonMain` with simple implementations for non-Android platforms.
- `SaveableHolder` -> `RetainableHolder`
- Updated Star sample to use a `continuityRetainedStateRegistry`

## Future

There's a few things that this PR doesn't tackle:

- Retaining state for different navigation roots. If the user switches the root navigation entry (i.e via a bottom navigation bar), it would be nice to (optionally) retain the state of each root, similar to AndroidX Navigations `saveState` flag. Should be fairly easy, just need to update the `CanRetainChecker` to retain `if screen was root` (or something).
