### PR TITLE
Support animating an overlay out after returning a result

### DIFF
--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
@@ -41,8 +41,7 @@ public fun ContentWithOverlays(
             (targetState?.overlay as? AnimatedOverlay)?.enterTransition ?: EnterTransition.None
           val exit =
             (initialState?.overlay as? AnimatedOverlay)?.exitTransition ?: ExitTransition.None
-          val sizeTransform =
-            if (targetState != null) SizeTransform { _, _ -> snap(0) } else null
+          val sizeTransform = if (targetState != null) SizeTransform { _, _ -> snap(0) } else null
           (enter togetherWith exit).using(sizeTransform).also {
             it.targetContentZIndex = targetState?.let { 1f } ?: -1f
           }

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
@@ -3,23 +3,18 @@
 package com.slack.circuit.overlay
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.core.SnapSpec
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.IntSize
 
 /**
  * Renders the given [content] with the ability to show overlays on top of it. This works by
@@ -40,7 +35,6 @@ public fun ContentWithOverlays(
     Box(modifier) {
       content()
       AnimatedContent(
-        modifier = Modifier.fillMaxSize(),
         targetState = overlayHostData,
         transitionSpec = {
           val enter =

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
@@ -41,16 +41,16 @@ public fun ContentWithOverlays(
             (targetState?.overlay as? AnimatedOverlay)?.enterTransition ?: EnterTransition.None
           val exit =
             (initialState?.overlay as? AnimatedOverlay)?.exitTransition ?: ExitTransition.None
-          (enter togetherWith exit)
-            // Disable the size transform animation
-            .using(SizeTransform(sizeAnimationSpec = { _, _ -> snap(0) }))
-            .also { it.targetContentZIndex = targetState?.let { 1f } ?: -1f }
+          val sizeTransform =
+            if (targetState != null) SizeTransform(clip = true) { _, _ -> snap(0) } else null
+          (enter togetherWith exit).using(sizeTransform).also {
+            it.targetContentZIndex = targetState?.let { 1f } ?: -1f
+          }
         },
         contentAlignment = Alignment.Center
       ) { overlayHostData ->
         when (val overlay = overlayHostData?.overlay) {
-          // If the target state content is empty, the exit transition will be ignored.
-          null -> Box(Modifier)
+          null -> Unit
           is AnimatedOverlay -> with(overlay) { AnimatedContent(overlayHostData::finish) }
           overlay -> overlay.Content(overlayHostData::finish)
         }

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.overlay
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 
 /**
@@ -18,6 +24,7 @@ import androidx.compose.ui.Modifier
  * @param overlayHost the [OverlayHost] to use for managing overlays.
  * @param content The regular content to render. Any overlays will be rendered over them.
  */
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 public fun ContentWithOverlays(
   modifier: Modifier = Modifier,
@@ -25,10 +32,40 @@ public fun ContentWithOverlays(
   content: @Composable () -> Unit
 ) {
   CompositionLocalProvider(LocalOverlayHost provides overlayHost) {
-    val overlayHostData by rememberUpdatedState(overlayHost.currentOverlayData)
     Box(modifier) {
       content()
-      key(overlayHostData) { overlayHostData?.let { data -> data.overlay.Content(data::finish) } }
+      val transition = updateTransition(overlayHost.currentOverlayData, label = null)
+      val enterTransition =
+        remember(transition.targetState) {
+          (transition.targetState?.overlay as? AnimatedOverlay)?.enterTransition
+            ?: EnterTransition.None
+        }
+      val exitTransition =
+        remember(transition.currentState) {
+          (transition.currentState?.overlay as? AnimatedOverlay)?.exitTransition
+            ?: ExitTransition.None
+        }
+      transition.AnimatedVisibility(
+        visible = { it != null },
+        modifier = Modifier.fillMaxSize(),
+        enter = enterTransition,
+        exit = exitTransition,
+      ) {
+        // Compute the current overlay data from the transition.
+        // If transitioning from null to not null, we want to use the targetState. And vice-versa,
+        // if transitioning from not null to null, we want to use the currentState.
+        val overlayData by remember {
+          derivedStateOf { transition.currentState ?: transition.targetState }
+        }
+        overlayData?.let { data ->
+          val animatedOverlay = data.overlay as? AnimatedOverlay
+          if (animatedOverlay != null) {
+            with(animatedOverlay) { AnimatedContent(data::finish) }
+          } else {
+            data.overlay.Content(data::finish)
+          }
+        }
+      }
     }
   }
 }

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
@@ -2,19 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.overlay
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.SnapSpec
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntSize
 
 /**
  * Renders the given [content] with the ability to show overlays on top of it. This works by
@@ -24,46 +29,36 @@ import androidx.compose.ui.Modifier
  * @param overlayHost the [OverlayHost] to use for managing overlays.
  * @param content The regular content to render. Any overlays will be rendered over them.
  */
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 public fun ContentWithOverlays(
   modifier: Modifier = Modifier,
   overlayHost: OverlayHost = rememberOverlayHost(),
   content: @Composable () -> Unit
 ) {
+  val overlayHostData by rememberUpdatedState(overlayHost.currentOverlayData)
   CompositionLocalProvider(LocalOverlayHost provides overlayHost) {
     Box(modifier) {
       content()
-      val transition = updateTransition(overlayHost.currentOverlayData, label = null)
-      val enterTransition =
-        remember(transition.targetState) {
-          (transition.targetState?.overlay as? AnimatedOverlay)?.enterTransition
-            ?: EnterTransition.None
-        }
-      val exitTransition =
-        remember(transition.currentState) {
-          (transition.currentState?.overlay as? AnimatedOverlay)?.exitTransition
-            ?: ExitTransition.None
-        }
-      transition.AnimatedVisibility(
-        visible = { it != null },
+      AnimatedContent(
         modifier = Modifier.fillMaxSize(),
-        enter = enterTransition,
-        exit = exitTransition,
-      ) {
-        // Compute the current overlay data from the transition.
-        // If transitioning from null to not null, we want to use the targetState. And vice-versa,
-        // if transitioning from not null to null, we want to use the currentState.
-        val overlayData by remember {
-          derivedStateOf { transition.currentState ?: transition.targetState }
-        }
-        overlayData?.let { data ->
-          val animatedOverlay = data.overlay as? AnimatedOverlay
-          if (animatedOverlay != null) {
-            with(animatedOverlay) { AnimatedContent(data::finish) }
-          } else {
-            data.overlay.Content(data::finish)
-          }
+        targetState = overlayHostData,
+        transitionSpec = {
+          val enter =
+            (targetState?.overlay as? AnimatedOverlay)?.enterTransition ?: EnterTransition.None
+          val exit =
+            (initialState?.overlay as? AnimatedOverlay)?.exitTransition ?: ExitTransition.None
+          (enter togetherWith exit)
+            // Disable the size transform animation
+            .using(SizeTransform(sizeAnimationSpec = { _, _ -> snap(0) }))
+            .also { it.targetContentZIndex = targetState?.let { 1f } ?: -1f }
+        },
+        contentAlignment = Alignment.Center
+      ) { overlayHostData ->
+        when (val overlay = overlayHostData?.overlay) {
+          // If the target state content is empty, the exit transition will be ignored.
+          null -> Box(Modifier)
+          is AnimatedOverlay -> with(overlay) { AnimatedContent(overlayHostData::finish) }
+          overlay -> overlay.Content(overlayHostData::finish)
         }
       }
     }

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/ContentWithOverlays.kt
@@ -42,17 +42,17 @@ public fun ContentWithOverlays(
           val exit =
             (initialState?.overlay as? AnimatedOverlay)?.exitTransition ?: ExitTransition.None
           val sizeTransform =
-            if (targetState != null) SizeTransform(clip = true) { _, _ -> snap(0) } else null
+            if (targetState != null) SizeTransform { _, _ -> snap(0) } else null
           (enter togetherWith exit).using(sizeTransform).also {
             it.targetContentZIndex = targetState?.let { 1f } ?: -1f
           }
         },
         contentAlignment = Alignment.Center
-      ) { overlayHostData ->
-        when (val overlay = overlayHostData?.overlay) {
+      ) { data ->
+        when (val overlay = data?.overlay) {
           null -> Unit
-          is AnimatedOverlay -> with(overlay) { AnimatedContent(overlayHostData::finish) }
-          overlay -> overlay.Content(overlayHostData::finish)
+          is AnimatedOverlay -> with(overlay) { AnimatedContent(data::finish) }
+          else -> overlay.Content(data::finish)
         }
       }
     }

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
@@ -15,11 +15,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.resume
 
 /**
  * An OverlayHost can be used [show] [overlays][Overlay] with content on top of other content. This

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.EnterExitState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.Transition
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.runtime.Composable
@@ -177,8 +176,8 @@ public interface Overlay<Result : Any> {
 /**
  * An [Overlay] that can be animated in and more interestingly out _after_ it has returned a
  * [Result]. The [Overlay] is animated in and out by its [enterTransition] and [exitTransition],
- * [AnimatedContent] is executed with with [AnimatedVisibilityScope] so that child animations can
- * be coordinated with the overlay's animations.
+ * [AnimatedContent] is executed with with [AnimatedVisibilityScope] so that child animations can be
+ * coordinated with the overlay's animations.
  */
 public abstract class AnimatedOverlay<Result : Any>(
   public val enterTransition: EnterTransition,
@@ -186,10 +185,12 @@ public abstract class AnimatedOverlay<Result : Any>(
 ) : Overlay<Result> {
   @Composable
   final override fun Content(navigator: OverlayNavigator<Result>) {
-    val scope = object : AnimatedVisibilityScope {
-      @ExperimentalAnimationApi
-      override val transition: Transition<EnterExitState> = updateTransition(EnterExitState.Visible)
-    }
+    val scope =
+      object : AnimatedVisibilityScope {
+        @ExperimentalAnimationApi
+        override val transition: Transition<EnterExitState> =
+          updateTransition(EnterExitState.Visible)
+      }
     with(scope) { AnimatedContent(navigator) }
   }
 

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.overlay
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.EnterExitState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.Transition
-import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.Stable
@@ -17,11 +15,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.resume
 
 /**
  * An OverlayHost can be used [show] [overlays][Overlay] with content on top of other content. This
@@ -185,13 +183,12 @@ public abstract class AnimatedOverlay<Result : Any>(
 ) : Overlay<Result> {
   @Composable
   final override fun Content(navigator: OverlayNavigator<Result>) {
-    val scope =
-      object : AnimatedVisibilityScope {
-        @ExperimentalAnimationApi
-        override val transition: Transition<EnterExitState> =
-          updateTransition(EnterExitState.Visible)
-      }
-    with(scope) { AnimatedContent(navigator) }
+    AnimatedContent(
+      targetState = Unit,
+      transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+    ) {
+      AnimatedContent(navigator)
+    }
   }
 
   @Composable

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -6,20 +6,15 @@ import android.content.res.Configuration
 import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.AnimationConstants
-import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.spacedBy
@@ -321,9 +316,7 @@ internal fun PetList(
         }
       is PetListScreen.State.Success ->
         PetListGrid(
-          modifier = Modifier
-            .padding(paddingValues)
-            .fillMaxSize(),
+          modifier = Modifier.padding(paddingValues).fillMaxSize(),
           animals = state.animals,
           isRefreshing = state.isRefreshing,
           eventSink = state.eventSink
@@ -358,9 +351,7 @@ private fun PetListGrid(
     @Suppress("MagicNumber")
     LazyVerticalStaggeredGrid(
       columns = StaggeredGridCells.Fixed(columnSpan),
-      modifier = Modifier
-        .fillMaxSize()
-        .testTag(GRID_TAG),
+      modifier = Modifier.fillMaxSize().testTag(GRID_TAG),
       verticalItemSpacing = 16.dp,
       horizontalArrangement = spacedBy(16.dp),
       contentPadding = PaddingValues(16.dp),
@@ -393,9 +384,7 @@ private fun PetListGridItem(
 ) {
   val updatedImageUrl = animal.imageUrl ?: R.drawable.star_icon
   ElevatedCard(
-    modifier = modifier
-      .fillMaxWidth()
-      .testTag(CARD_TAG),
+    modifier = modifier.fillMaxWidth().testTag(CARD_TAG),
     shape = RoundedCornerShape(16.dp),
     colors =
       CardDefaults.elevatedCardColors(
@@ -406,9 +395,7 @@ private fun PetListGridItem(
     Column(modifier = Modifier.clickable { onClick() }) {
       // Image
       AsyncImage(
-        modifier = Modifier
-          .fillMaxWidth()
-          .testTag(IMAGE_TAG),
+        modifier = Modifier.fillMaxWidth().testTag(IMAGE_TAG),
         model =
           ImageRequest.Builder(LocalContext.current)
             .data(updatedImageUrl)
@@ -444,30 +431,23 @@ private suspend fun OverlayHost.updateFilters(currentFilters: Filters): Filters 
     private val model: Model,
     private val onDismiss: () -> Result,
     private val content: @Composable (Model, OverlayNavigator<Result>) -> Unit,
-  ) : AnimatedOverlay<Result>(
-    enterTransition = fadeIn(),
-    exitTransition = fadeOut()
-  ) {
+  ) : AnimatedOverlay<Result>(enterTransition = fadeIn(), exitTransition = fadeOut()) {
     @Composable
     override fun AnimatedVisibilityScope.AnimatedContent(navigator: OverlayNavigator<Result>) {
       Box(Modifier.fillMaxSize()) {
-        Box(Modifier
-          .fillMaxSize()
-          .background(Color.Black.copy(alpha = 0.5f))
-          .clickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = null,
-            onClick = { navigator.finish(onDismiss()) }
-          )
+        Box(
+          Modifier.fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.5f))
+            .clickable(
+              interactionSource = remember { MutableInteractionSource() },
+              indication = null,
+              onClick = { navigator.finish(onDismiss()) }
+            )
         )
         Box(
-          Modifier
-            .fillMaxSize(0.75f)
+          Modifier.fillMaxSize(0.75f)
             .align(Alignment.Center)
-            .animateEnterExit(
-              enter = slideInVertically { it },
-              exit = slideOutVertically { it }
-            ),
+            .animateEnterExit(enter = slideInVertically { it }, exit = slideOutVertically { it }),
           contentAlignment = Alignment.Center
         ) {
           content(model, navigator)

--- a/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
+++ b/samples/star/src/main/kotlin/com/slack/circuit/star/petlist/PetList.kt
@@ -5,17 +5,9 @@ package com.slack.circuit.star.petlist
 import android.content.res.Configuration
 import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
-import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.AnimationConstants
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
@@ -69,7 +61,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -83,10 +74,8 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.overlay.AnimatedOverlay
 import com.slack.circuit.overlay.LocalOverlayHost
 import com.slack.circuit.overlay.OverlayHost
-import com.slack.circuit.overlay.OverlayNavigator
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
@@ -108,6 +97,7 @@ import com.slack.circuit.star.petlist.PetListTestConstants.PROGRESS_TAG
 import com.slack.circuit.star.repo.PetRepository
 import com.slack.circuit.star.ui.LocalWindowWidthSizeClass
 import com.slack.circuit.star.ui.StarTheme
+import com.slack.circuitx.overlays.BottomSheetOverlay
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -425,38 +415,9 @@ private fun PetListGridItem(
   }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 private suspend fun OverlayHost.updateFilters(currentFilters: Filters): Filters {
-  class CardDialogOverlay<Model : Any, Result : Any>(
-    private val model: Model,
-    private val onDismiss: () -> Result,
-    private val content: @Composable (Model, OverlayNavigator<Result>) -> Unit,
-  ) : AnimatedOverlay<Result>(enterTransition = fadeIn(), exitTransition = fadeOut()) {
-    @Composable
-    override fun AnimatedVisibilityScope.AnimatedContent(navigator: OverlayNavigator<Result>) {
-      Box(Modifier.fillMaxSize()) {
-        Box(
-          Modifier.fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.5f))
-            .clickable(
-              interactionSource = remember { MutableInteractionSource() },
-              indication = null,
-              onClick = { navigator.finish(onDismiss()) }
-            )
-        )
-        Box(
-          Modifier.fillMaxSize(0.75f)
-            .align(Alignment.Center)
-            .animateEnterExit(enter = slideInVertically { it }, exit = slideOutVertically { it }),
-          contentAlignment = Alignment.Center
-        ) {
-          content(model, navigator)
-        }
-      }
-    }
-  }
   return show(
-    CardDialogOverlay(
+    BottomSheetOverlay(
       model = currentFilters,
       onDismiss = { currentFilters },
     ) { initialFilters, overlayNavigator ->


### PR DESCRIPTION
Currently, if we want an exit animation for an overlay, we must wait for that animated to complete before returning the [Result]. This results in a lot of perceived lag if the [Result] should update the screen it was launched from. While this can be worked around with injecting callbacks or composition locals, those aren't ideal.

This updates `ContentWithOverlays` to animate an `AnimatedOverlay` in and out instead of just adding and removing it from composition. I'm open to ways to improve this.