### PR TITLE
Fall back to emulator runners on CI for external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,26 @@ jobs:
               assembleAndroidTest
 
       # Defer these until after the above run, no need to waste resources running them if there are other failures first
-      - name: Run instrumentation tests
+      - name: Run instrumentation tests via emulator.wtf (main repo only)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         id: gradle-instrumentation
         env:
           EW_API_TOKEN: ${{ secrets.EMULATOR_WTF_TOKEN }}
         run: ./gradlew testReleaseWithEmulatorWtf
+
+      # Forks cannot run emulator.wtf tests due to not being able to use repo secrets, so for them
+      # we run the tests via the android-emulator-runner action instead
+      - name: Run instrumentation tests (from forks only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        id: gradle-instrumentation-fork
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 21
+          arch: x86_64
+          disable-animations: true
+          disk-size: 6000M
+          heap-size: 600M
+          script: ./gradlew ciConnectedCheck --daemon
 
       - name: (Fail-only) Upload reports
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Forks cannot run emulator.wtf tests due to not being able to use repo secrets, so for them
       # we run the tests via the android-emulator-runner action instead
-      - name: Run instrumentation tests (from forks only)
+      - name: Run instrumentation tests via local emulator (from forks only)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         id: gradle-instrumentation-fork
         uses: reactivecircus/android-emulator-runner@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -449,6 +449,13 @@ subprojects {
     if (emulatorWtfToken.isPresent) {
       configure<EwExtension> { token.set(emulatorWtfToken) }
     }
+    // We don't always run emulator.wtf on CI (forks can't access it), so we add this helper
+    // lifecycle task that depends on connectedCheck as an alternative. We do this only on projects
+    // that apply emulator.wtf though as we don't want to run _all_ connected checks on CI since
+    // that would include benchmarks.
+    tasks.register("ciConnectedCheck") {
+      dependsOn("connectedCheck")
+    }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -453,9 +453,7 @@ subprojects {
     // lifecycle task that depends on connectedCheck as an alternative. We do this only on projects
     // that apply emulator.wtf though as we don't want to run _all_ connected checks on CI since
     // that would include benchmarks.
-    tasks.register("ciConnectedCheck") {
-      dependsOn("connectedCheck")
-    }
+    tasks.register("ciConnectedCheck") { dependsOn("connectedCheck") }
   }
 }
 


### PR DESCRIPTION
This should avoid the current setup of PRs from forks failing due to not being able to run EW tests.

CC @chrisbanes 