### PR TITLE
Decompose out multiple circuit internals for reuse + publicize CircuitContent

### DIFF
--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -140,6 +140,7 @@ public fun <UiState : CircuitUiState> CircuitContent(
  *   instantiation. True by default.
  * @param factory a factory to create the [EventListener].
  */
+@Suppress("NOTHING_TO_INLINE")
 @Composable
 public inline fun rememberEventListener(
   screen: Screen,
@@ -162,6 +163,7 @@ public inline fun rememberEventListener(
  *
  * @param factory a factory to create the [Presenter].
  */
+@Suppress("NOTHING_TO_INLINE")
 @Composable
 public inline fun rememberPresenter(
   screen: Screen,
@@ -183,6 +185,7 @@ public inline fun rememberPresenter(
  *
  * @param factory a factory to create the [Ui].
  */
+@Suppress("NOTHING_TO_INLINE")
 @Composable
 public inline fun rememberUi(
   screen: Screen,

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -4,7 +4,6 @@ package com.slack.circuit.foundation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
@@ -88,15 +87,12 @@ internal fun CircuitContent(
   unavailableContent: (@Composable (screen: Screen, modifier: Modifier) -> Unit),
   context: CircuitContext,
 ) {
-  val eventListener =
-    rememberEventListener(screen, context, factory = circuit.eventListenerFactory)
+  val eventListener = rememberEventListener(screen, context, factory = circuit.eventListenerFactory)
   DisposableEffect(eventListener, screen, context) { onDispose { eventListener.dispose() } }
 
-  val presenter =
-    rememberPresenter(screen, navigator, context, eventListener, circuit::presenter)
+  val presenter = rememberPresenter(screen, navigator, context, eventListener, circuit::presenter)
 
-  val ui =
-    rememberUi(screen, context, eventListener, circuit::ui)
+  val ui = rememberUi(screen, context, eventListener, circuit::ui)
 
   if (ui != null && presenter != null) {
     (CircuitContent(screen, modifier, presenter, ui, eventListener))
@@ -140,7 +136,8 @@ public fun <UiState : CircuitUiState> CircuitContent(
 /**
  * Remembers a new [EventListener] instance for the given [screen] and [context].
  *
- * @param startOnInit indicates whether to call [EventListener.start] automatically after instantiation. True by default.
+ * @param startOnInit indicates whether to call [EventListener.start] automatically after
+ *   instantiation. True by default.
  * @param factory a factory to create the [EventListener].
  */
 @Composable
@@ -160,7 +157,8 @@ public inline fun rememberEventListener(
 }
 
 /**
- * Remembers a new [Presenter] instance for the given [screen], [navigator], [context], and [eventListener].
+ * Remembers a new [Presenter] instance for the given [screen], [navigator], [context], and
+ * [eventListener].
  *
  * @param factory a factory to create the [Presenter].
  */
@@ -171,13 +169,14 @@ public inline fun rememberPresenter(
   context: CircuitContext = CircuitContext.EMPTY,
   eventListener: EventListener = EventListener.NONE,
   factory: Presenter.Factory
-): Presenter<CircuitUiState>? = remember(eventListener, screen, navigator, context) {
-  eventListener.onBeforeCreatePresenter(screen, navigator, context)
-  @Suppress("UNCHECKED_CAST")
-  (factory.create(screen, navigator, context) as Presenter<CircuitUiState>?).also {
-    eventListener.onAfterCreatePresenter(screen, navigator, it, context)
+): Presenter<CircuitUiState>? =
+  remember(eventListener, screen, navigator, context) {
+    eventListener.onBeforeCreatePresenter(screen, navigator, context)
+    @Suppress("UNCHECKED_CAST")
+    (factory.create(screen, navigator, context) as Presenter<CircuitUiState>?).also {
+      eventListener.onAfterCreatePresenter(screen, navigator, it, context)
+    }
   }
-}
 
 /**
  * Remembers a new [Ui] instance for the given [screen], [context], and [eventListener].
@@ -190,8 +189,11 @@ public inline fun rememberUi(
   context: CircuitContext = CircuitContext.EMPTY,
   eventListener: EventListener = EventListener.NONE,
   factory: Ui.Factory
-): Ui<CircuitUiState>? = remember(eventListener, screen, context) {
-  eventListener.onBeforeCreateUi(screen, context)
-  @Suppress("UNCHECKED_CAST")
-  (factory.create(screen, context) as Ui<CircuitUiState>?).also { ui -> eventListener.onAfterCreateUi(screen, ui, context) }
-}
+): Ui<CircuitUiState>? =
+  remember(eventListener, screen, context) {
+    eventListener.onBeforeCreateUi(screen, context)
+    @Suppress("UNCHECKED_CAST")
+    (factory.create(screen, context) as Ui<CircuitUiState>?).also { ui ->
+      eventListener.onAfterCreateUi(screen, ui, context)
+    }
+  }

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/CircuitContext.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/CircuitContext.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.runtime
 
+import com.slack.circuit.runtime.internal.NoOpMap
 import kotlin.reflect.KClass
 
 /**
@@ -16,9 +17,9 @@ public class CircuitContext
 @InternalCircuitApi
 public constructor(
   public val parent: CircuitContext?,
-) {
   // Don't expose the raw map.
-  private val tags = mutableMapOf<KClass<*>, Any>()
+  private val tags: MutableMap<KClass<*>, Any> = mutableMapOf(),
+) {
 
   /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
   public fun <T : Any> tag(type: KClass<T>): T? {
@@ -55,5 +56,12 @@ public constructor(
   /** Clears all the current tags. */
   public fun clearTags() {
     tags.clear()
+  }
+
+  public companion object {
+    /** An empty context */
+    @Suppress("UNCHECKED_CAST")
+    @OptIn(InternalCircuitApi::class)
+    public val EMPTY: CircuitContext = CircuitContext(null, NoOpMap as MutableMap<KClass<*>, Any>)
   }
 }

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/internal/NoOpCollections.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/internal/NoOpCollections.kt
@@ -1,0 +1,74 @@
+package com.slack.circuit.runtime.internal
+
+/**
+ * A no-op [MutableMap]. This mimics the behavior of Java's Collections.emptyMap(), which silently ignores mutating operations.
+ */
+internal object NoOpMap : MutableMap<Any, Any> {
+  override val size: Int = 0
+
+  @Suppress("UNCHECKED_CAST")
+  override val entries: MutableSet<MutableMap.MutableEntry<Any, Any>> =
+    NoOpSet as MutableSet<MutableMap.MutableEntry<Any, Any>>
+  override val keys: MutableSet<Any> = NoOpSet
+  override val values: MutableCollection<Any> = NoOpSet
+  override fun clear() {
+
+  }
+
+  override fun isEmpty() = true
+
+  override fun remove(key: Any) = null
+
+  override fun putAll(from: Map<out Any, Any>) {
+
+  }
+
+  override fun put(key: Any, value: Any) = null
+
+  override fun get(key: Any) = null
+
+  override fun containsValue(value: Any) = false
+
+  override fun containsKey(key: Any) = false
+}
+
+/**
+ * A no-op [MutableSet]. This mimics the behavior of Java's Collections.emptySet(), which silently ignores mutating operations.
+ */
+private object NoOpSet : MutableSet<Any> {
+  override fun add(element: Any) = false
+
+  override fun addAll(elements: Collection<Any>) = false
+
+  override val size: Int = 0
+
+  override fun clear() {
+
+  }
+
+  override fun isEmpty() = true
+
+  override fun containsAll(elements: Collection<Any>) = elements.isEmpty()
+
+  override fun contains(element: Any) = false
+
+  override fun iterator() = NoOpIterator
+
+  override fun retainAll(elements: Collection<Any>) = false
+
+  override fun removeAll(elements: Collection<Any>) = false
+
+  override fun remove(element: Any) = false
+
+  object NoOpIterator : MutableIterator<Any> {
+    override fun hasNext() = false
+
+    override fun next(): Any {
+      throw UnsupportedOperationException()
+    }
+
+    override fun remove() {
+      throw UnsupportedOperationException()
+    }
+  }
+}

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/internal/NoOpCollections.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/internal/NoOpCollections.kt
@@ -1,7 +1,10 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.runtime.internal
 
 /**
- * A no-op [MutableMap]. This mimics the behavior of Java's Collections.emptyMap(), which silently ignores mutating operations.
+ * A no-op [MutableMap]. This mimics the behavior of Java's Collections.emptyMap(), which silently
+ * ignores mutating operations.
  */
 internal object NoOpMap : MutableMap<Any, Any> {
   override val size: Int = 0
@@ -11,17 +14,14 @@ internal object NoOpMap : MutableMap<Any, Any> {
     NoOpSet as MutableSet<MutableMap.MutableEntry<Any, Any>>
   override val keys: MutableSet<Any> = NoOpSet
   override val values: MutableCollection<Any> = NoOpSet
-  override fun clear() {
 
-  }
+  override fun clear() {}
 
   override fun isEmpty() = true
 
   override fun remove(key: Any) = null
 
-  override fun putAll(from: Map<out Any, Any>) {
-
-  }
+  override fun putAll(from: Map<out Any, Any>) {}
 
   override fun put(key: Any, value: Any) = null
 
@@ -33,7 +33,8 @@ internal object NoOpMap : MutableMap<Any, Any> {
 }
 
 /**
- * A no-op [MutableSet]. This mimics the behavior of Java's Collections.emptySet(), which silently ignores mutating operations.
+ * A no-op [MutableSet]. This mimics the behavior of Java's Collections.emptySet(), which silently
+ * ignores mutating operations.
  */
 private object NoOpSet : MutableSet<Any> {
   override fun add(element: Any) = false
@@ -42,9 +43,7 @@ private object NoOpSet : MutableSet<Any> {
 
   override val size: Int = 0
 
-  override fun clear() {
-
-  }
+  override fun clear() {}
 
   override fun isEmpty() = true
 


### PR DESCRIPTION
This allows more granular use of CircuitContent and bringing your own presenter/ui instances. This allows more advanced presenters that could choose to pass composable lambdas in as state properties with tight linking of shared state.

It's a little verbose right now as I'm not sure what the best spots are to offer default values or not, but I think that's ok since these are advanced use cases and we can get feedback now. It doesn't take a particularly strong opinion on how to do this, just opens up doors.

```kotlin
// A state with nested content controlled by the presenter.
// Alternatively, the state could expose a presenter factory for the nested content too
data class MyState(
  // other props
  val nestedContent: @Composable () -> Unit,
)

// In a presenter with an injected anotherPresenterFactory and circuit instance
@Composable
override fun present(): MyState {
  val sharedState = remember { mutableStateOf("") }   

  val nestedPresenter = rememberPresenter(...) {
    anotherPresenterFactory.create(sharedState)
  }

  return MyState(...) {
    CircuitContent(NestedScreen, nestedPresenter, ui = rememberUi(screen, ..., circuit::ui))
  }
}

// The UI slots it in
@Composable fun MyUi(state: MyState, modifier: Modifier) {
  Scaffold(modifier) {
    state.nestedContent()
  }
}
```