### PR TITLE
Navigator - Fix Android BackHandler infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ On top of Circuit's existing docs, we've added a new tutorial to help you get st
 - Convert STAR sample to KMP. Starting with Android and Desktop.
 - Fix baseline profiles packaging. Due to a bug in the baseline profile plugin, we were not packaging the baseline profiles in the artifacts. This is now fixed.
 - Mark `BackStack.Record` as `@Stable`.
-- Fix an infinite loop in the `onRootPop` of the Android `rememberCircuitNavigator`. 
+- Fix an infinite loop in the `onRootPop` of the Android `rememberCircuitNavigator`.
 - Update the default decoration to better match the android 34 transitions.
 - Update androidx.lifecycle to `2.7.0`.
 - Update to compose multiplatform to `1.5.12`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ On top of Circuit's existing docs, we've added a new tutorial to help you get st
 - Convert STAR sample to KMP. Starting with Android and Desktop.
 - Fix baseline profiles packaging. Due to a bug in the baseline profile plugin, we were not packaging the baseline profiles in the artifacts. This is now fixed.
 - Mark `BackStack.Record` as `@Stable`.
+- Fix an infinite loop in the `onRootPop` of the Android `rememberCircuitNavigator`. 
 - Update the default decoration to better match the android 34 transitions.
 - Update androidx.lifecycle to `2.7.0`.
 - Update to compose multiplatform to `1.5.12`.

--- a/circuit-foundation/src/androidMain/kotlin/com/slack/circuit/foundation/Navigator.android.kt
+++ b/circuit-foundation/src/androidMain/kotlin/com/slack/circuit/foundation/Navigator.android.kt
@@ -25,7 +25,10 @@ public fun rememberCircuitNavigator(
 ): Navigator {
   val navigator =
     rememberCircuitNavigator(backStack = backStack, onRootPop = backDispatcherRootPop())
-  BackHandler(enabled = enableBackHandler && backStack.size > 1, onBack = navigator::pop)
+  BackHandler(
+    enabled = enableBackHandler && backStack.size > 1,
+    onBack = onBack(backStack, navigator),
+  )
 
   return navigator
 }
@@ -36,4 +39,11 @@ private fun backDispatcherRootPop(): () -> Unit {
     LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
       ?: error("No OnBackPressedDispatcherOwner found, unable to handle root navigation pops.")
   return onBackPressedDispatcher::onBackPressed
+}
+
+private fun onBack(backStack: BackStack<out Record>, navigator: Navigator): () -> Unit = {
+  // Check the backStack on each call as the `BackHandler` enabled state only updates on composition
+  if (backStack.size > 1) {
+    navigator.pop()
+  }
 }

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigatorBackHandlerTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigatorBackHandlerTest.kt
@@ -1,0 +1,48 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestCountPresenter
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.createTestCircuit
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.popUntil
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(ComposeUiTestRunner::class)
+class NavigatorBackHandlerTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun androidNavigatorRootPopBackHandler() {
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.Standard)
+    lateinit var navigator: Navigator
+    composeTestRule.setContent {
+      CircuitCompositionLocals(circuit) {
+        val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+        navigator = rememberCircuitNavigator(backStack = backStack)
+        NavigableCircuitContent(navigator = navigator, backStack = backStack)
+      }
+    }
+    composeTestRule.run {
+      // Navigate to Screen B
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      // Navigate to Screen C
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      // Pop through the onRootPop into the back handler
+      navigator.popUntil { false }
+    }
+  }
+}

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
@@ -9,6 +9,7 @@ import com.slack.circuit.runtime.popUntil
 import com.slack.circuit.runtime.screen.Screen
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlin.test.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -82,6 +83,25 @@ class NavigatorTest {
 
     assertThat(backStack).hasSize(2)
     assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen2)
+  }
+
+  @Test
+  fun popUntilRoot() {
+    var onRootPopped = false
+    val backStack = SaveableBackStack()
+    backStack.push(TestScreen)
+    backStack.push(TestScreen2)
+    backStack.push(TestScreen3)
+
+    val navigator = NavigatorImpl(backStack) { onRootPopped = true }
+
+    assertThat(backStack).hasSize(3)
+
+    navigator.popUntil { false }
+
+    assertTrue(onRootPopped)
+    assertThat(backStack).hasSize(1)
+    assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen)
   }
 
   @Test

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -119,5 +119,5 @@ public inline fun Navigator.resetRoot(
 
 /** Calls [Navigator.pop] until the given [predicate] is matched or it pops the root. */
 public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
-  while (peek()?.let(predicate) == false) pop()
+  while (peek()?.let(predicate) == false) pop() ?: break // Break on root pop
 }


### PR DESCRIPTION
## Fixes
### `rememberCircuitNavigator` 
- Using `rememberCircuitNavigator` with the `BackHandler` enabled and you programmatically `pop()` through a `backStack` with more then one record
- This causes an infinite loop with the `onRootPop` of `rememberCircuitNavigator` calling the `BackHandler`, which calls `pop()` on the navigator, which calls `onRootPop` 🔁 
- This occurs because the `backStack` changes and doesn't recompose to disable the `BackHandler`
- Fix is to check the current `backStack.size` during the `onBack`

### `popUntil`
- Coincidently `popUntil` was no longer stopping on the root pop and would get stuck in an infinite loop if you returned false on the root screen