### PR TITLE
Run CI on macOS to cover iOS targets too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Necessary to run full tests to cover iOS too
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Their tests will otherwise no-op on non-mac runners