### PR TITLE
Prototype different state designs

### DIFF
--- a/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/CounterCircuit.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/CounterCircuit.kt
@@ -1,0 +1,240 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.stateprototyping
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.google.common.truth.Truth.assertThat
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.test.test
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+sealed interface CounterState : CircuitUiState {
+  val count: Int
+
+  /** An interface-only approach where all the events are defined as functions on the interface. */
+  interface AsInterface : CounterState {
+    fun increment()
+
+    fun decrement()
+  }
+
+  /**
+   * As an interface but implementing a common [EventSink] interface and funneling all events as
+   * concrete [Event] classes
+   */
+  interface AsInterfaceWithEventSink : CounterState, EventSink<Event>
+
+  /** As an abstract class with a helper constructor param for funneling events. */
+  abstract class AsAbstractClassWithEventSink(
+    eventSink: (Event) -> Unit = {},
+  ) : CounterState, EventSink<Event> by eventSink(eventSink)
+
+  /** As an abstract class with a helper constructor param for funneling events and properties. */
+  abstract class AsAbstractClassWithEventSinkAndProperties(
+    final override val count: Int,
+    eventSink: (Event) -> Unit = {},
+  ) : CounterState, EventSink<Event> by eventSink(eventSink)
+
+  /** A standard data class implementation of a canonical Circuit state. */
+  data class AsDataClass(
+    override val count: Int,
+    val eventSink: (Event) -> Unit = {},
+  ) : CounterState
+}
+
+sealed interface Event : CircuitUiEvent {
+  data object Increment : Event
+
+  data object Decrement : Event
+}
+
+class AsInterfacePresenter : Presenter<CounterState.AsInterface> {
+  @Composable
+  override fun present(): CounterState.AsInterface {
+    return remember {
+      object : CounterState.AsInterface {
+        override var count: Int by mutableIntStateOf(0)
+          private set
+
+        override fun increment() {
+          count++
+        }
+
+        override fun decrement() {
+          count--
+        }
+      }
+    }
+  }
+}
+
+class AsInterfaceWithEventSinkPresenter : Presenter<CounterState.AsInterfaceWithEventSink> {
+  @Composable
+  override fun present(): CounterState.AsInterfaceWithEventSink {
+    return remember {
+      object : CounterState.AsInterfaceWithEventSink {
+        override var count: Int by mutableIntStateOf(0)
+          private set
+
+        override fun send(event: Event) {
+          when (event) {
+            is Event.Increment -> {
+              count++
+            }
+            is Event.Decrement -> {
+              count--
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+class AsAbstractClassWithEventSinkPresenter : Presenter<CounterState.AsAbstractClassWithEventSink> {
+  @Composable
+  override fun present(): CounterState.AsAbstractClassWithEventSink {
+    return remember {
+      object : CounterState.AsAbstractClassWithEventSink() {
+        override var count: Int by mutableIntStateOf(0)
+          private set
+
+        override fun send(event: Event) {
+          when (event) {
+            is Event.Increment -> {
+              count++
+            }
+            is Event.Decrement -> {
+              count--
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+class AsAbstractClassWithEventSinkAndPropertiesPresenter :
+  Presenter<CounterState.AsAbstractClassWithEventSinkAndProperties> {
+  @Composable
+  override fun present(): CounterState.AsAbstractClassWithEventSinkAndProperties {
+    var count by remember { mutableIntStateOf(0) }
+    // TODO could this be remembered too? Does the State get captured and thus keep it live?
+    return object : CounterState.AsAbstractClassWithEventSinkAndProperties(count) {
+      override fun send(event: Event) {
+        when (event) {
+          is Event.Increment -> {
+            count++
+          }
+          is Event.Decrement -> {
+            count--
+          }
+        }
+      }
+    }
+  }
+}
+
+class AsDataClassPresenter : Presenter<CounterState.AsDataClass> {
+  @Composable
+  override fun present(): CounterState.AsDataClass {
+    var count by remember { mutableIntStateOf(0) }
+    return CounterState.AsDataClass(
+      count = count,
+      eventSink = { event ->
+        when (event) {
+          is Event.Increment -> {
+            count++
+          }
+          is Event.Decrement -> {
+            count--
+          }
+        }
+      }
+    )
+  }
+}
+
+@RunWith(RobolectricTestRunner::class) // Necessary because ComposerImpl touches android.os.Trace
+class Tests {
+  @Test
+  fun asInterface() = runTest {
+    val presenter = AsInterfacePresenter()
+    presenter.test {
+      // Only ever get one item
+      val state = awaitItem()
+      assertThat(state.count).isEqualTo(0)
+      state.increment()
+      assertThat(state.count).isEqualTo(1)
+      state.decrement()
+      assertThat(state.count).isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun asInterfaceWithEventSink() = runTest {
+    val presenter = AsInterfaceWithEventSinkPresenter()
+    presenter.test {
+      // Only ever get one item
+      val state = awaitItem()
+      assertThat(state.count).isEqualTo(0)
+      state.send(Event.Increment)
+      assertThat(state.count).isEqualTo(1)
+      state.send(Event.Decrement)
+      assertThat(state.count).isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun asAbstractClassWithEventSink() = runTest {
+    val presenter = AsAbstractClassWithEventSinkPresenter()
+    presenter.test {
+      // Only ever get one item
+      val state = awaitItem()
+      assertThat(state.count).isEqualTo(0)
+      state.send(Event.Increment)
+      assertThat(state.count).isEqualTo(1)
+      state.send(Event.Decrement)
+      assertThat(state.count).isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun asAbstractClassWithEventSinkAndProperties() = runTest {
+    val presenter = AsAbstractClassWithEventSinkAndPropertiesPresenter()
+    presenter.test {
+      val state = awaitItem()
+      assertThat(state.count).isEqualTo(0)
+      state.send(Event.Increment)
+      val state2 = awaitItem()
+      assertThat(state2.count).isEqualTo(1)
+      state.send(Event.Decrement)
+      val state3 = awaitItem()
+      assertThat(state3.count).isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun asDataClass() = runTest {
+    val presenter = AsDataClassPresenter()
+    presenter.test {
+      val state = awaitItem()
+      assertThat(state.count).isEqualTo(0)
+      state.eventSink(Event.Increment)
+      val state2 = awaitItem()
+      assertThat(state2.count).isEqualTo(1)
+      state.eventSink(Event.Decrement)
+      val state3 = awaitItem()
+      assertThat(state3.count).isEqualTo(0)
+    }
+  }
+}

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/CounterCircuit.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/CounterCircuit.kt
@@ -2,19 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.star.stateprototyping
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToString
 import com.google.common.truth.Truth.assertThat
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.star.stateprototyping.CounterState.AsAbstractClassWithEventSink
+import com.slack.circuit.star.stateprototyping.CounterState.AsDataClass
+import com.slack.circuit.star.stateprototyping.CounterState.AsInterface
+import com.slack.circuit.star.stateprototyping.CounterState.AsInterfaceWithEventSink
+import com.slack.circuit.star.stateprototyping.CounterState.AsPokoClass
 import com.slack.circuit.test.test
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RobolectricTestRunner
 
 sealed interface CounterState : CircuitUiState {
@@ -22,9 +41,10 @@ sealed interface CounterState : CircuitUiState {
 
   /** An interface-only approach where all the events are defined as functions on the interface. */
   interface AsInterface : CounterState {
-    fun increment()
+    // TODO should these have empty defaults for easier testing?
+    fun increment() {}
 
-    fun decrement()
+    fun decrement() {}
   }
 
   /**
@@ -38,13 +58,20 @@ sealed interface CounterState : CircuitUiState {
     eventSink: (Event) -> Unit = {},
   ) : CounterState, EventSink<Event> by eventSink(eventSink)
 
-  /** As an abstract class with a helper constructor param for funneling events and properties. */
-  abstract class AsAbstractClassWithEventSinkAndProperties(
-    final override val count: Int,
+  /**
+   * As a Poko class with a helper constructor param for funneling events and properties.
+   *
+   * Note that Poko isn't actually enabled on the project, but would use a class like this.
+   *
+   * See https://github.com/drewhamilton/Poko
+   */
+  // @Poko
+  class AsPokoClass(
+    override val count: Int,
     eventSink: (Event) -> Unit = {},
   ) : CounterState, EventSink<Event> by eventSink(eventSink)
 
-  /** A standard data class implementation of a canonical Circuit state. */
+  /** As a standard data class implementation of a canonical Circuit state. */
   data class AsDataClass(
     override val count: Int,
     val eventSink: (Event) -> Unit = {},
@@ -57,11 +84,11 @@ sealed interface Event : CircuitUiEvent {
   data object Decrement : Event
 }
 
-class AsInterfacePresenter : Presenter<CounterState.AsInterface> {
+class AsInterfacePresenter : Presenter<AsInterface> {
   @Composable
-  override fun present(): CounterState.AsInterface {
+  override fun present(): AsInterface {
     return remember {
-      object : CounterState.AsInterface {
+      object : AsInterface {
         override var count: Int by mutableIntStateOf(0)
           private set
 
@@ -77,11 +104,11 @@ class AsInterfacePresenter : Presenter<CounterState.AsInterface> {
   }
 }
 
-class AsInterfaceWithEventSinkPresenter : Presenter<CounterState.AsInterfaceWithEventSink> {
+class AsInterfaceWithEventSinkPresenter : Presenter<AsInterfaceWithEventSink> {
   @Composable
-  override fun present(): CounterState.AsInterfaceWithEventSink {
+  override fun present(): AsInterfaceWithEventSink {
     return remember {
-      object : CounterState.AsInterfaceWithEventSink {
+      object : AsInterfaceWithEventSink {
         override var count: Int by mutableIntStateOf(0)
           private set
 
@@ -100,11 +127,11 @@ class AsInterfaceWithEventSinkPresenter : Presenter<CounterState.AsInterfaceWith
   }
 }
 
-class AsAbstractClassWithEventSinkPresenter : Presenter<CounterState.AsAbstractClassWithEventSink> {
+class AsAbstractClassWithEventSinkPresenter : Presenter<AsAbstractClassWithEventSink> {
   @Composable
-  override fun present(): CounterState.AsAbstractClassWithEventSink {
+  override fun present(): AsAbstractClassWithEventSink {
     return remember {
-      object : CounterState.AsAbstractClassWithEventSink() {
+      object : AsAbstractClassWithEventSink() {
         override var count: Int by mutableIntStateOf(0)
           private set
 
@@ -123,32 +150,29 @@ class AsAbstractClassWithEventSinkPresenter : Presenter<CounterState.AsAbstractC
   }
 }
 
-class AsAbstractClassWithEventSinkAndPropertiesPresenter :
-  Presenter<CounterState.AsAbstractClassWithEventSinkAndProperties> {
+class AsPokoClassPresenter : Presenter<AsPokoClass> {
   @Composable
-  override fun present(): CounterState.AsAbstractClassWithEventSinkAndProperties {
+  override fun present(): AsPokoClass {
     var count by remember { mutableIntStateOf(0) }
     // TODO could this be remembered too? Does the State get captured and thus keep it live?
-    return object : CounterState.AsAbstractClassWithEventSinkAndProperties(count) {
-      override fun send(event: Event) {
-        when (event) {
-          is Event.Increment -> {
-            count++
-          }
-          is Event.Decrement -> {
-            count--
-          }
+    return AsPokoClass(count) { event ->
+      when (event) {
+        is Event.Increment -> {
+          count++
+        }
+        is Event.Decrement -> {
+          count--
         }
       }
     }
   }
 }
 
-class AsDataClassPresenter : Presenter<CounterState.AsDataClass> {
+class AsDataClassPresenter : Presenter<AsDataClass> {
   @Composable
-  override fun present(): CounterState.AsDataClass {
+  override fun present(): AsDataClass {
     var count by remember { mutableIntStateOf(0) }
-    return CounterState.AsDataClass(
+    return AsDataClass(
       count = count,
       eventSink = { event ->
         when (event) {
@@ -164,7 +188,8 @@ class AsDataClassPresenter : Presenter<CounterState.AsDataClass> {
   }
 }
 
-@RunWith(RobolectricTestRunner::class) // Necessary because ComposerImpl touches android.os.Trace
+// Robolectric is necessary because ComposerImpl touches android.os.Trace
+@RunWith(RobolectricTestRunner::class)
 class Tests {
   @Test
   fun asInterface() = runTest {
@@ -209,8 +234,8 @@ class Tests {
   }
 
   @Test
-  fun asAbstractClassWithEventSinkAndProperties() = runTest {
-    val presenter = AsAbstractClassWithEventSinkAndPropertiesPresenter()
+  fun asPokoClass() = runTest {
+    val presenter = AsPokoClassPresenter()
     presenter.test {
       val state = awaitItem()
       assertThat(state.count).isEqualTo(0)
@@ -235,6 +260,131 @@ class Tests {
       state.eventSink(Event.Decrement)
       val state3 = awaitItem()
       assertThat(state3.count).isEqualTo(0)
+    }
+  }
+}
+
+abstract class BaseUiTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Composable
+  fun Counter(state: CounterState, modifier: Modifier = Modifier) {
+    Column(modifier) {
+      Button(
+        onClick = {
+          when (state) {
+            is AsInterface -> state.increment()
+            is AsInterfaceWithEventSink -> state.send(Event.Increment)
+            is AsAbstractClassWithEventSink -> state.send(Event.Increment)
+            is AsPokoClass -> state.send(Event.Increment)
+            is AsDataClass -> state.eventSink(Event.Increment)
+          }
+        }
+      ) {
+        Text(text = "Increment")
+      }
+      Text(text = "Count: ${state.count}", modifier = Modifier.testTag("COUNT"))
+      Button(
+        onClick = {
+          when (state) {
+            is AsInterface -> state.decrement()
+            is AsInterfaceWithEventSink -> state.send(Event.Decrement)
+            is AsAbstractClassWithEventSink -> state.send(Event.Decrement)
+            is AsPokoClass -> state.send(Event.Decrement)
+            is AsDataClass -> state.eventSink(Event.Decrement)
+          }
+        }
+      ) {
+        Text(text = "Decrement")
+      }
+    }
+  }
+}
+
+/**
+ * Tests that demonstrate what it's like standing up new functional [Counter] UIs with presenters.
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class FunctionalUiTest(private val presenter: Presenter<CounterState>) : BaseUiTest() {
+  companion object {
+    @JvmStatic
+    @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+    fun data(): List<Array<Any>> {
+      return listOf(
+        arrayOf(AsInterfacePresenter()),
+        arrayOf(AsInterfaceWithEventSinkPresenter()),
+        arrayOf(AsAbstractClassWithEventSinkPresenter()),
+        arrayOf(AsPokoClassPresenter()),
+        arrayOf(AsDataClassPresenter()),
+      )
+    }
+  }
+
+  @Test
+  fun functionalTest() {
+    composeTestRule.run {
+      setContent {
+        val state = presenter.present()
+        Counter(state)
+      }
+
+      println(onRoot().printToString())
+
+      onNodeWithText("Count").assertTextContains("0")
+      onNodeWithText("Increment").performClick()
+      onNodeWithText("Count").assertTextContains("1")
+      onNodeWithText("Decrement").performClick()
+      onNodeWithText("Count").assertTextContains("0")
+    }
+  }
+}
+
+/**
+ * Tests that demonstrate what it's like standing up new [CounterState] instances manually. This
+ * reflects how simple UI tests without a presenter, previews, or snapshot tests would work.
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class StaticUiTest(val state: (count: Int) -> CounterState) : BaseUiTest() {
+  companion object {
+    @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
+    @JvmStatic
+    @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+    fun data(): List<Array<Any>> {
+      return listOf(
+        arrayOf({ count: Int ->
+          object : AsInterface {
+            override val count = count
+          }
+        }),
+        arrayOf({ count: Int ->
+          object : AsInterfaceWithEventSink, EventSink<Event> by fakeSink() {
+            override val count = count
+          }
+        }),
+        arrayOf({ count: Int ->
+          object : AsAbstractClassWithEventSink(), EventSink<Event> by fakeSink() {
+            override val count = count
+          }
+        }),
+        arrayOf(::AsPokoClass),
+        // Standard data class state. Simplest to stand up
+        arrayOf(::AsDataClass),
+      )
+    }
+  }
+
+  @Test
+  fun simpleTest() {
+    composeTestRule.run {
+      var count by mutableStateOf(state(0))
+      setContent { Counter(count) }
+
+      println(onRoot().printToString())
+
+      onNodeWithText("Count").assertTextContains("0")
+      count = state(1)
+      onNodeWithText("Count").assertTextContains("1")
     }
   }
 }

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/CounterCircuit.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/CounterCircuit.kt
@@ -367,9 +367,9 @@ class StaticUiTest(val state: (count: Int) -> CounterState) : BaseUiTest() {
             override val count = count
           }
         }),
-        arrayOf(::AsPokoClass),
+        arrayOf({ count: Int -> AsPokoClass(count) }),
         // Standard data class state. Simplest to stand up
-        arrayOf(::AsDataClass),
+        arrayOf({ count: Int -> AsDataClass(count) }),
       )
     }
   }

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/EventSink.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/EventSink.kt
@@ -17,11 +17,25 @@ fun <UiEvent : CircuitUiEvent> fakeSink(): EventSink<UiEvent> =
     }
   }
 
+/**
+ * Creates an [EventSink] that calls the given [body] when [EventSink.send] is called.
+ *
+ * Note this inline function + [InlineEventSink] return type are a bit of bytecode trickery to avoid
+ * creating a new class for every lambda passed to this function. The end result should be that the
+ * lambda is inlined directly to the field in the implementing class and the inlined
+ * [EventSink.send] method impl is inlined directly as well to call it.
+ */
+@Suppress("NOTHING_TO_INLINE")
 inline fun <UiEvent : CircuitUiEvent> eventSink(
-  crossinline body: (UiEvent) -> Unit
-): EventSink<UiEvent> =
-  object : EventSink<UiEvent> {
-    override fun send(event: UiEvent) {
-      body(event)
-    }
+  noinline body: (UiEvent) -> Unit
+): InlineEventSink<UiEvent> = InlineEventSink(body)
+
+/** @see eventSink */
+@JvmInline
+value class InlineEventSink<UiEvent : CircuitUiEvent>
+@PublishedApi
+internal constructor(private val body: (UiEvent) -> Unit) : EventSink<UiEvent> {
+  override fun send(event: UiEvent) {
+    body(event)
   }
+}

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/EventSink.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/EventSink.kt
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.star.stateprototyping
+
+import androidx.compose.runtime.Stable
+import com.slack.circuit.runtime.CircuitUiEvent
+
+@Stable
+interface EventSink<UiEvent : CircuitUiEvent> {
+  fun send(event: UiEvent)
+}
+
+inline fun <UiEvent : CircuitUiEvent> eventSink(
+  crossinline body: (UiEvent) -> Unit
+): EventSink<UiEvent> =
+  object : EventSink<UiEvent> {
+    override fun send(event: UiEvent) {
+      body(event)
+    }
+  }

--- a/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/EventSink.kt
+++ b/samples/star/src/test/kotlin/com/slack/circuit/star/stateprototyping/EventSink.kt
@@ -10,6 +10,13 @@ interface EventSink<UiEvent : CircuitUiEvent> {
   fun send(event: UiEvent)
 }
 
+fun <UiEvent : CircuitUiEvent> fakeSink(): EventSink<UiEvent> =
+  object : EventSink<UiEvent> {
+    override fun send(event: UiEvent) {
+      // Do nothing
+    }
+  }
+
 inline fun <UiEvent : CircuitUiEvent> eventSink(
   crossinline body: (UiEvent) -> Unit
 ): EventSink<UiEvent> =


### PR DESCRIPTION
Based on some conversations with @adamp and @jingibus

There are a few different examples here.

1. `AsDataClass` - a canonical Circuit state data class with an encapsulated event sink.
	  - **Pros**
	    - Familiar to UDF
	    - Easy to pipe into Molecule, which unlocks...
	      - Dead-simple to stand up tests, assert new state emissions
	      - Easy to potentially run presenters detached from the UI (retained, off the main thread, etc)
	      - Easy to interop to non-Compose/non-Circuit frameworks
	    - Dead-simple to stand up UI tests with stub states
	    - Testing events coming out of UIs is easy w/ `TestEventSink`
	  - **Cons**
	  	- New states emit each time, incurring recompositions
	  	- Event sink property results in broken equals/hashCode/toString unless you remember the sink first (sometimes?). See #1074

2. `AsPokoClass` - similar to `AsDataClass`, but would use the [Poko](https://github.com/drewhamilton/Poko) library to generate `equals`/`hashCode`/`toString` for every property but the `eventSink`. Events in this case would move to a `EventSink` interface, where events are sent instead to a `send()` function.
	  - **Pros**
	    - Familiar to UDF
	    - Easy to pipe into Molecule, which unlocks...
	      - Dead-simple to stand up tests, assert new state emissions
	      - Easy to potentially run presenters detached from the UI (retained, off the main thread, etc)
	      - Easy to interop to non-Compose/non-Circuit frameworks
	    - Dead-simple to stand up UI tests with stub states
	    - Event sink doesn't participate in equals/hashCode/toString
	    - Testing events coming out of UIs is easy w/ `TestEventSink`
	  - **Cons**
	  	- New states emit each time, incurring recompositions
	  	- Requires another library/compiler plugin
	  - **Unclear if pro or con or neither**
	  	- State now _is_ an event sink

3. `AsInterface` - an interface implementation of state, more akin to traditional Compose states with interfaces backed by `State` objects and driven by snapshots. This exposes no event sink, but rather semantically meaningful functions. These state objects are `remember`'d and only one is ever emitted.
	  - **Pros**
	    - Familiar to conventional Compose
	    - Single state emission/instance, stable by definition. Properties can be backed directly with `State` objects. More granular recomposition in the UI as a result.
	    - Event sink doesn't participate in equals/hashCode/toString
	  - **Cons**
	  	- Realistically requires lint checks to prevent `var`, `MutableState`, missing `remember`, etc calls.
	  	- Unclear if this can work with Molecule at all, which in turn...
	  	  - Makes interop with other frameworks harder
	  	  - Cannot potentially run presenters detached from the UI (retained, off the main thread, etc)
	  	- Standing up stub states in tests are more tedious vs simple value classes
	  	- Line between the state class and the presenter get blurrier WRT state ownership/responsibilities
	  	- Testing events coming out of UI is no longer easy or doable with `TestEventSink`. Developers may reach for mocking + verify if they aren't using a functional presenter
	  - **Unclear if pro or con or neither**
	  	- State now only emits once, tests must now assert state properties individually
	  	- Somewhat departs UDF, or at least a significantly different flavor of it
	  	- Presenter tests are different, only one state means you just interact with that instance. Tools like `snapshotFlow` could still be useful in tandem with Turbine, but most of the existing test infra in Circuit isn't useful for this pattern.

This boils down to two patterns - immutable state trees (1 and 2) and stable snapshot-driven objects (3). 1 and 2 are more traditional UDF, 3 is more traditional compose.

Others presented as examples
4. `AsInterfaceWithEventSink` - similar to `AsInterface`, but with an `EventSink` supertype for event objects rather than function calls.
5. `AsAbstractClassWithEventSink` - something in between the 1 and 3, with the best/worst of both worlds.

----

One really great thing here is that Circuit's current published API supports all of these cases, so its preference/guidance for one doesn't inherently prohibit the use of the others.