### PR TITLE
Include retained state registry setup in CircuitCompositionLocals

### DIFF
--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -37,9 +37,8 @@ kotlin {
         api(projects.circuitRuntime)
         api(projects.circuitRuntimePresenter)
         api(projects.circuitRuntimeUi)
+        api(projects.circuitRetained)
         api(libs.compose.ui)
-
-        implementation(projects.circuitRetained)
       }
     }
     val androidMain by getting {

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
@@ -17,8 +16,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.slack.circuit.backstack.rememberSaveableBackStack
-import com.slack.circuit.retained.LocalRetainedStateRegistry
-import com.slack.circuit.retained.continuityRetainedStateRegistry
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
@@ -59,14 +56,10 @@ class NavigableCircuitRetainedStateTest {
           .build()
 
       setContent {
-        CompositionLocalProvider(
-          LocalRetainedStateRegistry provides continuityRetainedStateRegistry()
-        ) {
-          CircuitCompositionLocals(circuit) {
-            val backstack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
-            val navigator = rememberCircuitNavigator(backstack = backstack)
-            NavigableCircuitContent(navigator = navigator, backstack = backstack)
-          }
+        CircuitCompositionLocals(circuit) {
+          val backstack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+          val navigator = rememberCircuitNavigator(backstack = backstack)
+          NavigableCircuitContent(navigator = navigator, backstack = backstack)
         }
       }
 

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitCompositionLocals.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitCompositionLocals.kt
@@ -8,6 +8,9 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
+import com.slack.circuit.retained.LocalRetainedStateRegistry
+import com.slack.circuit.retained.RetainedStateRegistry
+import com.slack.circuit.retained.continuityRetainedStateRegistry
 import com.slack.circuit.runtime.CircuitContext
 
 /**
@@ -15,9 +18,14 @@ import com.slack.circuit.runtime.CircuitContext
  * adds any other composition locals that Circuit needs.
  */
 @Composable
-public fun CircuitCompositionLocals(circuit: Circuit, content: @Composable () -> Unit) {
+public fun CircuitCompositionLocals(
+  circuit: Circuit,
+  retainedStateRegistry: RetainedStateRegistry = continuityRetainedStateRegistry(),
+  content: @Composable () -> Unit
+) {
   CompositionLocalProvider(
     LocalCircuit provides circuit,
+    LocalRetainedStateRegistry provides retainedStateRegistry,
   ) {
     content()
   }

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -23,8 +23,6 @@ import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.overlay.ContentWithOverlays
-import com.slack.circuit.retained.LocalRetainedStateRegistry
-import com.slack.circuit.retained.continuityRetainedStateRegistry
 import com.slack.circuit.star.benchmark.ListBenchmarksScreen
 import com.slack.circuit.star.di.ActivityKey
 import com.slack.circuit.star.di.AppScope
@@ -83,7 +81,6 @@ class MainActivity @Inject constructor(private val circuit: Circuit) : AppCompat
           val windowSizeClass = calculateWindowSizeClass(this)
           CompositionLocalProvider(
             LocalWindowWidthSizeClass provides windowSizeClass.widthSizeClass,
-            LocalRetainedStateRegistry provides continuityRetainedStateRegistry()
           ) {
             CircuitCompositionLocals(circuit) {
               ContentWithOverlays {


### PR DESCRIPTION
This enables circuit-retained automatically in CircuitCompositionLocals by default, while still allowing overriding it to a no-op impl.

Resolves #891