### PR TITLE
Fix unused enter/exit transitions in AnimatedOverlay

### DIFF
--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
@@ -185,7 +185,7 @@ public abstract class AnimatedOverlay<Result : Any>(
   final override fun Content(navigator: OverlayNavigator<Result>) {
     AnimatedContent(
       targetState = Unit,
-      transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
+      transitionSpec = { enterTransition togetherWith exitTransition },
     ) {
       AnimatedContent(navigator)
     }


### PR DESCRIPTION
CC @bryanstern. Spotted in https://github.com/slackhq/circuit/pull/1066#discussion_r1438902009