### PR TITLE
Update the default decoration to match the android 34 transition

### DIFF
--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -3,10 +3,16 @@
 package com.slack.circuit.foundation
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
@@ -20,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.slack.circuit.backstack.BackStack
 import com.slack.circuit.backstack.BackStack.Record
@@ -34,6 +41,7 @@ import com.slack.circuit.retained.RetainedStateRegistry
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.Screen
+import kotlin.math.sign
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableList
@@ -203,12 +211,69 @@ private val Record.registryKey: String
 /** Default values and common alternatives used by navigable composables. */
 public object NavigatorDefaults {
 
-  private const val FIVE_PERCENT = 0.05f
-  private val SlightlyRight = { width: Int -> (width * FIVE_PERCENT).toInt() }
-  private val SlightlyLeft = { width: Int -> 0 - (width * FIVE_PERCENT).toInt() }
+  private val FastOutExtraSlowInEasing = CubicBezierEasing(0.208333f, 0.82f, 0.25f, 1f)
+  private val AccelerateEasing = CubicBezierEasing(0.3f, 0f, 1f, 1f)
+  private const val DEBUG_MULTIPLIER = 1
+  private const val SHORT_DURATION = 83 * DEBUG_MULTIPLIER
+  private const val NORMAL_DURATION = 450 * DEBUG_MULTIPLIER
 
   /** The default [NavDecoration] used in navigation. */
+  // Mirrors the forward and backward transitions of activities in Android 34
   public object DefaultDecoration : NavDecoration {
+
+    private val forward: ContentTransform = computeTransition(1)
+
+    private val backward: ContentTransform = computeTransition(-1)
+
+    private fun computeTransition(sign: Int): ContentTransform {
+      val enterTransition =
+        fadeIn(
+          animationSpec =
+            tween(durationMillis = SHORT_DURATION, delayMillis = 50, easing = LinearEasing)
+        ) +
+          slideInHorizontally(
+            initialOffsetX = { fullWidth -> (fullWidth / 10) * sign },
+            animationSpec =
+              tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
+          ) +
+          expandHorizontally(
+            animationSpec =
+              tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
+            initialWidth = { (it * .9f).toInt() },
+            expandFrom = Alignment.Start,
+          )
+
+      val exitTransition =
+        fadeOut(
+          animationSpec = tween(durationMillis = NORMAL_DURATION, easing = AccelerateEasing)
+        ) +
+          slideOutHorizontally(
+            targetOffsetX = { fullWidth -> (fullWidth / 10) * -sign },
+            animationSpec =
+              tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
+          ) +
+          shrinkHorizontally(
+            animationSpec =
+              tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
+            targetWidth = { (it * .9f).toInt() },
+            shrinkTowards = Alignment.End,
+          )
+
+      return enterTransition togetherWith exitTransition
+    }
+
+    private fun AnimatedContentTransitionScope<*>.transitionFor(diff: Int): ContentTransform {
+      return when {
+        diff > 0 -> forward
+        diff < 0 -> backward
+        else -> fadeIn() togetherWith fadeOut()
+      }.using(
+        // Disable clipping since the faded slide-in/out should
+        // be displayed out of bounds.
+        SizeTransform(clip = false)
+      )
+    }
+
     @Composable
     override fun <T> DecoratedContent(
       args: ImmutableList<T>,
@@ -223,27 +288,7 @@ public object NavigatorDefaults {
       AnimatedContent(
         targetState = args,
         modifier = modifier,
-        transitionSpec = {
-          // Mirror the forward and backward transitions of activities in Android 33
-          when {
-            diff > 0 -> {
-              (slideInHorizontally(tween(), SlightlyRight) + fadeIn()) togetherWith
-                slideOutHorizontally(tween(), SlightlyLeft) + fadeOut()
-            }
-            diff < 0 -> {
-              (slideInHorizontally(tween(), SlightlyLeft) + fadeIn()) togetherWith
-                slideOutHorizontally(tween(), SlightlyRight) + fadeOut()
-            }
-            else -> {
-              // Crossfade if there was no diff
-              fadeIn() togetherWith fadeOut()
-            }
-          }.using(
-            // Disable clipping since the faded slide-in/out should
-            // be displayed out of bounds.
-            SizeTransform(clip = false)
-          )
-        },
+        transitionSpec = { transitionFor(diff) },
       ) {
         content(it.first())
       }


### PR DESCRIPTION
Implemented from the android-34 activity_open_exit and activity_open_enter animations. This is what I eyeballed manually before, and slightly better matches the system.

| Before | After |
|--------|--------|
| https://github.com/slackhq/circuit/assets/1361086/c480a985-c02b-4641-b5d1-2f4edf911af3 | https://github.com/slackhq/circuit/assets/1361086/beb1474a-6539-425c-b059-1d623154c292 |

CC @chrisbanes 