### PR TITLE
Interop sample updates

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -10,5 +10,7 @@ See the README.md files in each sample directory for more information.
   use Circuit in a real-world app. Contains lots of cute dogs.
 - `counter` – A multiplatform counter circuit. This circuit is a simple counter that increments or
   decrements a count.
+- `interop` - A set of examples of interop from different paradigms into Circuit using a simple
+  Counter example.
 - `tacos` - A food ordering flow/wizard app demonstrating use of a composite Circuit presenter and
   multiple nested UIs.

--- a/samples/interop/build.gradle.kts
+++ b/samples/interop/build.gradle.kts
@@ -19,8 +19,6 @@ android {
 
 dependencies {
   implementation(projects.circuitFoundation)
-  // Reuse the counter presenter logic for this sample
-  implementation(projects.samples.counter)
   implementation(libs.androidx.compose.integration.activity)
   implementation(libs.androidx.appCompat)
   implementation(libs.androidx.browser)

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CircuitCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CircuitCounterPresenter.kt
@@ -7,15 +7,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import com.slack.circuit.retained.rememberRetained
-import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
-import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
-import com.slack.circuit.runtime.presenter.presenterOf
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.parcelize.Parcelize
-
 
 class CircuitCounterPresenter : Presenter<CounterScreen.State> {
   @Composable

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CircuitCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CircuitCounterPresenter.kt
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.sample.interop
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import com.slack.circuit.retained.rememberRetained
+import com.slack.circuit.runtime.CircuitContext
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.presenter.presenterOf
+import com.slack.circuit.runtime.screen.Screen
+import kotlinx.parcelize.Parcelize
+
+
+class CircuitCounterPresenter : Presenter<CounterScreen.State> {
+  @Composable
+  override fun present(): CounterScreen.State {
+    var count by rememberRetained { mutableIntStateOf(0) }
+
+    return CounterScreen.State(count) { event ->
+      when (event) {
+        is CounterScreen.Event.Increment -> count++
+        is CounterScreen.Event.Decrement -> count--
+      }
+    }
+  }
+}
+
+@Parcelize
+data object CounterScreen : Screen {
+  data class State(
+    val count: Int,
+    val eventSink: (Event) -> Unit = {},
+  ) : CircuitUiState
+
+  sealed interface Event : CircuitUiEvent {
+
+    data object Increment : Event
+
+    data object Decrement : Event
+  }
+}

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/ComposeCounterUi.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/ComposeCounterUi.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
-import com.slack.circuit.sample.counter.CounterScreen
 
 /** A standard Circuit Counter UI in Compose. */
 @Composable

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
-import com.slack.circuit.sample.counter.CounterScreen
 import com.slack.circuit.sample.interop.databinding.CounterViewBinding
 
 /**

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/CounterView.kt
@@ -12,6 +12,8 @@ import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.slack.circuit.sample.interop.databinding.CounterViewBinding
@@ -61,12 +63,13 @@ constructor(
 /** An interop compose function that renders [CounterView] as a Circuit-powered [AndroidView]. */
 @Composable
 fun CounterViewComposable(state: CounterScreen.State, modifier: Modifier = Modifier) {
+  val eventSink by rememberUpdatedState(state.eventSink)
   AndroidView(
     modifier = modifier.fillMaxSize(),
     factory = { context ->
       CounterView(context).apply {
-        setOnIncrementClickListener { state.eventSink(CounterScreen.Event.Increment) }
-        setOnDecrementClickListener { state.eventSink(CounterScreen.Event.Decrement) }
+        setOnIncrementClickListener { eventSink(CounterScreen.Event.Increment) }
+        setOnDecrementClickListener { eventSink(CounterScreen.Event.Decrement) }
       }
     },
     update = { view -> view.setState(state.count) }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
@@ -11,7 +11,6 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.launchMolecule
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.presenter.presenterOf
-import com.slack.circuit.sample.counter.CounterScreen
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -42,7 +41,6 @@ class FlowCounterPresenter : FlowPresenter<Int, CounterScreen.Event> {
           is CounterScreen.Event.Decrement -> {
             count.emit(count.value - 1)
           }
-          else -> Unit
         }
       }
     }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -40,10 +41,10 @@ import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.presenter.presenterOf
+import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import com.slack.circuit.sample.counter.CounterPresenterFactory
-import com.slack.circuit.sample.counter.CounterScreen
 import kotlinx.parcelize.Parcelize
 
 class MainActivity : AppCompatActivity() {
@@ -138,7 +139,7 @@ private fun SourceMenu(
 ) {
   var expanded by remember { mutableStateOf(false) }
   val selectedName: String by
-    remember(selectedIndex) { mutableStateOf(sourceValues[selectedIndex].presentationName) }
+  remember(selectedIndex) { mutableStateOf(sourceValues[selectedIndex].presentationName) }
   ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
     TextField(
       readOnly = true,
@@ -195,7 +196,7 @@ private fun SourceMenuItem(
 private data class InteropCounterScreen(
   val presenterSource: PresenterSource,
   val uiSource: UiSource
-) : CounterScreen, Parcelable
+) : Screen, Parcelable
 
 @Stable
 private interface Displayable {
@@ -203,15 +204,13 @@ private interface Displayable {
   val presentationName: String
 }
 
-@Suppress("UNCHECKED_CAST")
 private enum class PresenterSource : Displayable {
   Circuit {
     override fun createPresenter(
       screen: InteropCounterScreen,
       context: CircuitContext,
     ): Presenter<CounterScreen.State> {
-      return CounterPresenterFactory().create(screen, Navigator.NoOp, context)
-        as Presenter<CounterScreen.State>
+      return CircuitCounterPresenter()
     }
 
     override val presentationName

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
@@ -39,9 +39,7 @@ import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.runtime.CircuitContext
-import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
-import com.slack.circuit.runtime.presenter.presenterOf
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
@@ -139,7 +137,7 @@ private fun SourceMenu(
 ) {
   var expanded by remember { mutableStateOf(false) }
   val selectedName: String by
-  remember(selectedIndex) { mutableStateOf(sourceValues[selectedIndex].presentationName) }
+    remember(selectedIndex) { mutableStateOf(sourceValues[selectedIndex].presentationName) }
   ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
     TextField(
       readOnly = true,

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/MainActivity.kt
@@ -69,13 +69,13 @@ class MainActivity : AppCompatActivity() {
 
     setContent {
       CircuitCompositionLocals(circuit) {
-        var selectedPresenterIndex by remember { mutableStateOf(0) }
-        var selectedUiIndex by remember { mutableStateOf(0) }
+        var selectedPresenterIndex by remember { mutableIntStateOf(0) }
+        var selectedUiIndex by remember { mutableIntStateOf(0) }
         val circuitScreen =
           remember(selectedUiIndex, selectedPresenterIndex) {
             InteropCounterScreen(
-              PresenterSource.values()[selectedPresenterIndex],
-              UiSource.values()[selectedUiIndex]
+              PresenterSource.entries[selectedPresenterIndex],
+              UiSource.entries[selectedUiIndex]
             )
           }
         val useColumn =
@@ -83,30 +83,33 @@ class MainActivity : AppCompatActivity() {
 
         val menus: @Composable () -> Unit = {
           Column(Modifier.padding(16.dp), Arrangement.spacedBy(16.dp)) {
-            SourceMenu("Presenter Source", selectedPresenterIndex, PresenterSource.values()) { index
-              ->
+            SourceMenu(
+              "Presenter Source",
+              selectedPresenterIndex,
+              PresenterSource.entries.toTypedArray()
+            ) { index ->
               selectedPresenterIndex = index
             }
-            SourceMenu("UI Source", selectedUiIndex, UiSource.values()) { index ->
+            SourceMenu("UI Source", selectedUiIndex, UiSource.entries.toTypedArray()) { index ->
               selectedUiIndex = index
             }
           }
         }
 
         val content = remember {
-          movableContentOf {
+          movableContentOf { screen: Screen ->
             // TODO this is necessary because the CircuitContent caches the Ui and Presenter, which
             //  doesn't play well swapping out the Ui and Presenter sources. Might be nice to make
             //  them live enough to support this, but also sort of orthogonal to the point of this
             //  sample.
-            key(circuitScreen) { CircuitContent(screen = circuitScreen) }
+            key(screen) { CircuitContent(screen = screen) }
           }
         }
 
         Scaffold { paddingValues ->
           if (useColumn) {
             Column(Modifier.padding(paddingValues), Arrangement.spacedBy(16.dp)) {
-              Box(Modifier.weight(1f)) { content() }
+              Box(Modifier.weight(1f)) { content(circuitScreen) }
               menus()
             }
           } else {
@@ -116,7 +119,7 @@ class MainActivity : AppCompatActivity() {
               verticalAlignment = Alignment.CenterVertically
             ) {
               menus()
-              Box(Modifier.weight(1f)) { content() }
+              Box(Modifier.weight(1f)) { content(circuitScreen) }
             }
           }
         }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/RxCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/RxCounterPresenter.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rxjava3.subscribeAsState
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.presenter.presenterOf
-import com.slack.circuit.sample.counter.CounterScreen
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 
@@ -32,7 +31,6 @@ fun RxCounterPresenter.asCircuitPresenter(): Presenter<CounterScreen.State> {
       when (event) {
         is CounterScreen.Event.Increment -> increment()
         is CounterScreen.Event.Decrement -> decrement()
-        else -> Unit
       }
     }
   }

--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/SimpleCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/SimpleCounterPresenter.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.presenter.presenterOf
-import com.slack.circuit.sample.counter.CounterScreen
 
 /** A simple presenter that uses a listener for signaling count changes. */
 class SimpleCounterPresenter {
@@ -66,7 +65,6 @@ fun SimpleCounterPresenter.asCircuitPresenter(): Presenter<CounterScreen.State> 
       when (event) {
         is CounterScreen.Event.Increment -> increment()
         is CounterScreen.Event.Decrement -> decrement()
-        else -> Unit
       }
     }
   }


### PR DESCRIPTION
# Description
Collection of fixes and changes in the interop sample to get it back up to speed and working.

# Changes
## [Update readme to include the interop project](https://github.com/slackhq/circuit/commit/c226da9003dc428f956ac05e28f476cd6138ca03)
- Didn't have the interop sample listed in the samples readme 

## [Fix bug where the screen wouldn't update on selection](https://github.com/slackhq/circuit/commit/624315c8de35ef10b6a348e9cf22f566521d200e)
- Changing the presenter or ui sources was not updating as only the initial screen was captured in the `movableContentOf`

## [Break the dependency on the counter sample](https://github.com/slackhq/circuit/commit/892481c0ba35747116490a73e9b338594bd27480)
- Wasn't really a need to be dependent on the other sample, will make it easier to update the counter sample too

## [Fix CounterView not calling back on right event sink](https://github.com/slackhq/circuit/commit/9e18b81bb6fac85b534fc26f7fccba3be4c180d7)
- When the UI was the view and the presenter was switched the event sink wasn't getting updated to the latest


