### PR TITLE
Add ability to customize ModalBottomSheet appearance in BottomSheetOverlay

### DIFF
--- a/circuitx/overlays/src/androidMain/kotlin/com/slack/circuitx/overlays/BottomSheetOverlay.kt
+++ b/circuitx/overlays/src/androidMain/kotlin/com/slack/circuitx/overlays/BottomSheetOverlay.kt
@@ -4,6 +4,7 @@ package com.slack.circuitx.overlays
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
@@ -15,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.foundation.internal.BackHandler
 import com.slack.circuit.overlay.Overlay
@@ -42,35 +44,67 @@ private constructor(
   private val model: Model,
   private val dismissOnTapOutside: Boolean = true,
   private val onDismiss: (() -> Result)? = null,
+  private val sheetShape: androidx.compose.ui.graphics.Shape? = null,
+  private val sheetContainerColor: Color? = null,
+  private val dragHandle: (@Composable () -> Unit)? = null,
+  private val skipPartiallyExpandedState: Boolean = false,
   private val content: @Composable (Model, OverlayNavigator<Result>) -> Unit,
 ) : Overlay<Result> {
 
   /**
    * Constructs a new [BottomSheetOverlay] that will not dismiss when tapped outside of the sheet.
-   * This means that only the [content] can finish the overlay.
+   * This means that only the [content] can finish the overlay. Additionally the appearance of the
+   * sheet can be customized
+   *
+   * @param sheetContainerColor - set the container color of the ModalBottomSheet
+   * @param dragHandle - customize the drag handle of the sheet
+   * @param skipPartiallyExpandedState - indicates if the Sheet should be expanded per default (if
+   *   it's height exceed the partial height threshold)
    */
   public constructor(
     model: Model,
+    sheetContainerColor: Color? = null,
+    sheetShape: androidx.compose.ui.graphics.Shape? = null,
+    dragHandle: @Composable (() -> Unit)? = null,
+    skipPartiallyExpandedState: Boolean = false,
     content: @Composable (Model, OverlayNavigator<Result>) -> Unit,
   ) : this(
     model = model,
     dismissOnTapOutside = false,
     onDismiss = null,
+    dragHandle = dragHandle,
+    sheetShape = sheetShape,
+    sheetContainerColor = sheetContainerColor,
+    skipPartiallyExpandedState = skipPartiallyExpandedState,
     content = content,
   )
 
   /**
    * Constructs a new [BottomSheetOverlay] that will dismiss when tapped outside of the sheet.
-   * [onDismiss] is required in this case to offer a default value in this event.
+   * [onDismiss] is required in this case to offer a default value in this event. Additionally the
+   * appearance of the sheet can be customized
+   *
+   * @param sheetContainerColor - set the container color of the ModalBottomSheet
+   * @param dragHandle - customize the drag handle of the sheet
+   * @param skipPartiallyExpandedState - indicates if the Sheet should be expanded per default (if
+   *   it's height exceed the partial height threshold)
    */
   public constructor(
     model: Model,
     onDismiss: (() -> Result),
+    sheetContainerColor: Color? = null,
+    sheetShape: androidx.compose.ui.graphics.Shape? = null,
+    dragHandle: @Composable (() -> Unit)? = null,
+    skipPartiallyExpandedState: Boolean = false,
     content: @Composable (Model, OverlayNavigator<Result>) -> Unit,
   ) : this(
     model = model,
     dismissOnTapOutside = true,
     onDismiss = onDismiss,
+    dragHandle = dragHandle,
+    sheetShape = sheetShape,
+    sheetContainerColor = sheetContainerColor,
+    skipPartiallyExpandedState = skipPartiallyExpandedState,
     content = content,
   )
 
@@ -79,6 +113,7 @@ private constructor(
     var hasShown by remember { mutableStateOf(false) }
     val sheetState =
       rememberModalBottomSheetState(
+        skipPartiallyExpanded = skipPartiallyExpandedState,
         confirmValueChange = { newValue ->
           if (hasShown && newValue == SheetValue.Hidden) {
             dismissOnTapOutside
@@ -111,7 +146,9 @@ private constructor(
         }
       },
       sheetState = sheetState,
-      shape = RoundedCornerShape(32.dp),
+      shape = sheetShape ?: RoundedCornerShape(32.dp),
+      containerColor = sheetContainerColor ?: BottomSheetDefaults.ContainerColor,
+      dragHandle = dragHandle ?: { BottomSheetDefaults.DragHandle() },
       // Go edge-to-edge
       windowInsets = WindowInsets(0, 0, 0, 0),
       onDismissRequest = {

--- a/circuitx/overlays/src/androidMain/kotlin/com/slack/circuitx/overlays/BottomSheetOverlay.kt
+++ b/circuitx/overlays/src/androidMain/kotlin/com/slack/circuitx/overlays/BottomSheetOverlay.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.foundation.internal.BackHandler
 import com.slack.circuit.overlay.Overlay
@@ -44,7 +45,7 @@ private constructor(
   private val model: Model,
   private val dismissOnTapOutside: Boolean = true,
   private val onDismiss: (() -> Result)? = null,
-  private val sheetShape: androidx.compose.ui.graphics.Shape? = null,
+  private val sheetShape: Shape? = null,
   private val sheetContainerColor: Color? = null,
   private val dragHandle: (@Composable () -> Unit)? = null,
   private val skipPartiallyExpandedState: Boolean = false,
@@ -64,7 +65,7 @@ private constructor(
   public constructor(
     model: Model,
     sheetContainerColor: Color? = null,
-    sheetShape: androidx.compose.ui.graphics.Shape? = null,
+    sheetShape: Shape? = null,
     dragHandle: @Composable (() -> Unit)? = null,
     skipPartiallyExpandedState: Boolean = false,
     content: @Composable (Model, OverlayNavigator<Result>) -> Unit,
@@ -93,7 +94,7 @@ private constructor(
     model: Model,
     onDismiss: (() -> Result),
     sheetContainerColor: Color? = null,
-    sheetShape: androidx.compose.ui.graphics.Shape? = null,
+    sheetShape: Shape? = null,
     dragHandle: @Composable (() -> Unit)? = null,
     skipPartiallyExpandedState: Boolean = false,
     content: @Composable (Model, OverlayNavigator<Result>) -> Unit,


### PR DESCRIPTION
I've read that you're not accepting external contributions - raised the limitations of the `BottomSheetOverlay` in [a discussion](https://github.com/slackhq/circuit/discussions/1048) - but thought it might be a quick win if we could incorporate those changes directly.

This change adds the ability to customize the `ModalBottomSheet`s appearance:
* `dragHandle`
* `sheetShape`
* `containerColor`

Additionally it adds the ability to specify if the partiallyExpanded state of the sheet should be skipped. (There are use cases where the sheet should directly expand to it's full height)

Would be great if this could be incorporated.
Let me know if the optional parameters in the existing constructors are fine or there should be dedicated ones.