### PR TITLE
Demo kotlin 1.9.20 issue with KT-21846

### DIFF
--- a/circuit-test/build.gradle.kts
+++ b/circuit-test/build.gradle.kts
@@ -21,6 +21,8 @@ kotlin {
   }
   // endregion
 
+  compilerOptions { freeCompilerArgs.add("-Xexpect-actual-classes") }
+
   applyDefaultHierarchyTemplate()
 
   sourceSets {

--- a/circuit-test/src/androidMain/kotlin/com/slack/circuit/test/TestEventSink.android.kt
+++ b/circuit-test/src/androidMain/kotlin/com/slack/circuit/test/TestEventSink.android.kt
@@ -1,0 +1,5 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.test
+
+public actual sealed interface BaseTestEventSinkType<UiEvent> : (UiEvent) -> Unit

--- a/circuit-test/src/androidMain/kotlin/com/slack/circuit/test/TestEventSink.android.kt
+++ b/circuit-test/src/androidMain/kotlin/com/slack/circuit/test/TestEventSink.android.kt
@@ -2,4 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.test
 
+@OptIn(ExperimentalMultiplatform::class)
+@AllowDifferentMembersInActual
+// https://youtrack.jetbrains.com/issue/KT-21846
+@Suppress("ACTUAL_TYPE_ALIAS_TO_CLASS_WITH_DECLARATION_SITE_VARIANCE", "INCOMPATIBLE_MATCHING")
 public actual sealed interface BaseTestEventSinkType<UiEvent> : (UiEvent) -> Unit

--- a/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/TestEventSink.kt
+++ b/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/TestEventSink.kt
@@ -8,6 +8,18 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 /**
+ * Base `expect` type for [TestEventSink]. This layer of indirection is necessary because Kotlin/JS
+ * does not allow extension of function types. To work around it, we make this interface extend
+ * `(UiEvent) -> Unit` on all platforms except JS, and then expose an `asEventSinkFunction()`
+ * extension function on [TestEventSink] in JS that returns a function wrapper around it.
+ *
+ * This type is _not_ intended to be used directly or implemented by consumers of this library.
+ */
+public expect sealed interface BaseTestEventSinkType<UiEvent> {
+  public operator fun invoke(event: UiEvent)
+}
+
+/**
  * A test event sink that records events from a Circuit UI and allows making assertions about them.
  *
  * Note: this class was heavily influenced by RxJava3's
@@ -15,7 +27,7 @@ import kotlin.time.toDuration
  *
  * @see CircuitUiEvent
  */
-public class TestEventSink<UiEvent : CircuitUiEvent> {
+public class TestEventSink<UiEvent : CircuitUiEvent> : BaseTestEventSinkType<UiEvent> {
   private val receivedEvents = mutableListOf<UiEvent>()
 
   /**
@@ -23,7 +35,7 @@ public class TestEventSink<UiEvent : CircuitUiEvent> {
    *
    * @param event the [UiEvent] being added to the sink
    */
-  public fun emit(event: UiEvent) {
+  public override operator fun invoke(event: UiEvent) {
     receivedEvents.add(event)
   }
 
@@ -186,12 +198,3 @@ public class TestEventSink<UiEvent : CircuitUiEvent> {
     private fun valueAndClass(obj: Any): String = "$obj (${obj::class.simpleName})"
   }
 }
-
-/**
- * A helper function for creating a function wrapper around this [TestEventSink] for use in tests as
- * an event sink function. We can't make [TestEventSink] extend a function type due to that being
- * prohibited in JS, and we can't use expect/actual for the base type due to that being prohibited
- * in Kotlin 1.9.20+.
- */
-public fun <UiEvent : CircuitUiEvent> TestEventSink<UiEvent>.asEventSinkFunction():
-  (UiEvent) -> Unit = this::emit

--- a/circuit-test/src/iosMain/kotlin/com/slack/circuit/test/TestEventSink.ios.kt
+++ b/circuit-test/src/iosMain/kotlin/com/slack/circuit/test/TestEventSink.ios.kt
@@ -1,0 +1,5 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.test
+
+public actual sealed interface BaseTestEventSinkType<UiEvent> : (UiEvent) -> Unit

--- a/circuit-test/src/iosMain/kotlin/com/slack/circuit/test/TestEventSink.ios.kt
+++ b/circuit-test/src/iosMain/kotlin/com/slack/circuit/test/TestEventSink.ios.kt
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.test
 
+@Suppress("ACTUAL_TYPE_ALIAS_TO_CLASS_WITH_DECLARATION_SITE_VARIANCE", "INCOMPATIBLE_MATCHING")
 public actual sealed interface BaseTestEventSinkType<UiEvent> : (UiEvent) -> Unit

--- a/circuit-test/src/iosMain/kotlin/com/slack/circuit/test/TestEventSink.ios.kt
+++ b/circuit-test/src/iosMain/kotlin/com/slack/circuit/test/TestEventSink.ios.kt
@@ -2,5 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.test
 
+@OptIn(ExperimentalMultiplatform::class)
+@AllowDifferentMembersInActual
+// https://youtrack.jetbrains.com/issue/KT-21846
 @Suppress("ACTUAL_TYPE_ALIAS_TO_CLASS_WITH_DECLARATION_SITE_VARIANCE", "INCOMPATIBLE_MATCHING")
 public actual sealed interface BaseTestEventSinkType<UiEvent> : (UiEvent) -> Unit

--- a/circuit-test/src/jsMain/kotlin/com/slack/circuit/test/TestEventSink.js.kt
+++ b/circuit-test/src/jsMain/kotlin/com/slack/circuit/test/TestEventSink.js.kt
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.test
+
+import com.slack.circuit.runtime.CircuitUiEvent
+
+public actual sealed interface BaseTestEventSinkType<UiEvent> {
+  public actual operator fun invoke(event: UiEvent)
+}
+
+/**
+ * A helper function for creating a function wrapper around this [TestEventSink] for use in tests as
+ * an event sink function. We have to do this workaround in JS due to Kotlin/JS not allowing
+ * function type extension directly.
+ */
+public fun <UiEvent : CircuitUiEvent> TestEventSink<UiEvent>.asEventSinkFunction():
+  (UiEvent) -> Unit = this::invoke

--- a/circuit-test/src/jvmMain/kotlin/com/slack/circuit/test/TestEventSink.jvm.kt
+++ b/circuit-test/src/jvmMain/kotlin/com/slack/circuit/test/TestEventSink.jvm.kt
@@ -1,0 +1,5 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.test
+
+public actual sealed interface BaseTestEventSinkType<UiEvent> : (UiEvent) -> Unit

--- a/circuit-test/src/jvmMain/kotlin/com/slack/circuit/test/TestEventSink.jvm.kt
+++ b/circuit-test/src/jvmMain/kotlin/com/slack/circuit/test/TestEventSink.jvm.kt
@@ -2,4 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.test
 
+@OptIn(ExperimentalMultiplatform::class)
+@AllowDifferentMembersInActual
+// https://youtrack.jetbrains.com/issue/KT-21846
+@Suppress("ACTUAL_TYPE_ALIAS_TO_CLASS_WITH_DECLARATION_SITE_VARIANCE", "INCOMPATIBLE_MATCHING")
 public actual sealed interface BaseTestEventSinkType<UiEvent> : (UiEvent) -> Unit

--- a/circuit-test/src/jvmTest/kotlin/com/slack/circuit/test/TestEventSinkTest.kt
+++ b/circuit-test/src/jvmTest/kotlin/com/slack/circuit/test/TestEventSinkTest.kt
@@ -14,9 +14,9 @@ class TestEventSinkTest {
   @Test
   fun assertEventCount() {
     TestEventSink<Event>().run {
-      emit(Event1)
-      emit(Event2)
-      emit(Event3)
+      invoke(Event1)
+      invoke(Event2)
+      invoke(Event3)
 
       assertEventCount(3)
       assertEvents(Event1, Event2, Event3)
@@ -31,7 +31,7 @@ class TestEventSinkTest {
   @Test
   fun `assertEvent - verify single event`() {
     TestEventSink<Event>().run {
-      emit(Event1)
+      invoke(Event1)
 
       assertEvent(Event1)
     }
@@ -46,8 +46,8 @@ class TestEventSinkTest {
   fun `assertEvent - fails if too many events have been received`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
-        emit(Event2)
+        invoke(Event1)
+        invoke(Event2)
 
         assertEvent(Event1)
       }
@@ -58,7 +58,7 @@ class TestEventSinkTest {
   fun `assertEvent - fails if received and expected fail equality check`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
+        invoke(Event1)
 
         assertEvent(Event2)
       }
@@ -68,7 +68,7 @@ class TestEventSinkTest {
   @Test
   fun `assertEvent - verify single event using predicate`() {
     TestEventSink<Event>().run {
-      emit(Event1)
+      invoke(Event1)
 
       assertEvent { actual -> Event1 == actual }
     }
@@ -78,8 +78,8 @@ class TestEventSinkTest {
   fun `assertEvent - fails using predicate if too many events have been received`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
-        emit(Event2)
+        invoke(Event1)
+        invoke(Event2)
 
         assertEvent { actual -> Event1 == actual }
       }
@@ -90,7 +90,7 @@ class TestEventSinkTest {
   fun `assertEvent - fails when predicate returns false`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
+        invoke(Event1)
 
         assertEvent { false }
       }
@@ -100,9 +100,9 @@ class TestEventSinkTest {
   @Test
   fun `assertEventAt - verify event at index`() {
     TestEventSink<Event>().run {
-      emit(Event1)
-      emit(Event2)
-      emit(Event3)
+      invoke(Event1)
+      invoke(Event2)
+      invoke(Event3)
 
       assertEventAt(0, Event1)
       assertEventAt(1, Event2)
@@ -115,7 +115,7 @@ class TestEventSinkTest {
     val events = listOf(Event1, Event2, Event3)
 
     TestEventSink<Event>().run {
-      events.forEach { emit(it) }
+      events.forEach { invoke(it) }
 
       events.indices.forEach { i -> assertEventAt(i) { actual -> events[i] == actual } }
     }
@@ -134,7 +134,7 @@ class TestEventSinkTest {
   ) {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
+        invoke(Event1)
         assertEventAt(index) { actual -> Event1 == actual }
       }
     }
@@ -144,7 +144,7 @@ class TestEventSinkTest {
   fun `assertEventAt - fails when predicate returns false`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
+        invoke(Event1)
         assertEventAt(0) { false }
       }
     }
@@ -153,9 +153,9 @@ class TestEventSinkTest {
   @Test
   fun `assertEvents - verify multiple events`() {
     TestEventSink<Event>().run {
-      emit(Event1)
-      emit(Event2)
-      emit(Event3)
+      invoke(Event1)
+      invoke(Event2)
+      invoke(Event3)
 
       assertEvents(Event1, Event2, Event3)
     }
@@ -165,9 +165,9 @@ class TestEventSinkTest {
   fun `assertEvents - fails when number of received and expected differ`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
-        emit(Event2)
-        emit(Event3)
+        invoke(Event1)
+        invoke(Event2)
+        invoke(Event3)
 
         assertEvents(Event1, Event2)
       }
@@ -178,9 +178,9 @@ class TestEventSinkTest {
   fun `assertEvents - fails when received and expected fail equality check`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
-        emit(Event2)
-        emit(Event3)
+        invoke(Event1)
+        invoke(Event2)
+        invoke(Event3)
 
         assertEvents(Event1, Event2, Event2)
       }
@@ -192,7 +192,7 @@ class TestEventSinkTest {
     val events = listOf(Event1, Event2, Event3)
 
     TestEventSink<Event>().run {
-      events.forEach { emit(it) }
+      events.forEach { invoke(it) }
 
       assertEvents { i, actual -> events[i] == actual }
     }
@@ -202,7 +202,7 @@ class TestEventSinkTest {
   fun `assertEvents - fails when predicate returns false`() {
     assertThrows(AssertionError::class.java) {
       TestEventSink<Event>().run {
-        emit(Event1)
+        invoke(Event1)
 
         assertEvents { _, _ -> false }
       }

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/petdetail/PetDetailUiTest.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/petdetail/PetDetailUiTest.kt
@@ -24,7 +24,6 @@ import com.slack.circuit.star.petdetail.PetDetailTestConstants.PROGRESS_TAG
 import com.slack.circuit.star.petdetail.PetDetailTestConstants.UNKNOWN_ANIMAL_TAG
 import com.slack.circuit.star.petdetail.PetPhotoCarouselTestConstants.CAROUSEL_TAG
 import com.slack.circuit.test.TestEventSink
-import com.slack.circuit.test.asEventSinkFunction
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -135,7 +134,7 @@ class PetDetailUiTest {
         name = "Baxter",
         description = "Grumpy looking Australian Terrier",
         tags = persistentListOf("dog", "terrier", "male"),
-        eventSink = testSink.asEventSinkFunction()
+        eventSink = testSink
       )
 
     val circuit =

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/petlist/PetListUiTest.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/petlist/PetListUiTest.kt
@@ -22,7 +22,6 @@ import com.slack.circuit.star.petlist.PetListTestConstants.IMAGE_TAG
 import com.slack.circuit.star.petlist.PetListTestConstants.NO_ANIMALS_TAG
 import com.slack.circuit.star.petlist.PetListTestConstants.PROGRESS_TAG
 import com.slack.circuit.test.TestEventSink
-import com.slack.circuit.test.asEventSinkFunction
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -87,13 +86,7 @@ class PetListUiTest {
 
     composeTestRule.run {
       setContent {
-        PetList(
-          PetListScreen.State.Success(
-            animals,
-            isRefreshing = false,
-            eventSink = testSink.asEventSinkFunction()
-          )
-        )
+        PetList(PetListScreen.State.Success(animals, isRefreshing = false, eventSink = testSink))
       }
 
       onAllNodesWithTag(CARD_TAG).assertCountEquals(1)[0].performClick()


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-21846

```
> Task :circuit-test:compileKotlinIosSimulatorArm64 FAILED
e: file:///Users/zacsweers/dev/slack/oss/circuit/circuit-test/src/iosMain/kotlin/com/slack/circuit/test/TestEventSink.ios.kt:5:1 Actual interface 'BaseTestEventSinkType': actual class and its non-final expect class must declare exactly the same supertypes. Actual class declares the following supertypes that are not presented in expect class: 'Function1'. This error happens because the expect class 'BaseTestEventSinkType' is non-final. Also see https://youtrack.jetbrains.com/issue/KT-22841 for more details

```