### PR TITLE
Allow saving/restoring navigation stack on root resets (aka multi back stack)

### DIFF
--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.compose)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.baselineprofile)
+  alias(libs.plugins.kotlin.plugin.parcelize)
 }
 
 kotlin {
@@ -44,7 +45,13 @@ kotlin {
         api(libs.androidx.compose.runtime)
       }
     }
-    val commonTest by getting { dependencies { implementation(libs.kotlin.test) } }
+    val commonTest by getting {
+      dependencies {
+        implementation(libs.kotlin.test)
+        implementation(libs.testing.assertk)
+        implementation(projects.internalTestUtils)
+      }
+    }
     val commonJvmTest =
       maybeCreate("commonJvmTest").apply {
         dependencies {

--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
   alias(libs.plugins.compose)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.baselineprofile)
-  alias(libs.plugins.kotlin.plugin.parcelize)
 }
 
 kotlin {

--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -62,6 +62,14 @@ kotlin {
   }
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>().configureEach {
+  compilerOptions {
+    // Need to disable, due to 'duplicate library name' warning
+    // https://youtrack.jetbrains.com/issue/KT-51110
+    allWarningsAsErrors = false
+  }
+}
+
 android { namespace = "com.slack.circuit.backstack" }
 
 androidComponents { beforeVariants { variant -> variant.enableAndroidTest = false } }

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
@@ -53,10 +53,22 @@ public interface BackStack<R : Record> : Iterable<R> {
     while (topRecord?.let(predicate) == false) pop()
   }
 
-  /** TODO */
+  /**
+   * Saves the current back stack entry list in an internal state store. It can be later restored by
+   * the root screen to [restoreState].
+   *
+   * This call will overwrite any existing stored state with the same root screen.
+   */
   public fun saveState()
 
-  /** TODO */
+  /**
+   * Restores the saved state with the given [screen], adding it on top of the existing entry list.
+   * If you wish to replace the current entry list, you should [pop] all of the existing entries off
+   * before calling this function.
+   *
+   * @param screen The root screen which was previously saved using [saveState].
+   * @return Returns true if there was any back stack state to restore.
+   */
   public fun restoreState(screen: Screen): Boolean
 
   public interface Record {

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
@@ -53,6 +53,12 @@ public interface BackStack<R : Record> : Iterable<R> {
     while (topRecord?.let(predicate) == false) pop()
   }
 
+  /** TODO */
+  public fun saveState()
+
+  /** TODO */
+  public fun restoreState(screen: Screen): Boolean
+
   public interface Record {
     /**
      * A value that identifies this record uniquely, even if it shares the same [screen] with

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -38,6 +38,10 @@ public class SaveableBackStack : BackStack<SaveableBackStack.Record> {
 
   private val entryList = mutableStateListOf<Record>()
 
+  // TODO: make this lazy?
+  // TODO: make this map limited in size?
+  private val stateStore = mutableMapOf<Screen, List<Record>>()
+
   override val size: Int
     get() = entryList.size
 
@@ -59,6 +63,23 @@ public class SaveableBackStack : BackStack<SaveableBackStack.Record> {
   }
 
   override fun pop(): Record? = entryList.removeFirstOrNull()
+
+  override fun saveState() {
+    val rootScreen = entryList.last().screen
+    stateStore[rootScreen] = entryList.toList()
+  }
+
+  override fun restoreState(screen: Screen): Boolean {
+    val stored = stateStore[screen]
+    if (!stored.isNullOrEmpty()) {
+      // Add the store state into the entry list
+      entryList.addAll(stored)
+      // Clear the stored state
+      stateStore.remove(screen)
+      return true
+    }
+    return false
+  }
 
   public data class Record(
     override val screen: Screen,

--- a/backstack/src/commonTest/kotlin/com/slack/circuit/backstack/SaveableBackStackTest.kt
+++ b/backstack/src/commonTest/kotlin/com/slack/circuit/backstack/SaveableBackStackTest.kt
@@ -22,13 +22,20 @@ class SaveableBackStackTest {
     backStack.push(TestScreen.ScreenB)
 
     assertThat(backStack.entryList).hasSize(3)
-    assertThat(backStack.entryList[0].screen).isEqualTo(TestScreen.ScreenB)
-    assertThat(backStack.entryList[1].screen).isEqualTo(TestScreen.ScreenA)
-    assertThat(backStack.entryList[2].screen).isEqualTo(TestScreen.RootAlpha)
     assertThat(backStack.stateStore).isEmpty()
 
-    // Now save state and pop everything off
+    // Now save state
     backStack.saveState()
+    // Assert that state store contains the current back stack
+    assertThat(backStack.stateStore).hasSize(1)
+    backStack.stateStore[TestScreen.RootAlpha].let { saved ->
+      assertThat(saved).isNotNull()
+      saved!!
+      assertThat(saved[0].screen).isEqualTo(TestScreen.ScreenB)
+      assertThat(saved[1].screen).isEqualTo(TestScreen.ScreenA)
+      assertThat(saved[2].screen).isEqualTo(TestScreen.RootAlpha)
+    }
+
     // Now pop everything off and add RootB + Screen C
     backStack.popUntil { false }
     backStack.push(TestScreen.RootBeta)
@@ -38,16 +45,6 @@ class SaveableBackStackTest {
     assertThat(backStack.entryList).hasSize(2)
     assertThat(backStack.entryList[0].screen).isEqualTo(TestScreen.ScreenC)
     assertThat(backStack.entryList[1].screen).isEqualTo(TestScreen.RootBeta)
-
-    // Assert that the state store contains the stack from RootB
-    assertThat(backStack.stateStore).hasSize(1)
-    backStack.stateStore[TestScreen.RootAlpha].let { stack ->
-      assertThat(stack).isNotNull().hasSize(3)
-      stack!!
-      assertThat(stack[0].screen).isEqualTo(TestScreen.ScreenB)
-      assertThat(stack[1].screen).isEqualTo(TestScreen.ScreenA)
-      assertThat(stack[2].screen).isEqualTo(TestScreen.RootAlpha)
-    }
 
     // Now pop everything off and restore RootA
     backStack.popUntil { false }

--- a/backstack/src/commonTest/kotlin/com/slack/circuit/backstack/SaveableBackStackTest.kt
+++ b/backstack/src/commonTest/kotlin/com/slack/circuit/backstack/SaveableBackStackTest.kt
@@ -1,0 +1,115 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package com.slack.circuit.backstack
+
+import androidx.compose.runtime.saveable.SaverScope
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import com.slack.circuit.internal.test.TestScreen
+import kotlin.test.Test
+
+class SaveableBackStackTest {
+
+  @Test
+  fun test_save_and_restore_backstack_state() {
+    val backStack = SaveableBackStack()
+    backStack.push(TestScreen.RootAlpha)
+    backStack.push(TestScreen.ScreenA)
+    backStack.push(TestScreen.ScreenB)
+
+    assertThat(backStack.entryList).hasSize(3)
+    assertThat(backStack.entryList[0].screen).isEqualTo(TestScreen.ScreenB)
+    assertThat(backStack.entryList[1].screen).isEqualTo(TestScreen.ScreenA)
+    assertThat(backStack.entryList[2].screen).isEqualTo(TestScreen.RootAlpha)
+    assertThat(backStack.stateStore).isEmpty()
+
+    // Now save state and pop everything off
+    backStack.saveState()
+    // Now pop everything off and add RootB + Screen C
+    backStack.popUntil { false }
+    backStack.push(TestScreen.RootBeta)
+    backStack.push(TestScreen.ScreenC)
+
+    // Assert that the entry list contains the new items
+    assertThat(backStack.entryList).hasSize(2)
+    assertThat(backStack.entryList[0].screen).isEqualTo(TestScreen.ScreenC)
+    assertThat(backStack.entryList[1].screen).isEqualTo(TestScreen.RootBeta)
+
+    // Assert that the state store contains the stack from RootB
+    assertThat(backStack.stateStore).hasSize(1)
+    backStack.stateStore[TestScreen.RootAlpha].let { stack ->
+      assertThat(stack).isNotNull().hasSize(3)
+      stack!!
+      assertThat(stack[0].screen).isEqualTo(TestScreen.ScreenB)
+      assertThat(stack[1].screen).isEqualTo(TestScreen.ScreenA)
+      assertThat(stack[2].screen).isEqualTo(TestScreen.RootAlpha)
+    }
+
+    // Now pop everything off and restore RootA
+    backStack.popUntil { false }
+    backStack.restoreState(TestScreen.RootAlpha)
+
+    // Assert that the RootA stack was restored
+    assertThat(backStack.entryList).hasSize(3)
+    assertThat(backStack.entryList[0].screen).isEqualTo(TestScreen.ScreenB)
+    assertThat(backStack.entryList[1].screen).isEqualTo(TestScreen.ScreenA)
+    assertThat(backStack.entryList[2].screen).isEqualTo(TestScreen.RootAlpha)
+    // And that the state store is now empty
+    assertThat(backStack.stateStore).isEmpty()
+  }
+
+  @Test
+  fun test_saveable_save_and_restore() {
+    val backStack = SaveableBackStack()
+    backStack.push(TestScreen.RootAlpha)
+    backStack.push(TestScreen.ScreenA)
+    backStack.push(TestScreen.ScreenB)
+
+    val saved = save(backStack)
+    assertThat(saved).isNotNull()
+    saved!!
+
+    val restored = SaveableBackStack.Saver.restore(saved)
+    assertThat(restored).isNotNull()
+    restored!!
+
+    assertThat(backStack.entryList.toList()).isEqualTo(restored.entryList.toList())
+    assertThat(backStack.stateStore.toMap()).isEqualTo(restored.stateStore.toMap())
+  }
+
+  @Test
+  fun test_saveable_save_and_restore_with_backstack_state() {
+    val backStack = SaveableBackStack()
+    backStack.push(TestScreen.RootAlpha)
+    backStack.push(TestScreen.ScreenA)
+    backStack.push(TestScreen.ScreenB)
+
+    // Now save state and pop everything off
+    backStack.saveState()
+    // Now pop everything off and add RootB + Screen C
+    backStack.popUntil { false }
+    backStack.push(TestScreen.RootBeta)
+    backStack.push(TestScreen.ScreenC)
+
+    val saved = save(backStack)
+    assertThat(saved).isNotNull()
+    saved!!
+
+    val restored = SaveableBackStack.Saver.restore(saved)
+    assertThat(restored).isNotNull()
+    restored!!
+
+    assertThat(backStack.entryList.toList()).isEqualTo(restored.entryList.toList())
+    assertThat(backStack.stateStore.toMap()).isEqualTo(restored.stateStore.toMap())
+  }
+}
+
+private fun save(backStack: SaveableBackStack) =
+  with(SaveableBackStack.Saver) {
+    val scope = SaverScope { true }
+    scope.save(backStack)
+  }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -29,7 +29,10 @@ class NavigableCircuitRetainedStateTest {
   @Test fun retainedStateScopedToBackstackWithKeys() = retainedStateScopedToBackstack(true)
 
   @Test fun retainedStateScopedToBackstackWithoutKeys() = retainedStateScopedToBackstack(false)
-  @Test fun retainedStateScopedToBackstackResetRootsWithoutKeys() = retainedStateScopedToBackstackResetRoots(false)
+
+  @Test
+  fun retainedStateScopedToBackstackResetRootsWithoutKeys() =
+    retainedStateScopedToBackstackResetRoots(false)
 
   private fun retainedStateScopedToBackstack(useKeys: Boolean) {
     composeTestRule.run {
@@ -98,7 +101,12 @@ class NavigableCircuitRetainedStateTest {
 
   private fun retainedStateScopedToBackstackResetRoots(useKeys: Boolean) {
     composeTestRule.run {
-      val circuit = createTestCircuit(useKeys = useKeys, rememberType = RememberType.Retained)
+      val circuit = createTestCircuit(
+        useKeys = useKeys,
+        rememberType = RememberType.Retained,
+        saveStateOnRootChange = true,
+        restoreStateOnRootChange = true,
+      )
 
       setContent {
         CircuitCompositionLocals(circuit) {

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -12,6 +12,8 @@ import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
 import com.slack.circuit.internal.test.TestContentTags.TAG_INCREASE_COUNT
 import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
 import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import com.slack.circuit.internal.test.TestContentTags.TAG_RESET_ROOT_ALPHA
+import com.slack.circuit.internal.test.TestContentTags.TAG_RESET_ROOT_BETA
 import com.slack.circuit.internal.test.TestCountPresenter.RememberType
 import com.slack.circuit.internal.test.TestScreen
 import com.slack.circuit.internal.test.createTestCircuit
@@ -27,6 +29,7 @@ class NavigableCircuitRetainedStateTest {
   @Test fun retainedStateScopedToBackstackWithKeys() = retainedStateScopedToBackstack(true)
 
   @Test fun retainedStateScopedToBackstackWithoutKeys() = retainedStateScopedToBackstack(false)
+  @Test fun retainedStateScopedToBackstackResetRootsWithoutKeys() = retainedStateScopedToBackstackResetRoots(false)
 
   private fun retainedStateScopedToBackstack(useKeys: Boolean) {
     composeTestRule.run {
@@ -90,6 +93,101 @@ class NavigableCircuitRetainedStateTest {
       onNodeWithTag(TAG_GO_NEXT).performClick()
       onNodeWithTag(TAG_LABEL).assertTextEquals("B")
       onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+
+  private fun retainedStateScopedToBackstackResetRoots(useKeys: Boolean) {
+    composeTestRule.run {
+      val circuit = createTestCircuit(useKeys = useKeys, rememberType = RememberType.Retained)
+
+      setContent {
+        CircuitCompositionLocals(circuit) {
+          val backstack = rememberSaveableBackStack { push(TestScreen.RootAlpha) }
+          val navigator =
+            rememberCircuitNavigator(
+              backstack = backstack,
+              onRootPop = {}, // no-op for tests
+            )
+          NavigableCircuitContent(navigator = navigator, backstack = backstack)
+        }
+      }
+
+      // Current: Root Alpha. Navigate to Screen A
+      onNodeWithTag(TAG_LABEL).assertTextEquals("Root Alpha")
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+
+      // Current: Screen A. Increase count to 1
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen C. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Pop to Screen B. Increase count from 1 to 2.
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Navigate to Screen C. Assert that it's state was not retained
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Pop to Screen B. Assert that it's state was retained
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // So at this point:
+      // Active: Root Alpha, Screen A (count: 1), Screen B: (count: 2)
+      // Retained: empty
+
+      // Let's switch to Root B
+      onNodeWithTag(TAG_RESET_ROOT_BETA).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("Root Beta")
+
+      // Navigate to Screen A, and increase count to 2
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // So at this point:
+      // Active: Root Beta, Screen A (count: 2)
+      // Retained: Root Alpha, Screen A (count: 1), Screen B: (count: 2)
+
+      // Let's switch back to Root Alpha
+      onNodeWithTag(TAG_RESET_ROOT_ALPHA).performClick()
+      // Root Alpha should now be active. The top record for Root Alpha is Screen B: (count: 2)
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Pop to Screen A
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Let's switch back to Root B
+      onNodeWithTag(TAG_RESET_ROOT_BETA).performClick()
+      // Root Beta should now be active. The top record for Root Beta  is Screen A: (count: 2)
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
     }
   }
 }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -34,6 +34,10 @@ class NavigableCircuitRetainedStateTest {
   fun retainedStateScopedToBackstackResetRootsWithoutKeys() =
     retainedStateScopedToBackstackResetRoots(false)
 
+  @Test
+  fun retainedStateScopedToBackstackResetRootsWithKeys() =
+    retainedStateScopedToBackstackResetRoots(true)
+
   private fun retainedStateScopedToBackstack(useKeys: Boolean) {
     composeTestRule.run {
       val circuit = createTestCircuit(useKeys = useKeys, rememberType = RememberType.Retained)

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -101,12 +101,13 @@ class NavigableCircuitRetainedStateTest {
 
   private fun retainedStateScopedToBackstackResetRoots(useKeys: Boolean) {
     composeTestRule.run {
-      val circuit = createTestCircuit(
-        useKeys = useKeys,
-        rememberType = RememberType.Retained,
-        saveStateOnRootChange = true,
-        restoreStateOnRootChange = true,
-      )
+      val circuit =
+        createTestCircuit(
+          useKeys = useKeys,
+          rememberType = RememberType.Retained,
+          saveStateOnRootChange = true,
+          restoreStateOnRootChange = true,
+        )
 
       setContent {
         CircuitCompositionLocals(circuit) {

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -170,6 +170,7 @@ class NavigableCircuitRetainedStateTest {
       onNodeWithTag(TAG_LABEL).assertTextEquals("Root Beta")
 
       // Navigate to Screen A, and increase count to 2
+      onNodeWithTag(TAG_GO_NEXT).performClick()
       onNodeWithTag(TAG_LABEL).assertTextEquals("A")
       onNodeWithTag(TAG_COUNT).assertTextEquals("0")
       onNodeWithTag(TAG_INCREASE_COUNT).performClick()

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
@@ -138,7 +138,9 @@ class ProvidedValuesLifetimeTest {
               else -> error("Can't navigate from $screen")
             }
           }
-          else -> { /* no-op */ }
+          else -> {
+            /* no-op */
+          }
         }
       }
     }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
@@ -138,6 +138,7 @@ class ProvidedValuesLifetimeTest {
               else -> error("Can't navigate from $screen")
             }
           }
+          else -> { /* no-op */ }
         }
       }
     }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -44,8 +44,12 @@ public fun CircuitContent(
           onNavEvent(NavEvent.GoTo(screen))
         }
 
-        override fun resetRoot(newRoot: Screen): List<Screen> {
-          onNavEvent(NavEvent.ResetRoot(newRoot))
+        override fun resetRoot(
+          newRoot: Screen,
+          saveState: Boolean,
+          restoreState: Boolean,
+        ): List<Screen> {
+          onNavEvent(NavEvent.ResetRoot(newRoot, saveState, restoreState))
           return emptyList()
         }
 

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -58,9 +58,9 @@ public fun CircuitContent(
           return null
         }
 
-        override fun peek(): Screen {
-          return screen
-        }
+        override fun peek(): Screen = screen
+
+        override fun peekBackStack(): List<Screen> = listOf(screen)
       }
     }
   CircuitContent(screen, navigator, modifier, circuit, unavailableContent)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavEvent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavEvent.kt
@@ -28,5 +28,9 @@ public sealed interface NavEvent : CircuitUiEvent {
   public data class GoTo(val screen: Screen) : NavEvent
 
   /** Corresponds to [Navigator.resetRoot]. */
-  public data class ResetRoot(val newRoot: Screen) : NavEvent
+  public data class ResetRoot(
+    val newRoot: Screen,
+    val saveState: Boolean,
+    val restoreState: Boolean,
+  ) : NavEvent
 }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -223,16 +223,14 @@ public object NavigatorDefaults {
      * This isn't meant for public consumption, so be aware that this may be removed/changed at any
      * time.
      */
-    @InternalCircuitApi
-    public val forward: ContentTransform by lazy { computeTransition(1) }
+    @InternalCircuitApi public val forward: ContentTransform by lazy { computeTransition(1) }
 
     /**
      * The [ContentTransform] used for 'backward' navigation changes (i.e. items popped off stack).
      * This isn't meant for public consumption, so be aware that this may be removed/changed at any
      * time.
      */
-    @InternalCircuitApi
-    public val backward: ContentTransform by lazy { computeTransition(-1) }
+    @InternalCircuitApi public val backward: ContentTransform by lazy { computeTransition(-1) }
 
     private fun computeTransition(sign: Int): ContentTransform {
       val enterTransition =

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -36,6 +36,7 @@ import com.slack.circuit.retained.LocalCanRetainChecker
 import com.slack.circuit.retained.LocalRetainedStateRegistry
 import com.slack.circuit.retained.RetainedStateRegistry
 import com.slack.circuit.retained.rememberRetained
+import com.slack.circuit.runtime.InternalCircuitApi
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.collections.immutable.ImmutableList
@@ -222,6 +223,7 @@ public object NavigatorDefaults {
      * This isn't meant for public consumption, so be aware that this may be removed/changed at any
      * time.
      */
+    @InternalCircuitApi
     public val forward: ContentTransform by lazy { computeTransition(1) }
 
     /**
@@ -229,6 +231,7 @@ public object NavigatorDefaults {
      * This isn't meant for public consumption, so be aware that this may be removed/changed at any
      * time.
      */
+    @InternalCircuitApi
     public val backward: ContentTransform by lazy { computeTransition(-1) }
 
     private fun computeTransition(sign: Int): ContentTransform {
@@ -275,6 +278,7 @@ public object NavigatorDefaults {
       modifier: Modifier,
       content: @Composable (T) -> Unit,
     ) {
+      @OptIn(InternalCircuitApi::class)
       AnimatedContent(
         targetState = args,
         modifier = modifier,

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -50,6 +50,8 @@ internal class NavigatorImpl(
 
   override fun peek(): Screen? = backstack.firstOrNull()?.screen
 
+  override fun peekBackStack(): List<Screen> = backstack.map { it.screen }
+
   override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
     val currentStack = backstack.map(Record::screen)
 

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -49,7 +49,7 @@ internal class NavigatorImpl(
 
   override fun peek(): Screen? = backstack.firstOrNull()?.screen
 
-  override fun resetRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
     return buildList(backstack.size) {
       backstack.popUntil { record ->
         add(record.screen)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -51,7 +51,7 @@ internal class NavigatorImpl(
   override fun peek(): Screen? = backstack.firstOrNull()?.screen
 
   override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
-    val currentStack = backstack.toList()
+    val currentStack = backstack.map(Record::screen)
 
     // Run this in a mutable snapshot (bit like a transaction)
     Snapshot.withMutableSnapshot {
@@ -66,8 +66,7 @@ internal class NavigatorImpl(
       }
     }
 
-    // The old impl return the list in reverse order, so we need to be consistent
-    return currentStack.map { it.screen }.asReversed()
+    return currentStack
   }
 
   override fun equals(other: Any?): Boolean {

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -15,6 +15,9 @@ public interface Navigator {
   /** Returns current top most screen of backstack, or null if backstack is empty. */
   public fun peek(): Screen?
 
+  /** Returns the current back stack. */
+  public fun peekBackStack(): List<Screen>
+
   /**
    * Clear the existing backstack of [screens][Screen] and navigate to [newRoot].
    *
@@ -75,12 +78,36 @@ public interface Navigator {
 
     override fun peek(): Screen? = null
 
+    override fun peekBackStack(): List<Screen> = emptyList()
+
     override fun resetRoot(
       newRoot: Screen,
       saveState: Boolean,
       restoreState: Boolean,
     ): List<Screen> = emptyList()
   }
+}
+
+/**
+ * Clear the existing backstack of [screens][Screen] and navigate to [newRoot].
+ *
+ * This is useful in preventing the user from returning to a completed workflow, such as a tutorial,
+ * wizard, or authentication flow.
+ *
+ * This version of the function provides easy to lambdas for [saveState] and [restoreState] allowing
+ * computation of the values based on the current root screen.
+ */
+public inline fun Navigator.resetRoot(
+  newRoot: Screen,
+  saveState: (currentRoot: Screen?) -> Boolean = { false },
+  restoreState: (currentRoot: Screen?) -> Boolean = { false },
+): List<Screen> {
+  val root = peekBackStack().lastOrNull()
+  return resetRoot(
+    newRoot = newRoot,
+    saveState = saveState(root),
+    restoreState = restoreState(root),
+  )
 }
 
 /** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -31,6 +31,36 @@ public interface Navigator {
    * // Login flow is complete. Wipe backstack and set new root screen
    * val loginScreens = navigator.resetRoot(HomeScreen)
    * ```
+   *
+   * ## Multiple back stacks
+   *
+   * The [saveState] and [restoreState] parameters enable functionality what is commonly called
+   * 'multiple back stacks'. By optionally saving, and later restoring the back stack, you can
+   * enable different root screens to have their own back stacks. A common use case is with
+   * the bottom navigation bar UX pattern.
+   *
+   * ``` kotlin
+   * navigator.resetRoot(HomeNavTab1, saveState = true, restoreState = true)
+   * // User navigates to a details screen
+   * navigator.push(EntityDetails(id = foo))
+   * // Later, user clicks on a bottom navigation item
+   * navigator.resetRoot(HomeNavTab2, saveState = true, restoreState = true)
+   * // Later, user switches back to the first navigation item
+   * navigator.resetRoot(HomeNavTab1, saveState = true, restoreState = true)
+   * // The existing back stack is restored, and EntityDetails(id = foo) will be top of
+   * // the back stack
+   * ```
+   *
+   * There are times when saving and restoring the back stack may not be appropriate, so use this
+   * feature only when it makes sense. A common example where it probably does not make sense is
+   * launching screens which define a UX flow which has a defined completion, such as onboarding.
+   *
+   * @param newRoot The new root [Screen]
+   * @param saveState Whether to save the current entry list. It can be restored by passing the
+   *   current root [Screen] to [resetRoot] with `restoreState = true`
+   * @param restoreState Whether any previously saved state for the given [newRoot] should be
+   *   restored. If this is `false` or there is no previous state, the back stack will only contain
+   *   [newRoot].
    */
   public fun resetRoot(
     newRoot: Screen,

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -36,8 +36,8 @@ public interface Navigator {
    *
    * The [saveState] and [restoreState] parameters enable functionality what is commonly called
    * 'multiple back stacks'. By optionally saving, and later restoring the back stack, you can
-   * enable different root screens to have their own back stacks. A common use case is with
-   * the bottom navigation bar UX pattern.
+   * enable different root screens to have their own back stacks. A common use case is with the
+   * bottom navigation bar UX pattern.
    *
    * ``` kotlin
    * navigator.resetRoot(HomeNavTab1, saveState = true, restoreState = true)

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -32,7 +32,11 @@ public interface Navigator {
    * val loginScreens = navigator.resetRoot(HomeScreen)
    * ```
    */
-  public fun resetRoot(newRoot: Screen): List<Screen>
+  public fun resetRoot(
+    newRoot: Screen,
+    saveState: Boolean = false,
+    restoreState: Boolean = false,
+  ): List<Screen>
 
   public object NoOp : Navigator {
     override fun goTo(screen: Screen) {}
@@ -41,7 +45,11 @@ public interface Navigator {
 
     override fun peek(): Screen? = null
 
-    override fun resetRoot(newRoot: Screen): List<Screen> = emptyList()
+    override fun resetRoot(
+      newRoot: Screen,
+      saveState: Boolean,
+      restoreState: Boolean,
+    ): List<Screen> = emptyList()
   }
 }
 

--- a/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -38,7 +38,11 @@ public class FakeNavigator : Navigator {
   }
 
   override fun peek(): Screen? {
-    error("peek() is not supported in FakeNavigator!")
+    error("peek() is not supported in FakeNavigator")
+  }
+
+  override fun peekBackStack(): List<Screen> {
+    error("peekBackStack() is not supported in FakeNavigator")
   }
 
   override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {

--- a/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -41,7 +41,7 @@ public class FakeNavigator : Navigator {
     error("peek() is not supported in FakeNavigator!")
   }
 
-  override fun resetRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
     newRoots.add(newRoot)
     val oldScreens = buildList {
       val channel = navigatedScreens.asChannel()

--- a/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
+++ b/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
@@ -85,8 +85,8 @@ private class OnNavEventNavigator(val delegate: Navigator, val onNavEvent: () ->
     return delegate.peek()
   }
 
-  override fun resetRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
     onNavEvent()
-    return delegate.resetRoot(newRoot)
+    return delegate.resetRoot(newRoot, saveState, restoreState)
   }
 }

--- a/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
+++ b/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
@@ -81,9 +81,9 @@ private class OnNavEventNavigator(val delegate: Navigator, val onNavEvent: () ->
     return delegate.pop()
   }
 
-  override fun peek(): Screen? {
-    return delegate.peek()
-  }
+  override fun peek(): Screen? = delegate.peek()
+
+  override fun peekBackStack(): List<Screen> = delegate.peekBackStack()
 
   override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
     onNavEvent()

--- a/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationDecoration.kt
+++ b/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationDecoration.kt
@@ -10,24 +10,18 @@ import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.core.Transition
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -39,6 +33,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.slack.circuit.backstack.NavDecoration
+import com.slack.circuit.foundation.NavigatorDefaults
 import kotlin.math.absoluteValue
 import kotlinx.collections.immutable.ImmutableList
 
@@ -61,16 +56,20 @@ private class AndroidPredictiveNavigationDecoration(private val onBackInvoked: (
     modifier: Modifier,
     content: @Composable (T) -> Unit,
   ) {
-    val current = args.first()
-    val previous = args.getOrNull(1)
-
     Box(modifier = modifier) {
+      val current = args.first()
+      val previous = args.getOrNull(1)
+
       var showPrevious by remember { mutableStateOf(false) }
       var recordPoppedFromGesture by remember { mutableStateOf<T?>(null) }
 
-      val transition = updateTransition(targetState = current, label = "GestureNavDecoration")
+      val transition =
+        updateTransition(
+          targetState = GestureNavTransitionHolder(current, backStackDepth, args.last()),
+          label = "GestureNavDecoration",
+        )
 
-      if (previous != null && !transition.isStateBeingAnimated(previous)) {
+      if (previous != null && !transition.isStateBeingAnimated { it.record == previous }) {
         // We display the 'previous' item in the back stack for when the user performs a gesture
         // to go back.
         // We only display it here if the transition is not running. When the transition is
@@ -81,10 +80,6 @@ private class AndroidPredictiveNavigationDecoration(private val onBackInvoked: (
         OptionalLayout(shouldLayout = { showPrevious }) { content(previous) }
       }
 
-      // Remember the previous stack depth so we know if the navigation is going "back".
-      var prevStackDepth by remember { mutableIntStateOf(backStackDepth) }
-      SideEffect { prevStackDepth = backStackDepth }
-
       LaunchedEffect(transition.currentState) {
         // When the current state has changed (i.e. any transition has completed),
         // clear out any transient state
@@ -94,21 +89,19 @@ private class AndroidPredictiveNavigationDecoration(private val onBackInvoked: (
 
       transition.AnimatedContent(
         transitionSpec = {
-          // Mirror the forward and backward transitions of activities in Android 33
+          val diff = targetState.backStackDepth - initialState.backStackDepth
+          val sameRoot = targetState.rootRecord == initialState.rootRecord
+
           when {
             // adding to back stack
-            backStackDepth > prevStackDepth -> {
-              (slideInHorizontally(tween(), SlightlyRight) + fadeIn()) togetherWith
-                (slideOutHorizontally(tween(), SlightlyLeft) + fadeOut())
-            }
+            sameRoot && diff > 0 -> NavigatorDefaults.DefaultDecoration.forward
 
             // come back from back stack
-            backStackDepth < prevStackDepth -> {
-              if (recordPoppedFromGesture == initialState) {
+            sameRoot && diff < 0 -> {
+              if (recordPoppedFromGesture == initialState.record) {
                   EnterTransition.None togetherWith scaleOut(targetScale = 0.8f) + fadeOut()
                 } else {
-                  slideInHorizontally(tween(), SlightlyLeft) + fadeIn() togetherWith
-                    slideOutHorizontally(tween(), SlightlyRight) + fadeOut()
+                  NavigatorDefaults.DefaultDecoration.backward
                 }
                 .apply { targetContentZIndex = -1f }
             }
@@ -117,7 +110,7 @@ private class AndroidPredictiveNavigationDecoration(private val onBackInvoked: (
             else -> fadeIn() togetherWith fadeOut()
           }
         }
-      ) { record ->
+      ) { holder ->
         var swipeProgress by remember { mutableFloatStateOf(0f) }
 
         if (backStackDepth > 1) {
@@ -131,7 +124,7 @@ private class AndroidPredictiveNavigationDecoration(private val onBackInvoked: (
                 // If back has been invoked, and the swipe progress isn't zero,
                 // mark this record as 'popped via gesture' so we can
                 // use a different transition
-                recordPoppedFromGesture = record
+                recordPoppedFromGesture = holder.record
               }
               onBackInvoked()
             },
@@ -144,19 +137,11 @@ private class AndroidPredictiveNavigationDecoration(private val onBackInvoked: (
             progress = { swipeProgress },
           )
         ) {
-          content(record)
+          content(holder.record)
         }
       }
     }
   }
-}
-
-private const val FIVE_PERCENT = 0.05f
-private val SlightlyRight = { width: Int -> (width * FIVE_PERCENT).toInt() }
-private val SlightlyLeft = { width: Int -> 0 - (width * FIVE_PERCENT).toInt() }
-
-private fun <T> Transition<T>.isStateBeingAnimated(state: T): Boolean {
-  return isRunning && (currentState == state || targetState == state)
 }
 
 /**

--- a/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationDecoration.kt
+++ b/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationDecoration.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.slack.circuit.backstack.NavDecoration
 import com.slack.circuit.foundation.NavigatorDefaults
+import com.slack.circuit.runtime.InternalCircuitApi
 import kotlin.math.absoluteValue
 import kotlinx.collections.immutable.ImmutableList
 
@@ -87,6 +88,7 @@ private class AndroidPredictiveNavigationDecoration(private val onBackInvoked: (
         recordPoppedFromGesture = null
       }
 
+      @OptIn(InternalCircuitApi::class)
       transition.AnimatedContent(
         transitionSpec = {
           val diff = targetState.backStackDepth - initialState.backStackDepth

--- a/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/TransitionUtils.kt
+++ b/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/TransitionUtils.kt
@@ -1,0 +1,17 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuitx.gesturenavigation
+
+import androidx.compose.animation.core.Transition
+import androidx.compose.runtime.Immutable
+
+internal fun <T> Transition<T>.isStateBeingAnimated(equals: (T) -> Boolean): Boolean {
+  return isRunning && (equals(currentState) || equals(targetState))
+}
+
+@Immutable
+internal data class GestureNavTransitionHolder<T>(
+  val record: T,
+  val backStackDepth: Int,
+  val rootRecord: T,
+)

--- a/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/TransitionUtils.kt
+++ b/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/TransitionUtils.kt
@@ -9,6 +9,10 @@ internal fun <T> Transition<T>.isStateBeingAnimated(equals: (T) -> Boolean): Boo
   return isRunning && (equals(currentState) || equals(targetState))
 }
 
+/**
+ * A holder class used by the `AnimatedContent` composables. This enables us to pass through all of
+ * the necessary information as an argument, which is optimal for `AnimatedContent`.
+ */
 @Immutable
 internal data class GestureNavTransitionHolder<T>(
   val record: T,

--- a/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
+++ b/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
@@ -76,7 +76,7 @@ internal class DispatchingOverlayNavigator(
 
   override fun peek(): Screen = currentScreen
 
-  override fun resetRoot(newRoot: Screen): List<Screen> {
+  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
     error("resetRoot() is not supported in full screen overlays!")
   }
 }

--- a/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
+++ b/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
@@ -76,6 +76,8 @@ internal class DispatchingOverlayNavigator(
 
   override fun peek(): Screen = currentScreen
 
+  override fun peekBackStack(): List<Screen> = listOf(currentScreen)
+
   override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
     error("resetRoot() is not supported in full screen overlays!")
   }

--- a/internal-test-utils/src/commonMain/kotlin/com/slack/circuit/internal/test/TestContent.kt
+++ b/internal-test-utils/src/commonMain/kotlin/com/slack/circuit/internal/test/TestContent.kt
@@ -27,6 +27,8 @@ object TestContentTags {
   const val TAG_GO_NEXT = "go"
   const val TAG_POP = "pop"
   const val TAG_INCREASE_COUNT = "inc"
+  const val TAG_RESET_ROOT_ALPHA = "reset_alpha"
+  const val TAG_RESET_ROOT_BETA = "reset_beta"
   const val TAG_COUNT = "count"
   const val TAG_LABEL = "label"
 }
@@ -54,6 +56,10 @@ sealed class TestScreen(val label: String) : Screen {
   @Parcelize data object ScreenB : TestScreen("B")
 
   @Parcelize data object ScreenC : TestScreen("C")
+
+  @Parcelize data object RootAlpha : TestScreen("Root Alpha")
+
+  @Parcelize data object RootBeta : TestScreen("Root Beta")
 }
 
 @Composable
@@ -70,7 +76,6 @@ fun TestContent(state: TestState, modifier: Modifier = Modifier) {
           state.eventSink(TestEvent.IncreaseCount)
         },
     )
-
     BasicText(
       text = "Pop",
       modifier =
@@ -84,6 +89,18 @@ fun TestContent(state: TestState, modifier: Modifier = Modifier) {
         Modifier.testTag(TestContentTags.TAG_GO_NEXT).clickable {
           state.eventSink(TestEvent.GoToNextScreen)
         },
+    )
+
+    BasicText(
+      text = "Reset to Root Alpha",
+      modifier = Modifier.testTag(TestContentTags.TAG_RESET_ROOT_ALPHA)
+        .clickable { state.eventSink(TestEvent.ResetRootAlpha) },
+    )
+
+    BasicText(
+      text = "Reset to Root Beta",
+      modifier = Modifier.testTag(TestContentTags.TAG_RESET_ROOT_BETA)
+        .clickable { state.eventSink(TestEvent.ResetRootBeta) },
     )
   }
 }
@@ -118,11 +135,17 @@ class TestCountPresenter(
         TestEvent.PopNavigation -> navigator.pop()
         TestEvent.GoToNextScreen -> {
           when (screen) {
-            is TestScreen.ScreenA -> navigator.goTo(TestScreen.ScreenB)
-            is TestScreen.ScreenB -> navigator.goTo(TestScreen.ScreenC)
+            // Root screens all go to ScreenA
+            TestScreen.RootAlpha -> navigator.goTo(TestScreen.ScreenA)
+            TestScreen.RootBeta -> navigator.goTo(TestScreen.ScreenA)
+            // Otherwise each screen navigates to the next screen
+            TestScreen.ScreenA -> navigator.goTo(TestScreen.ScreenB)
+            TestScreen.ScreenB -> navigator.goTo(TestScreen.ScreenC)
             else -> error("Can't navigate from $screen")
           }
         }
+        TestEvent.ResetRootAlpha -> navigator.resetRoot(TestScreen.RootAlpha)
+        TestEvent.ResetRootBeta -> navigator.resetRoot(TestScreen.RootBeta)
       }
     }
   }
@@ -146,4 +169,9 @@ sealed interface TestEvent {
   data object PopNavigation : TestEvent
 
   data object IncreaseCount : TestEvent
+
+  data object ResetRootAlpha: TestEvent
+
+  data object ResetRootBeta: TestEvent
+
 }

--- a/internal-test-utils/src/commonMain/kotlin/com/slack/circuit/internal/test/TestContent.kt
+++ b/internal-test-utils/src/commonMain/kotlin/com/slack/circuit/internal/test/TestContent.kt
@@ -36,12 +36,16 @@ object TestContentTags {
 fun createTestCircuit(
   useKeys: Boolean = false,
   rememberType: TestCountPresenter.RememberType = TestCountPresenter.RememberType.Standard,
+  saveStateOnRootChange: Boolean = false,
+  restoreStateOnRootChange: Boolean = false,
   presenter: (Screen, Navigator) -> Presenter<*> = { screen, navigator ->
     TestCountPresenter(
       screen = screen as TestScreen,
       navigator = navigator,
       useKeys = useKeys,
       rememberType = rememberType,
+      saveStateOnRootChange = saveStateOnRootChange,
+      restoreStateOnRootChange = restoreStateOnRootChange,
     )
   },
 ): Circuit =
@@ -93,14 +97,18 @@ fun TestContent(state: TestState, modifier: Modifier = Modifier) {
 
     BasicText(
       text = "Reset to Root Alpha",
-      modifier = Modifier.testTag(TestContentTags.TAG_RESET_ROOT_ALPHA)
-        .clickable { state.eventSink(TestEvent.ResetRootAlpha) },
+      modifier =
+        Modifier.testTag(TestContentTags.TAG_RESET_ROOT_ALPHA).clickable {
+          state.eventSink(TestEvent.ResetRootAlpha)
+        },
     )
 
     BasicText(
       text = "Reset to Root Beta",
-      modifier = Modifier.testTag(TestContentTags.TAG_RESET_ROOT_BETA)
-        .clickable { state.eventSink(TestEvent.ResetRootBeta) },
+      modifier =
+        Modifier.testTag(TestContentTags.TAG_RESET_ROOT_BETA).clickable {
+          state.eventSink(TestEvent.ResetRootBeta)
+        },
     )
   }
 }
@@ -110,6 +118,8 @@ class TestCountPresenter(
   private val navigator: Navigator,
   private val useKeys: Boolean,
   private val rememberType: RememberType,
+  private val saveStateOnRootChange: Boolean = false,
+  private val restoreStateOnRootChange: Boolean = false,
 ) : Presenter<TestState> {
   @Composable
   override fun present(): TestState {
@@ -144,8 +154,10 @@ class TestCountPresenter(
             else -> error("Can't navigate from $screen")
           }
         }
-        TestEvent.ResetRootAlpha -> navigator.resetRoot(TestScreen.RootAlpha)
-        TestEvent.ResetRootBeta -> navigator.resetRoot(TestScreen.RootBeta)
+        TestEvent.ResetRootAlpha ->
+          navigator.resetRoot(TestScreen.RootAlpha, saveStateOnRootChange, restoreStateOnRootChange)
+        TestEvent.ResetRootBeta ->
+          navigator.resetRoot(TestScreen.RootBeta, saveStateOnRootChange, restoreStateOnRootChange)
       }
     }
   }
@@ -170,8 +182,7 @@ sealed interface TestEvent {
 
   data object IncreaseCount : TestEvent
 
-  data object ResetRootAlpha: TestEvent
+  data object ResetRootAlpha : TestEvent
 
-  data object ResetRootBeta: TestEvent
-
+  data object ResetRootBeta : TestEvent
 }


### PR DESCRIPTION
aka _multi-back stack_

### Demo

Tried this out in Tivi and it works _real nice_. All of the bottom navigation items are triggered by `Navigator.resetRoot()` calls.


https://github.com/slackhq/circuit/assets/227486/3a80a5fa-000f-4a14-a811-5e0a1f4d850f

