### PR TITLE
Interop Sample - Remember the present in `asCircuitPresenter()`

### DIFF
--- a/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
+++ b/samples/interop/src/main/kotlin/com/slack/circuit/sample/interop/FlowCounterPresenter.kt
@@ -51,7 +51,7 @@ fun FlowPresenter<Int, CounterScreen.Event>.asCircuitPresenter(): Presenter<Coun
     val channel = remember { Channel<CounterScreen.Event>(Channel.BUFFERED) }
     val eventsFlow = remember { channel.receiveAsFlow() }
     val scope = rememberCoroutineScope()
-    val state by present(scope, eventsFlow).collectAsState()
+    val state by remember { present(scope, eventsFlow) }.collectAsState()
     CounterScreen.State(state, channel::trySend)
   }
 }


### PR DESCRIPTION
The `present()` in `FlowCounterPresenter` would get called on each composition, which would launch a new coroutine to collect from the event channel/flow. Could get a bunch of coroutines running at once 😅 