### PR TITLE
Fix lifetime of Records' ViewModelStores

### DIFF
--- a/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/ViewModelBackStackRecordLocalProvider.kt
+++ b/backstack/src/androidMain/kotlin/com/slack/circuit/backstack/ViewModelBackStackRecordLocalProvider.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
 private fun Context.findActivity(): Activity? {
@@ -56,25 +57,14 @@ internal object ViewModelBackStackRecordLocalProvider :
       )
     val viewModelStore = containerViewModel.viewModelStoreForKey(record.key)
     val activity = LocalContext.current.findActivity()
-    remember(record, viewModelStore) {
-      object : RememberObserver {
-        override fun onAbandoned() {
-          disposeIfNotChangingConfiguration()
-        }
-
-        override fun onForgotten() {
-          disposeIfNotChangingConfiguration()
-        }
-
-        override fun onRemembered() {}
-
-        fun disposeIfNotChangingConfiguration() {
+    val observer =
+      remember(record, viewModelStore) {
+        NestedRememberObserver {
           if (activity?.isChangingConfigurations != true) {
             containerViewModel.removeViewModelStoreOwnerForKey(record.key)?.clear()
           }
         }
       }
-    }
     return remember(viewModelStore) {
       val list =
         persistentListOf<ProvidedValue<*>>(
@@ -85,7 +75,11 @@ internal object ViewModelBackStackRecordLocalProvider :
         )
       @Suppress("ObjectLiteralToLambda")
       object : ProvidedValues {
-        @Composable override fun provideValues() = list
+        @Composable
+        override fun provideValues(): PersistentList<ProvidedValue<*>> {
+          remember { observer.UiRememberObserver() }
+          return list
+        }
       }
     }
   }
@@ -111,5 +105,49 @@ internal class BackStackRecordLocalProviderViewModel : ViewModel() {
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
       return create(modelClass)
     }
+  }
+}
+
+private class NestedRememberObserver(
+  private val onCompletelyForgotten: () -> Unit,
+) : RememberObserver {
+  private var isRememberedForStack: Boolean = false
+    set(value) {
+      field = value
+      recomputeState()
+    }
+
+  private var isRememberedForUi: Boolean = false
+    set(value) {
+      field = value
+      recomputeState()
+    }
+
+  private fun recomputeState() {
+    if (!isRememberedForUi && !isRememberedForStack) {
+      onCompletelyForgotten()
+    }
+  }
+
+  inner class UiRememberObserver : RememberObserver {
+    override fun onRemembered() {
+      isRememberedForUi = true
+    }
+
+    override fun onAbandoned() = onForgotten()
+
+    override fun onForgotten() {
+      isRememberedForUi = false
+    }
+  }
+
+  override fun onRemembered() {
+    isRememberedForStack = true
+  }
+
+  override fun onAbandoned() = onForgotten()
+
+  override fun onForgotten() {
+    isRememberedForStack = false
   }
 }

--- a/circuit-foundation/src/androidUnitTest/AndroidManifest.xml
+++ b/circuit-foundation/src/androidUnitTest/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <activity android:name="com.slack.circuit.foundation.NavigableCircuitRetainedStateTestActivity"/>
+        <activity android:name="com.slack.circuit.foundation.NavigableCircuitViewModelStateTestActivity"/>
     </application>
 </manifest>

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitViewModelStateAndroidTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitViewModelStateAndroidTest.kt
@@ -1,0 +1,190 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertAll
+import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasTextExactly
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import com.slack.circuit.internal.test.TestContentTags.TAG_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_INCREASE_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(ComposeUiTestRunner::class)
+class NavigableCircuitViewModelStateAndroidTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<NavigableCircuitViewModelStateTestActivity>()
+
+  private val scenario: ActivityScenario<NavigableCircuitViewModelStateTestActivity>
+    get() = composeTestRule.activityRule.scenario
+
+  @Test
+  fun retainedStateScopedToBackstackWithRecreations() {
+    composeTestRule.run {
+      mainClock.autoAdvance = false
+
+      // Current: Screen A. Increase count to 1
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      mainClock.advanceTimeByFrame()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      mainClock.advanceTimeBy(1_000)
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      mainClock.advanceTimeByFrame()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen C. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      mainClock.advanceTimeBy(1_000)
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      mainClock.advanceTimeByFrame()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Pop to Screen B. Increase count from 1 to 2.
+      onNodeWithTag(TAG_POP).performClick()
+
+      // Part-way through pop, both screens should be visible
+      onEachFrameWhileMultipleScreens(hasTestTag(TAG_LABEL)) {
+        onAllNodesWithTag(TAG_LABEL)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("C"))
+          .assertAny(hasTextExactly("B"))
+        onAllNodesWithTag(TAG_COUNT).assertCountEquals(2).assertAll(hasTextExactly("1"))
+      }
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      mainClock.advanceTimeByFrame()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Navigate to Screen C. Assert that it's state was not retained
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+
+      // Part-way through push, both screens should be visible
+      onEachFrameWhileMultipleScreens(hasTestTag(TAG_LABEL)) {
+        onAllNodesWithTag(TAG_LABEL)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("C"))
+          .assertAny(hasTextExactly("B"))
+        onAllNodesWithTag(TAG_COUNT)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("0"))
+          .assertAny(hasTextExactly("2"))
+      }
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Pop to Screen B. Assert that it's state was retained
+      onNodeWithTag(TAG_POP).performClick()
+
+      // Part-way through pop, both screens should be visible
+      onEachFrameWhileMultipleScreens(hasTestTag(TAG_LABEL)) {
+        onAllNodesWithTag(TAG_LABEL)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("C"))
+          .assertAny(hasTextExactly("B"))
+        onAllNodesWithTag(TAG_COUNT)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("0"))
+          .assertAny(hasTextExactly("2"))
+      }
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Pop to Screen A. Assert that it's state was retained
+      onNodeWithTag(TAG_POP).performClick()
+
+      // Part-way through pop, both screens should be visible
+      onEachFrameWhileMultipleScreens(hasTestTag(TAG_LABEL)) {
+        onAllNodesWithTag(TAG_LABEL)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("B"))
+          .assertAny(hasTextExactly("A"))
+        onAllNodesWithTag(TAG_COUNT)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("2"))
+          .assertAny(hasTextExactly("1"))
+      }
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Assert that it's state was not retained
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      mainClock.advanceTimeBy(1_000)
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+
+  private fun ComposeTestRule.onEachFrameWhileMultipleScreens(
+    matcher: SemanticsMatcher,
+    block: ComposeTestRule.() -> Unit
+  ) {
+    var i = 0
+    while (true) {
+      mainClock.advanceTimeByFrame()
+      if (onAllNodes(matcher).fetchSemanticsNodes().size <= 1) {
+        break
+      }
+      try {
+        block()
+      } catch (e: Throwable) {
+        throw AssertionError("Error on frame $i", e)
+      }
+      i++
+    }
+  }
+}

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitViewModelStateTestActivity.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitViewModelStateTestActivity.kt
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.internal.test.TestCountPresenter
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.createTestCircuit
+
+class NavigableCircuitViewModelStateTestActivity : ComponentActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.ViewModel)
+
+    setContent {
+      CircuitCompositionLocals(circuit) {
+        val backstack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+        val navigator =
+          rememberCircuitNavigator(
+            backstack = backstack,
+            onRootPop = {} // no-op for tests
+          )
+        NavigableCircuitContent(navigator = navigator, backstack = backstack)
+      }
+    }
+  }
+}

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
@@ -72,11 +72,17 @@ class ProvidedValuesLifetimeTest {
       // Navigate to Screen B
       onNodeWithTag(TestContentTags.TAG_GO_NEXT).performClick()
       mainClock.advanceTimeBy(1_000)
+      waitForIdle()
+      mainClock.advanceTimeBy(1_000)
+      waitForIdle()
       onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("Local B")
 
       // Navigate to Screen C
       onNodeWithTag(TestContentTags.TAG_GO_NEXT).performClick()
       mainClock.advanceTimeBy(1_000)
+      waitForIdle()
+      mainClock.advanceTimeBy(1_000)
+      waitForIdle()
       onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("Local C")
 
       // Pop to Screen B

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
@@ -4,6 +4,10 @@ package com.slack.circuit.foundation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertTextEquals
@@ -18,8 +22,12 @@ import com.slack.circuit.backstack.ProvidedValues
 import com.slack.circuit.backstack.providedValuesForBackStack
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.internal.test.TestContentTags
+import com.slack.circuit.internal.test.TestEvent
 import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.TestState
 import com.slack.circuit.internal.test.createTestCircuit
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
 import kotlinx.collections.immutable.persistentListOf
 import org.junit.Rule
 import org.junit.Test
@@ -34,7 +42,10 @@ class ProvidedValuesLifetimeTest {
     composeTestRule.run {
       mainClock.autoAdvance = false
 
-      val circuit = createTestCircuit()
+      val circuit =
+        createTestCircuit(
+          presenter = { screen, navigator -> TestPresenter(screen as TestScreen, navigator) },
+        )
 
       setContent {
         CircuitCompositionLocals(circuit) {
@@ -56,49 +67,47 @@ class ProvidedValuesLifetimeTest {
         }
       }
 
-      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("Local A")
 
       // Navigate to Screen B
       onNodeWithTag(TestContentTags.TAG_GO_NEXT).performClick()
       mainClock.advanceTimeBy(1_000)
-      waitForIdle()
-      mainClock.advanceTimeBy(1_000)
-      waitForIdle()
-      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("Local B")
 
       // Navigate to Screen C
       onNodeWithTag(TestContentTags.TAG_GO_NEXT).performClick()
       mainClock.advanceTimeBy(1_000)
-      waitForIdle()
-      mainClock.advanceTimeBy(1_000)
-      waitForIdle()
-      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("Local C")
 
       // Pop to Screen B
       onNodeWithTag(TestContentTags.TAG_POP).performClick()
 
       // Part-way through pop, both screens should be visible
-      mainClock.advanceTimeByFrame()
-      onAllNodesWithTag(TestContentTags.TAG_LABEL)
-        .assertCountEquals(2)
-        .assertAny(hasTextExactly("C"))
-        .assertAny(hasTextExactly("B"))
+      repeat(10) {
+        mainClock.advanceTimeByFrame()
+        onAllNodesWithTag(TestContentTags.TAG_LABEL)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("Local C"))
+          .assertAny(hasTextExactly("Local B"))
+      }
 
       mainClock.advanceTimeBy(1_000)
-      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("Local B")
 
       // Pop to Screen A
       onNodeWithTag(TestContentTags.TAG_POP).performClick()
 
       // Part-way through pop, both screens should be visible
-      mainClock.advanceTimeByFrame()
-      onAllNodesWithTag(TestContentTags.TAG_LABEL)
-        .assertCountEquals(2)
-        .assertAny(hasTextExactly("B"))
-        .assertAny(hasTextExactly("A"))
+      repeat(10) {
+        mainClock.advanceTimeByFrame()
+        onAllNodesWithTag(TestContentTags.TAG_LABEL)
+          .assertCountEquals(2)
+          .assertAny(hasTextExactly("Local B"))
+          .assertAny(hasTextExactly("Local A"))
+      }
 
       mainClock.advanceTimeBy(1_000)
-      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TestContentTags.TAG_LABEL).assertTextEquals("Local A")
     }
   }
 
@@ -106,10 +115,38 @@ class ProvidedValuesLifetimeTest {
     val LocalWithDefault = compositionLocalOf { "Default" }
   }
 
+  class TestPresenter(
+    private val screen: TestScreen,
+    private val navigator: Navigator,
+  ) : Presenter<TestState> {
+    @Composable
+    override fun present(): TestState {
+      var count by remember { mutableIntStateOf(0) }
+
+      return TestState(count, LocalWithDefault.current) { event ->
+        when (event) {
+          TestEvent.IncreaseCount -> count++
+          TestEvent.PopNavigation -> navigator.pop()
+          TestEvent.GoToNextScreen -> {
+            when (screen) {
+              is TestScreen.ScreenA -> navigator.goTo(TestScreen.ScreenB)
+              is TestScreen.ScreenB -> navigator.goTo(TestScreen.ScreenC)
+              else -> error("Can't navigate from $screen")
+            }
+          }
+        }
+      }
+    }
+  }
+
   private object TestBackStackRecordLocalProvider : BackStackRecordLocalProvider<BackStack.Record> {
     @Composable
-    override fun providedValuesFor(record: BackStack.Record): ProvidedValues = ProvidedValues {
-      persistentListOf(LocalWithDefault provides (record.screen as TestScreen).label)
+    override fun providedValuesFor(record: BackStack.Record): ProvidedValues {
+      return ProvidedValues {
+        persistentListOf(
+          LocalWithDefault provides remember { "Local ${(record.screen as TestScreen).label}" }
+        )
+      }
     }
   }
 }

--- a/internal-test-utils/src/androidMain/kotlin/com/slack/circuit/internal/test/TestContent.android.kt
+++ b/internal-test-utils/src/androidMain/kotlin/com/slack/circuit/internal/test/TestContent.android.kt
@@ -1,0 +1,30 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.internal.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+actual fun rememberViewModel(key: String?): MutableIntState {
+  return viewModel<TestStateViewModel>(
+      key = key,
+      factory = TestStateViewModel.Factory,
+    )
+    .counterState
+}
+
+private class TestStateViewModel : ViewModel() {
+  val counterState = mutableIntStateOf(0)
+
+  object Factory : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      return TestStateViewModel() as T
+    }
+  }
+}

--- a/internal-test-utils/src/iosMain/kotlin/com/slack/circuit/internal/test/TestContent.ios.kt
+++ b/internal-test-utils/src/iosMain/kotlin/com/slack/circuit/internal/test/TestContent.ios.kt
@@ -1,0 +1,13 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.internal.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Composable
+actual fun rememberViewModel(key: String?): MutableIntState {
+  return rememberSaveable(key = key) { mutableIntStateOf(0) }
+}

--- a/internal-test-utils/src/jsMain/kotlin/com/slack/circuit/internal/test/TestContent.js.kt
+++ b/internal-test-utils/src/jsMain/kotlin/com/slack/circuit/internal/test/TestContent.js.kt
@@ -1,0 +1,13 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.internal.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Composable
+actual fun rememberViewModel(key: String?): MutableIntState {
+  return rememberSaveable(key = key) { mutableIntStateOf(0) }
+}

--- a/internal-test-utils/src/jvmMain/kotlin/com/slack/circuit/internal/test/TestContent.jvm.kt
+++ b/internal-test-utils/src/jvmMain/kotlin/com/slack/circuit/internal/test/TestContent.jvm.kt
@@ -1,0 +1,13 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.internal.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Composable
+actual fun rememberViewModel(key: String?): MutableIntState {
+  return rememberSaveable(key = key) { mutableIntStateOf(0) }
+}


### PR DESCRIPTION
Fixes original issue reported in https://github.com/slackhq/circuit/issues/1065

The fix in https://github.com/slackhq/circuit/pull/1086 only made sure the correct ViewModelStore was present, but `ViewModel.onCleared()` is still being called upon stack-pop, not once the Presenter/Ui completely left composition.

This PR tracks both "stack" lifetime and "ui" lifetime and only clears the ViewModelStore when both have been forgotten. I piggybacked on shared `RememberType` stuff, I hope that's alright.

Also fixes `ProvidedValuesLifetimeTest` to read the CompositionLocal again, using better special values to hopefully prevent accidental breaking again