### PR TITLE
Commonize SaveableStateRegistryBackStackRecordLocalProvider

### DIFF
--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
   alias(libs.plugins.agp.library)
   alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.kotlin.atomicfu)
   alias(libs.plugins.compose)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.baselineprofile)
@@ -26,6 +27,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        implementation(libs.atomicfu)
         api(libs.compose.runtime)
         api(libs.compose.ui)
         api(libs.coroutines)

--- a/backstack/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/backstack/dependencies/androidReleaseRuntimeClasspath.txt
@@ -55,6 +55,8 @@ org.jetbrains.kotlin:kotlin-bom
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:atomicfu-jvm
+org.jetbrains.kotlinx:atomicfu
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
 org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android

--- a/backstack/src/iOSMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.ios.kt
+++ b/backstack/src/iOSMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.ios.kt
@@ -5,4 +5,4 @@ import androidx.compose.runtime.compositionLocalOf
 
 internal actual val LocalBackStackRecordLocalProviders:
   ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
-  get() = compositionLocalOf { emptyList() }
+  get() = compositionLocalOf { listOf(SaveableStateRegistryBackStackRecordLocalProvider) }

--- a/backstack/src/iOSMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.ios.kt
+++ b/backstack/src/iOSMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.ios.kt
@@ -4,5 +4,7 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 
 internal actual val LocalBackStackRecordLocalProviders:
-  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
-  get() = compositionLocalOf { listOf(SaveableStateRegistryBackStackRecordLocalProvider) }
+  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>> =
+  compositionLocalOf {
+    listOf(SaveableStateRegistryBackStackRecordLocalProvider)
+  }

--- a/backstack/src/jsMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.js.kt
+++ b/backstack/src/jsMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.js.kt
@@ -5,4 +5,4 @@ import androidx.compose.runtime.compositionLocalOf
 
 internal actual val LocalBackStackRecordLocalProviders:
   ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
-  get() = compositionLocalOf { emptyList() }
+  get() = compositionLocalOf { listOf(SaveableStateRegistryBackStackRecordLocalProvider) }

--- a/backstack/src/jsMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.js.kt
+++ b/backstack/src/jsMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.js.kt
@@ -4,5 +4,7 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 
 internal actual val LocalBackStackRecordLocalProviders:
-  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
-  get() = compositionLocalOf { listOf(SaveableStateRegistryBackStackRecordLocalProvider) }
+  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>> =
+  compositionLocalOf {
+    listOf(SaveableStateRegistryBackStackRecordLocalProvider)
+  }

--- a/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.jvm.kt
+++ b/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.jvm.kt
@@ -5,4 +5,4 @@ import androidx.compose.runtime.compositionLocalOf
 
 internal actual val LocalBackStackRecordLocalProviders:
   ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
-  get() = compositionLocalOf { emptyList() }
+  get() = compositionLocalOf { listOf(SaveableStateRegistryBackStackRecordLocalProvider) }

--- a/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.jvm.kt
+++ b/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.jvm.kt
@@ -4,5 +4,7 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 
 internal actual val LocalBackStackRecordLocalProviders:
-  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
-  get() = compositionLocalOf { listOf(SaveableStateRegistryBackStackRecordLocalProvider) }
+  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>> =
+  compositionLocalOf {
+    listOf(SaveableStateRegistryBackStackRecordLocalProvider)
+  }

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -59,11 +59,15 @@ kotlin {
     val commonJvmTest =
       maybeCreate("commonJvmTest").apply {
         dependencies {
+          implementation(libs.compose.ui.testing.junit)
           implementation(libs.junit)
           implementation(libs.truth)
         }
       }
-    val jvmTest by getting { dependsOn(commonJvmTest) }
+    val jvmTest by getting {
+      dependsOn(commonJvmTest)
+      dependencies { implementation(compose.desktop.currentOs) }
+    }
     val androidUnitTest by getting {
       dependsOn(commonJvmTest)
       dependencies {
@@ -80,7 +84,12 @@ tasks
   .withType<KotlinCompile>()
   .matching { it.name.contains("test", ignoreCase = true) }
   .configureEach {
-    compilerOptions { freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi") }
+    compilerOptions {
+      freeCompilerArgs.addAll(
+        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+        "-Xexpect-actual-classes" // used for Parcelize in tests
+      )
+    }
   }
 
 android {

--- a/circuit-foundation/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuit-foundation/dependencies/androidReleaseRuntimeClasspath.txt
@@ -65,6 +65,8 @@ org.jetbrains.kotlin:kotlin-bom
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:atomicfu-jvm
+org.jetbrains.kotlinx:atomicfu
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
 org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/ComposeUiTestRunner.android.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/ComposeUiTestRunner.android.kt
@@ -1,0 +1,8 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import org.junit.runner.Runner
+import org.robolectric.RobolectricTestRunner
+
+internal actual fun createRunner(klass: Class<*>): Runner = RobolectricTestRunner(klass)

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/Parcelize.android.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/Parcelize.android.kt
@@ -1,0 +1,5 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+actual typealias Parcelize = kotlinx.parcelize.Parcelize

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/CircuitContentTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/CircuitContentTest.kt
@@ -20,16 +20,14 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.parcelize.Parcelize
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 private const val TAG_BUTTON = "Button"
 private const val TAG_COUNT = "Count"
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(ComposeUiTestRunner::class)
 class CircuitContentTest {
 
   @get:Rule val composeTestRule = createComposeRule()

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ComposeUiTestRunner.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ComposeUiTestRunner.kt
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import org.junit.runner.Description
+import org.junit.runner.Runner
+import org.junit.runner.notification.RunNotifier
+
+/**
+ * A [Runner] to be used with multiplatform Compose tests.
+ *
+ * Internally, this delegates to a platform specific runner.
+ */
+class ComposeUiTestRunner(
+  klass: Class<*>,
+) : Runner() {
+  private val delegateRunner = createRunner(klass)
+
+  override fun getDescription(): Description = delegateRunner.description
+
+  override fun run(notifier: RunNotifier?) = delegateRunner.run(notifier)
+}
+
+internal expect fun createRunner(klass: Class<*>): Runner

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -22,11 +22,9 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.parcelize.Parcelize
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 private const val TAG_GO_NEXT = "go"
 private const val TAG_POP = "pop"
@@ -34,7 +32,7 @@ private const val TAG_INCREASE_COUNT = "inc"
 private const val TAG_COUNT = "count"
 private const val TAG_LABEL = "label"
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(ComposeUiTestRunner::class)
 class NavigableCircuitRetainedStateTest {
 
   @get:Rule val composeTestRule = createComposeRule()
@@ -58,7 +56,11 @@ class NavigableCircuitRetainedStateTest {
       setContent {
         CircuitCompositionLocals(circuit) {
           val backstack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
-          val navigator = rememberCircuitNavigator(backstack = backstack)
+          val navigator =
+            rememberCircuitNavigator(
+              backstack = backstack,
+              onRootPop = {} // no-op for tests
+            )
           NavigableCircuitContent(navigator = navigator, backstack = backstack)
         }
       }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
@@ -1,0 +1,191 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.runtime.ui.ui
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val TAG_GO_NEXT = "go"
+private const val TAG_POP = "pop"
+private const val TAG_INCREASE_COUNT = "inc"
+private const val TAG_COUNT = "count"
+private const val TAG_LABEL = "label"
+
+@RunWith(ComposeUiTestRunner::class)
+class NavigableCircuitSaveableStateTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test fun saveableStateScopedToBackstackWithKeys() = saveableStateScopedToBackstack(true)
+
+  @Test fun saveableStateScopedToBackstackWithoutKeys() = saveableStateScopedToBackstack(false)
+
+  private fun saveableStateScopedToBackstack(useKeys: Boolean) {
+    composeTestRule.run {
+      val circuit =
+        Circuit.Builder()
+          .addPresenterFactory { screen, navigator, _ ->
+            TestCountPresenter(screen as TestScreen, navigator, useKeys)
+          }
+          .addUiFactory { _, _ ->
+            ui<TestState> { state, modifier -> TestContent(state, modifier) }
+          }
+          .build()
+
+      setContent {
+        CircuitCompositionLocals(circuit) {
+          val backstack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+          val navigator =
+            rememberCircuitNavigator(
+              backstack = backstack,
+              onRootPop = {} // no-op for tests
+            )
+          NavigableCircuitContent(navigator = navigator, backstack = backstack)
+        }
+      }
+
+      // Current: Screen A. Increase count to 1
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen C. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Pop to Screen B. Increase count from 1 to 2.
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Navigate to Screen C. Assert that it's state was not saved
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Pop to Screen B. Assert that it's state was saved
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Pop to Screen A. Assert that it's state was saved
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Assert that it's state was not saved
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+
+  private sealed class TestScreen(val label: String) : Screen {
+
+    @Parcelize data object ScreenA : TestScreen("A")
+
+    @Parcelize data object ScreenB : TestScreen("B")
+
+    @Parcelize data object ScreenC : TestScreen("C")
+  }
+
+  @Composable
+  private fun TestContent(state: TestState, modifier: Modifier) {
+    Column(modifier = modifier) {
+      BasicText(text = state.label, modifier = Modifier.testTag(TAG_LABEL))
+
+      BasicText(text = "${state.count}", modifier = Modifier.testTag(TAG_COUNT))
+
+      BasicText(
+        text = "Increase count",
+        modifier =
+          Modifier.testTag(TAG_INCREASE_COUNT).clickable {
+            state.eventSink(TestEvent.IncreaseCount)
+          }
+      )
+
+      BasicText(
+        text = "Pop",
+        modifier = Modifier.testTag(TAG_POP).clickable { state.eventSink(TestEvent.PopNavigation) }
+      )
+      BasicText(
+        text = "Go to next",
+        modifier =
+          Modifier.testTag(TAG_GO_NEXT).clickable { state.eventSink(TestEvent.GoToNextScreen) }
+      )
+    }
+  }
+
+  private class TestCountPresenter(
+    private val screen: TestScreen,
+    private val navigator: Navigator,
+    private val useKeys: Boolean,
+  ) : Presenter<TestState> {
+    @Composable
+    override fun present(): TestState {
+      var launchCount by rememberSaveable(key = "count".takeIf { useKeys }) { mutableIntStateOf(0) }
+
+      return TestState(launchCount, screen.label) { event ->
+        when (event) {
+          TestEvent.IncreaseCount -> launchCount++
+          TestEvent.PopNavigation -> navigator.pop()
+          TestEvent.GoToNextScreen -> {
+            when (screen) {
+              is TestScreen.ScreenA -> navigator.goTo(TestScreen.ScreenB)
+              is TestScreen.ScreenB -> navigator.goTo(TestScreen.ScreenC)
+              else -> error("Can't navigate from $screen")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private data class TestState(
+    val count: Int,
+    val label: String,
+    val eventSink: (TestEvent) -> Unit
+  ) : CircuitUiState
+
+  private sealed interface TestEvent {
+    data object GoToNextScreen : TestEvent
+
+    data object PopNavigation : TestEvent
+
+    data object IncreaseCount : TestEvent
+  }
+}

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
@@ -7,10 +7,8 @@ import com.slack.circuit.backstack.SaveableBackStack
 import com.slack.circuit.runtime.screen.Screen
 import kotlin.test.assertFailsWith
 import kotlin.test.fail
-import kotlinx.parcelize.Parcelize
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 @Parcelize private data object TestScreen : Screen
 
@@ -18,7 +16,7 @@ import org.robolectric.RobolectricTestRunner
 
 @Parcelize private data object TestScreen3 : Screen
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(ComposeUiTestRunner::class)
 class NavigatorTest {
   @Test
   fun errorWhenBackstackIsEmpty() {

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/Parcelize.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/Parcelize.kt
@@ -1,0 +1,7 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+expect annotation class Parcelize()

--- a/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/ComposeUiTestRunner.jvm.kt
+++ b/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/ComposeUiTestRunner.jvm.kt
@@ -1,0 +1,8 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import org.junit.runner.Runner
+import org.junit.runners.BlockJUnit4ClassRunner
+
+internal actual fun createRunner(klass: Class<*>): Runner = BlockJUnit4ClassRunner(klass)

--- a/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/EventListenerTest.kt
+++ b/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/EventListenerTest.kt
@@ -47,10 +47,10 @@ class EventListenerTest {
         .build()
 
     backgroundScope.launchMolecule(Immediate) {
-      CircuitContent(circuit = circuit, screen = TestScreen)
+      CircuitContent(circuit = circuit, screen = TestEventListenerScreen)
     }
     val (screen, listener) = eventListenerFactory.listeners.entries.first()
-    assertThat(screen).isEqualTo(TestScreen)
+    assertThat(screen).isEqualTo(TestEventListenerScreen)
 
     assertThat(listener.events.awaitItem()).isEqualTo(Event.Start)
     assertThat(listener.events.awaitItem()).isEqualTo(Event.OnBeforeCreatePresenter)
@@ -71,7 +71,7 @@ class EventListenerTest {
   }
 }
 
-private data object TestScreen : Screen
+private data object TestEventListenerScreen : Screen
 
 private data class StringState(val value: String) : CircuitUiState
 

--- a/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/Parcelize.jvm.kt
+++ b/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/Parcelize.jvm.kt
@@ -1,0 +1,8 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+/** A no-op [Parcelize] annotation for jvm */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+actual annotation class Parcelize

--- a/circuit-test/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuit-test/dependencies/androidReleaseRuntimeClasspath.txt
@@ -71,6 +71,8 @@ org.jetbrains.kotlin:kotlin-parcelize-runtime
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:atomicfu-jvm
+org.jetbrains.kotlinx:atomicfu
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
 org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android

--- a/circuitx/effects/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuitx/effects/dependencies/androidReleaseRuntimeClasspath.txt
@@ -67,6 +67,8 @@ org.jetbrains.kotlin:kotlin-parcelize-runtime
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:atomicfu-jvm
+org.jetbrains.kotlinx:atomicfu
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
 org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android

--- a/circuitx/gesture-navigation/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuitx/gesture-navigation/dependencies/androidReleaseRuntimeClasspath.txt
@@ -72,6 +72,8 @@ org.jetbrains.kotlin:kotlin-parcelize-runtime
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:atomicfu-jvm
+org.jetbrains.kotlinx:atomicfu
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
 org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android

--- a/circuitx/overlays/dependencies/androidReleaseRuntimeClasspath.txt
+++ b/circuitx/overlays/dependencies/androidReleaseRuntimeClasspath.txt
@@ -72,6 +72,8 @@ org.jetbrains.kotlin:kotlin-parcelize-runtime
 org.jetbrains.kotlin:kotlin-stdlib-jdk7
 org.jetbrains.kotlin:kotlin-stdlib-jdk8
 org.jetbrains.kotlin:kotlin-stdlib
+org.jetbrains.kotlinx:atomicfu-jvm
+org.jetbrains.kotlinx:atomicfu
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm
 org.jetbrains.kotlinx:kotlinx-collections-immutable
 org.jetbrains.kotlinx:kotlinx-coroutines-android

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidx-browser = "1.7.0"
 androidx-lifecycle = "2.6.2"
 agp = "8.2.0"
 anvil = "2.4.8"
+atomicfu = "0.23.1"
 benchmark = "1.2.1"
 coil = "2.5.0"
 compose-animation = "1.5.4"
@@ -69,6 +70,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ## Here to trigger Renovate updates
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-atomicfu = { id = "org.jetbrains.kotlin.plugin.atomicfu", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -153,6 +155,8 @@ androidx-test-monitor = "androidx.test:monitor:1.6.1"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.3.0-alpha05"
 
 anvil-annotations = { module = "com.squareup.anvil:annotations", version.ref = "anvil" }
+
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 
 autoService-annotations = { module = "com.google.auto.service:auto-service-annotations", version = "1.1.1" }
 autoService-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version = "1.1.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -174,6 +174,7 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 compose-runtime-saveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "compose-jb" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-jb" }
 compose-uiUtil = { module = "org.jetbrains.compose.ui:ui-util", version.ref = "compose-jb" }
+compose-ui-testing-junit = { module = "org.jetbrains.compose.ui:ui-test-junit4", version.ref = "compose-jb" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-jb" }
 compose-material-material = { module = "org.jetbrains.compose.material:material", version.ref = "compose-jb" }
 compose-material-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-jb" }


### PR DESCRIPTION
Commit 1:

Commonizes `SaveableStateRegistryBackStackRecordLocalProvider` to be supported across all currently supported platforms by adding it to the default `LocalBackStackRecordLocalProviders`.

The only change this requires was bringing in [atomicfu](https://github.com/Kotlin/kotlinx-atomicfu) for a multiplatform `synchronized` call to replace the jvm-only one.

Commit 2:

Adds tests in `circuit-foundation` to verify the new behavior on both jvm and Android, based on the current retained tests. This required a bit of work to allow the same test to run on both, by setting up a delegating `ComposeUiTestRunner` and typealiased `Parcelize`.

Commit 3:

While I was there, I commonized the rest of `circuit-foundation` tests to run across both jvm and Android. Not directly related to fixing #1036 , can remove or put into a new PR if desired.