### PR TITLE
Use ubuntu-latest with baseline profile gen

### DIFF
--- a/.github/workflows/update-baseline-profiles.yml
+++ b/.github/workflows/update-baseline-profiles.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   update-baseline-profiles:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-baseline-profiles.yml
+++ b/.github/workflows/update-baseline-profiles.yml
@@ -27,6 +27,12 @@ jobs:
           distribution: 'zulu'
           java-version: '20'
 
+      - name: Enable KVM group perms
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Looks like the new runners after [this](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/) support kvm too. Much faster too, from mid-20s to 5min.