### PR TITLE
Better name handling for nested projects in dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,6 +232,7 @@ subprojects {
     apply(plugin = "org.jetbrains.dokka")
 
     tasks.withType<DokkaTaskPartial>().configureEach {
+      moduleName.set(project.path.removePrefix(":").replace(":", "/"))
       outputDirectory.set(layout.buildDirectory.dir("docs/partial"))
       dokkaSourceSets.configureEach {
         val readMeProvider = project.layout.projectDirectory.file("README.md")


### PR DESCRIPTION
The default is the project name, so this better namespaces (albeit unfortunately doesn't collapse sections). Ref https://github.com/Kotlin/dokka/issues/1727

| Before | After |
| ------ | ----- |
| <img width="1470" alt="image" src="https://github.com/slackhq/circuit/assets/1361086/dfb083d8-81f7-45da-b28c-b23b65500c70"> | <img width="1466" alt="image" src="https://github.com/slackhq/circuit/assets/1361086/3860feda-ba44-48d6-a5ad-f3b937b98f38"> |