### PR TITLE
Tweak BackStackRecordLocalProvider to get it building on iOS again 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,23 +33,28 @@ jobs:
           java-version: '20'
 
       - name: Build and run checks
-        id: gradle-build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check :samples:star:apk:assembleDebug detektMain detektTest assembleAndroidTest --continue --no-configuration-cache
           gradle-home-cache-cleanup: true
           cache-read-only: false
+
+      - name: Build and run checks
+        id: gradle-build
+        run: |
+          ./gradlew --continue --no-configuration-cache \
+              check \
+              :samples:star:apk:assembleDebug \
+              :samples:counter:linkPodReleaseFrameworkIosX64 \
+              detektMain \
+              detektTest \
+              assembleAndroidTest
 
       # Defer these until after the above run, no need to waste resources running them if there are other failures first
       - name: Run instrumentation tests
         id: gradle-instrumentation
-        uses: gradle/gradle-build-action@v2
         env:
           EW_API_TOKEN: ${{ secrets.EMULATOR_WTF_TOKEN }}
-        with:
-          arguments: testReleaseWithEmulatorWtf
-          gradle-home-cache-cleanup: true
-          cache-read-only: false
+        run: ./gradlew testReleaseWithEmulatorWtf
 
       - name: (Fail-only) Upload reports
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           distribution: 'zulu'
           java-version: '20'
 
-      - name: Build and run checks
+      - name: Setup Gradle cache
         uses: gradle/gradle-build-action@v2
         with:
           gradle-home-cache-cleanup: true

--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.android.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.android.kt
@@ -1,9 +1,5 @@
 package com.slack.circuit.backstack
 
-import androidx.compose.runtime.compositionLocalOf
-
-@Suppress("RemoveExplicitTypeArguments")
-internal actual val LocalBackStackRecordLocalProviders =
-  compositionLocalOf<List<BackStackRecordLocalProvider<BackStack.Record>>> {
-    listOf(SaveableStateRegistryBackStackRecordLocalProvider, ViewModelBackStackRecordLocalProvider)
-  }
+internal actual val defaultBackStackRecordLocalProviders:
+  List<BackStackRecordLocalProvider<BackStack.Record>> =
+  listOf(SaveableStateRegistryBackStackRecordLocalProvider, ViewModelBackStackRecordLocalProvider)

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.kt
@@ -16,7 +16,6 @@
 package com.slack.circuit.backstack
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.key
 import kotlinx.collections.immutable.ImmutableList
@@ -53,7 +52,7 @@ public fun <R : BackStack.Record> providedValuesForBackStack(
             CompositeProvidedValues(
               buildList(stackLocalProviders.size + 1) {
                 if (includeDefaults) {
-                  LocalBackStackRecordLocalProviders.current.forEach {
+                  defaultBackStackRecordLocalProviders.forEach {
                     add(key(it) { it.providedValuesFor(record) })
                   }
                 }
@@ -66,5 +65,5 @@ public fun <R : BackStack.Record> providedValuesForBackStack(
     }
     .toImmutableMap()
 
-internal expect val LocalBackStackRecordLocalProviders:
-  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>>
+internal expect val defaultBackStackRecordLocalProviders:
+  List<BackStackRecordLocalProvider<BackStack.Record>>

--- a/backstack/src/iOSMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.ios.kt
+++ b/backstack/src/iOSMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.ios.kt
@@ -1,10 +1,9 @@
 package com.slack.circuit.backstack
 
-import androidx.compose.runtime.ProvidableCompositionLocal
-import androidx.compose.runtime.compositionLocalOf
-
-internal actual val LocalBackStackRecordLocalProviders:
-  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>> =
-  compositionLocalOf {
-    listOf(SaveableStateRegistryBackStackRecordLocalProvider)
-  }
+/**
+ * This is specifically a get() rather than a statically initialized property. The Kotlin/Native
+ * optimizer seems to trip up otherwise: https://github.com/slackhq/circuit/issues/1075
+ */
+internal actual val defaultBackStackRecordLocalProviders:
+  List<BackStackRecordLocalProvider<BackStack.Record>>
+  get() = listOf(SaveableStateRegistryBackStackRecordLocalProvider)

--- a/backstack/src/jsMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.js.kt
+++ b/backstack/src/jsMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.js.kt
@@ -1,10 +1,5 @@
 package com.slack.circuit.backstack
 
-import androidx.compose.runtime.ProvidableCompositionLocal
-import androidx.compose.runtime.compositionLocalOf
-
-internal actual val LocalBackStackRecordLocalProviders:
-  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>> =
-  compositionLocalOf {
-    listOf(SaveableStateRegistryBackStackRecordLocalProvider)
-  }
+internal actual val defaultBackStackRecordLocalProviders:
+  List<BackStackRecordLocalProvider<BackStack.Record>> =
+  listOf(SaveableStateRegistryBackStackRecordLocalProvider)

--- a/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.jvm.kt
+++ b/backstack/src/jvmMain/kotlin/com/slack/circuit/backstack/BackStackRecordLocalProvider.jvm.kt
@@ -1,10 +1,5 @@
 package com.slack.circuit.backstack
 
-import androidx.compose.runtime.ProvidableCompositionLocal
-import androidx.compose.runtime.compositionLocalOf
-
-internal actual val LocalBackStackRecordLocalProviders:
-  ProvidableCompositionLocal<List<BackStackRecordLocalProvider<BackStack.Record>>> =
-  compositionLocalOf {
-    listOf(SaveableStateRegistryBackStackRecordLocalProvider)
-  }
+internal actual val defaultBackStackRecordLocalProviders:
+  List<BackStackRecordLocalProvider<BackStack.Record>> =
+  listOf(SaveableStateRegistryBackStackRecordLocalProvider)


### PR DESCRIPTION
The Kotlin/Native optimizer seems to have issues with some static properties (issue [here](https://youtrack.jetbrains.com/issue/KT-64508/IndexOutOfBoundsException-in-Konan-StaticInitializersOptimization)).

This PR tweaks BackStackRecordLocalProvider to avoid the offending initializers all together. This does mean that we lose the `CompositionLocal`, but it's internal and not overridden anywhere anyway.

Closes #1075 