### PR TITLE
Fix default decoration backwards transition

### DIFF
--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -4,6 +4,7 @@ package com.slack.circuit.foundation
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.LinearEasing
@@ -32,6 +33,7 @@ import com.slack.circuit.backstack.NavDecoration
 import com.slack.circuit.backstack.ProvidedValues
 import com.slack.circuit.backstack.isEmpty
 import com.slack.circuit.backstack.providedValuesForBackStack
+import com.slack.circuit.foundation.NavigatorDefaults.DefaultDecoration.backward
 import com.slack.circuit.retained.CanRetainChecker
 import com.slack.circuit.retained.LocalCanRetainChecker
 import com.slack.circuit.retained.LocalRetainedStateRegistry
@@ -238,7 +240,11 @@ public object NavigatorDefaults {
       val enterTransition =
         fadeIn(
           animationSpec =
-            tween(durationMillis = SHORT_DURATION, delayMillis = 50, easing = LinearEasing)
+            tween(
+              durationMillis = if (sign > 0) SHORT_DURATION else NORMAL_DURATION,
+              delayMillis = 50,
+              easing = LinearEasing,
+            )
         ) +
           slideInHorizontally(
             initialOffsetX = { fullWidth -> (fullWidth / 10) * sign },
@@ -249,24 +255,32 @@ public object NavigatorDefaults {
             animationSpec =
               tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
             initialWidth = { (it * .9f).toInt() },
-            expandFrom = Alignment.Start,
+            expandFrom = if (sign > 0) Alignment.Start else Alignment.End,
           )
 
       val exitTransition =
         fadeOut(
-          animationSpec = tween(durationMillis = NORMAL_DURATION, easing = AccelerateEasing)
+          animationSpec =
+            tween(
+              durationMillis = if (sign > 0) NORMAL_DURATION else SHORT_DURATION,
+              easing = AccelerateEasing,
+            )
         ) +
           slideOutHorizontally(
             targetOffsetX = { fullWidth -> (fullWidth / 10) * -sign },
             animationSpec =
               tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
           ) +
-          shrinkHorizontally(
-            animationSpec =
-              tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
-            targetWidth = { (it * .9f).toInt() },
-            shrinkTowards = Alignment.End,
-          )
+          if (sign > 0) {
+            shrinkHorizontally(
+              animationSpec =
+                tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing),
+              targetWidth = { (it * .9f).toInt() },
+              shrinkTowards = Alignment.End,
+            )
+          } else {
+            ExitTransition.None
+          }
 
       return enterTransition togetherWith exitTransition
     }
@@ -283,7 +297,8 @@ public object NavigatorDefaults {
         targetState = args,
         modifier = modifier,
         transitionSpec = {
-          // A transitionSpec should only use values passed into the `AnimatedContent`, to minimize
+          // A transitionSpec should only use values passed into the `AnimatedContent`, to
+          // minimize
           // the transitionSpec recomposing. The states are available as `targetState` and
           // `initialState`
           val diff = targetState.size - initialState.size


### PR DESCRIPTION
## Fix
- The backwards exit transition was looking off from some combination of slide out and horizontal shrink. 
- This removes the horizontal shrink on the backwards exit transition and adjusts some of the timing to mirror the forward transition better

## Demo

|Before|After|
|-|-|
|<video src="https://github.com/slackhq/circuit/assets/3268847/82785179-0b42-4149-b286-e46fdcd2e3a4"></video>|<video src="https://github.com/slackhq/circuit/assets/3268847/fcb2b0a1-78d4-4c7a-a03f-9bb08dee9176"></video>|

