### PR TITLE
Significantly improve FakeNavigator + small API updates around it and Navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@ Changelog
 
 **Unreleased**
 --------------
-
+- Fix `FakeNavigator.awaitNextScreen()` not suspending.
+- Fix `FakeNavigator.resetRoot()` not returning the actual popped screens.
+- Make `Navigator.peekBackStack()` and `Navigator.resetRoot()` return `ImmutableList`.
+- Make `BackStack.popUntil()` return the `ImmutableList` of the popped records.
+- Strongly pop events and resetRoot events in `FakeNavigator`. This should offer much more information about the events.
+- Use a real `BackStack` instance in `FakeNavigator` + allow for specifying a user-provided instance.
+- Require an initial root screen to construct `FakeNavigator` unless using a custom `BackStack`.
+  - Note this slightly changes semantics, as now the root screen will not be recorded as the first `goTo` event.
+- Require an initial root screen (or list of screens) for `rememberSaveableBackStack()`.
+- Expose a top-level non-composable `Navigator()` factory function.
 
 0.19.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - Fix `FakeNavigator.resetRoot()` not returning the actual popped screens.
 - Make `Navigator.peekBackStack()` and `Navigator.resetRoot()` return `ImmutableList`.
 - Make `BackStack.popUntil()` return the `ImmutableList` of the popped records.
+- Support `FakeNavigator.peekBackStack()` return the `ImmutableList` of the popped records.
 - Strongly pop events and resetRoot events in `FakeNavigator`. This should offer much more information about the events.
 - Use a real `BackStack` instance in `FakeNavigator` + allow for specifying a user-provided instance.
 - Require an initial root screen to construct `FakeNavigator` unless using a custom `BackStack`.

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
@@ -19,6 +19,9 @@ import androidx.compose.runtime.Stable
 import com.slack.circuit.backstack.BackStack.Record
 import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.persistentListOf
 
 /**
  * A caller-supplied stack of [Record]s for presentation with a `Navigator`. Iteration order is
@@ -63,8 +66,13 @@ public interface BackStack<R : Record> : Iterable<R> {
   /**
    * Pop records off the top of the backstack until one is found that matches the given predicate.
    */
-  public fun popUntil(predicate: (R) -> Boolean) {
-    while (topRecord?.let(predicate) == false) pop()
+  public fun popUntil(predicate: (R) -> Boolean): ImmutableList<R> {
+    return persistentListOf<R>().mutate {
+      while (topRecord?.let(predicate) == false) {
+        val popped = pop() ?: break
+        it.add(popped)
+      }
+    }
   }
 
   /**

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -29,8 +29,11 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 
 @Composable
-public fun rememberSaveableBackStack(root: Screen): SaveableBackStack =
-  rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack(root) }
+public fun rememberSaveableBackStack(
+  root: Screen,
+  init: SaveableBackStack.() -> Unit = {},
+): SaveableBackStack =
+  rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack(root).apply(init) }
 
 /**
  * A [BackStack] that supports saving its state via [rememberSaveable]. See

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -35,6 +35,18 @@ public fun rememberSaveableBackStack(
 ): SaveableBackStack =
   rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack(root).apply(init) }
 
+@Composable
+public fun rememberSaveableBackStack(initialScreens: List<Screen>): SaveableBackStack {
+  require(initialScreens.isNotEmpty()) { "Initial input screens cannot be empty!" }
+  return rememberSaveable(saver = SaveableBackStack.Saver) {
+    SaveableBackStack(null).apply {
+      for (screen in initialScreens) {
+        push(screen)
+      }
+    }
+  }
+}
+
 /**
  * A [BackStack] that supports saving its state via [rememberSaveable]. See
  * [rememberSaveableBackStack].

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -28,6 +28,11 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 
+/**
+ * Creates and remembers a [SaveableBackStack] with the given [root] screen.
+ *
+ * @param init optional initializer callback to perform extra initialization logic.
+ */
 @Composable
 public fun rememberSaveableBackStack(
   root: Screen,
@@ -35,6 +40,10 @@ public fun rememberSaveableBackStack(
 ): SaveableBackStack =
   rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack(root).apply(init) }
 
+/**
+ * Creates and remembers a [SaveableBackStack] filled with the given [initialScreens].
+ * [initialScreens] must not be empty.
+ */
 @Composable
 public fun rememberSaveableBackStack(initialScreens: List<Screen>): SaveableBackStack {
   require(initialScreens.isNotEmpty()) { "Initial input screens cannot be empty!" }

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -29,26 +29,26 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 
 @Composable
-public fun rememberSaveableBackStack(initialScreen: Screen): SaveableBackStack =
-  rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack(initialScreen) }
+public fun rememberSaveableBackStack(root: Screen): SaveableBackStack =
+  rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack(root) }
 
 /**
  * A [BackStack] that supports saving its state via [rememberSaveable]. See
  * [rememberSaveableBackStack].
  */
-public class SaveableBackStack internal constructor(nullableInitialRecord: Record?) :
+public class SaveableBackStack internal constructor(nullableRootRecord: Record?) :
   BackStack<SaveableBackStack.Record> {
 
-  public constructor(initialRecord: Record) : this(nullableInitialRecord = initialRecord)
+  public constructor(initialRecord: Record) : this(nullableRootRecord = initialRecord)
 
-  public constructor(initialScreen: Screen) : this(Record(initialScreen))
+  public constructor(root: Screen) : this(Record(root))
 
   // Both visible for testing
   internal val entryList = mutableStateListOf<Record>()
   internal val stateStore = mutableMapOf<Screen, List<Record>>()
 
   init {
-    nullableInitialRecord?.let(::push)
+    nullableRootRecord?.let(::push)
   }
 
   override val size: Int

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -36,8 +36,12 @@ public fun rememberSaveableBackStack(root: Screen): SaveableBackStack =
  * A [BackStack] that supports saving its state via [rememberSaveable]. See
  * [rememberSaveableBackStack].
  */
-public class SaveableBackStack internal constructor(nullableRootRecord: Record?) :
-  BackStack<SaveableBackStack.Record> {
+public class SaveableBackStack
+internal constructor(
+  nullableRootRecord: Record?,
+  // Unused marker just to differentiate the internal constructor on the JVM.
+  @Suppress("UNUSED_PARAMETER") internalConstructorMarker: Any? = null,
+) : BackStack<SaveableBackStack.Record> {
 
   public constructor(initialRecord: Record) : this(nullableRootRecord = initialRecord)
 

--- a/backstack/src/commonTest/kotlin/com/slack/circuit/backstack/SaveableBackStackTest.kt
+++ b/backstack/src/commonTest/kotlin/com/slack/circuit/backstack/SaveableBackStackTest.kt
@@ -16,8 +16,7 @@ class SaveableBackStackTest {
 
   @Test
   fun test_save_and_restore_backstack_state() {
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen.RootAlpha)
+    val backStack = SaveableBackStack(TestScreen.RootAlpha)
     backStack.push(TestScreen.ScreenA)
     backStack.push(TestScreen.ScreenB)
 
@@ -61,8 +60,7 @@ class SaveableBackStackTest {
 
   @Test
   fun test_saveable_save_and_restore() {
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen.RootAlpha)
+    val backStack = SaveableBackStack(TestScreen.RootAlpha)
     backStack.push(TestScreen.ScreenA)
     backStack.push(TestScreen.ScreenB)
 
@@ -80,8 +78,7 @@ class SaveableBackStackTest {
 
   @Test
   fun test_saveable_save_and_restore_with_backstack_state() {
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen.RootAlpha)
+    val backStack = SaveableBackStack(TestScreen.RootAlpha)
     backStack.push(TestScreen.ScreenA)
     backStack.push(TestScreen.ScreenB)
 

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTestActivity.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTestActivity.kt
@@ -19,7 +19,7 @@ class NavigableCircuitRetainedStateTestActivity : ComponentActivity() {
 
     setContent {
       CircuitCompositionLocals(circuit) {
-        val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
         val navigator =
           rememberCircuitNavigator(
             backStack = backStack,

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitViewModelStateTestActivity.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitViewModelStateTestActivity.kt
@@ -19,7 +19,7 @@ class NavigableCircuitViewModelStateTestActivity : ComponentActivity() {
 
     setContent {
       CircuitCompositionLocals(circuit) {
-        val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
         val navigator =
           rememberCircuitNavigator(
             backStack = backStack,

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigatorBackHandlerTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigatorBackHandlerTest.kt
@@ -29,7 +29,7 @@ class NavigatorBackHandlerTest {
     lateinit var navigator: Navigator
     composeTestRule.setContent {
       CircuitCompositionLocals(circuit) {
-        val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
         navigator = rememberCircuitNavigator(backStack = backStack)
         NavigableCircuitContent(navigator = navigator, backStack = backStack)
       }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitRetainedStateTest.kt
@@ -44,7 +44,7 @@ class NavigableCircuitRetainedStateTest {
 
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
           val navigator =
             rememberCircuitNavigator(
               backStack = backStack,
@@ -115,7 +115,7 @@ class NavigableCircuitRetainedStateTest {
 
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack { push(TestScreen.RootAlpha) }
+          val backStack = rememberSaveableBackStack(TestScreen.RootAlpha)
           val navigator =
             rememberCircuitNavigator(
               backStack = backStack,

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
@@ -38,7 +38,7 @@ class NavigableCircuitSaveableStateTest {
 
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
           val navigator =
             rememberCircuitNavigator(
               backStack = backStack,

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
@@ -8,7 +8,6 @@ import com.slack.circuit.internal.test.Parcelize
 import com.slack.circuit.runtime.popUntil
 import com.slack.circuit.runtime.screen.Screen
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import org.junit.Test
@@ -23,16 +22,8 @@ import org.junit.runner.RunWith
 @RunWith(ComposeUiTestRunner::class)
 class NavigatorTest {
   @Test
-  fun errorWhenBackstackIsEmpty() {
-    val backStack = SaveableBackStack()
-    val t = assertFailsWith<IllegalStateException> { NavigatorImpl(backStack) {} }
-    assertThat(t).hasMessageThat().contains("Backstack size must not be empty.")
-  }
-
-  @Test
   fun popAtRoot() {
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen)
+    val backStack = SaveableBackStack(TestScreen)
     backStack.push(TestScreen)
 
     var onRootPop = 0
@@ -52,8 +43,7 @@ class NavigatorTest {
 
   @Test
   fun resetRoot() {
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen)
+    val backStack = SaveableBackStack(TestScreen)
     backStack.push(TestScreen2)
 
     val navigator = NavigatorImpl(backStack) { fail() }
@@ -70,8 +60,7 @@ class NavigatorTest {
 
   @Test
   fun popUntil() {
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen)
+    val backStack = SaveableBackStack(TestScreen)
     backStack.push(TestScreen2)
     backStack.push(TestScreen3)
 
@@ -88,8 +77,7 @@ class NavigatorTest {
   @Test
   fun popUntilRoot() {
     var onRootPopped = false
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen)
+    val backStack = SaveableBackStack(TestScreen)
     backStack.push(TestScreen2)
     backStack.push(TestScreen3)
 
@@ -106,8 +94,7 @@ class NavigatorTest {
 
   @Test
   fun peek() {
-    val backStack = SaveableBackStack()
-    backStack.push(TestScreen)
+    val backStack = SaveableBackStack(TestScreen)
     backStack.push(TestScreen2)
 
     val navigator = NavigatorImpl(backStack) { fail() }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/ProvidedValuesLifetimeTest.kt
@@ -49,7 +49,7 @@ class ProvidedValuesLifetimeTest {
 
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
           val navigator =
             rememberCircuitNavigator(
               backStack = backStack,

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
@@ -52,7 +52,7 @@ import com.slack.circuit.runtime.ui.ui
  * If using navigation, use `NavigableCircuitContent` instead.
  *
  * ```kotlin
- * val backStack = rememberSaveableBackStack { push(AddFavoritesScreen()) }
+ * val backStack = rememberSaveableBackStack(root = HomeScreen)
  * val navigator = rememberCircuitNavigator(backstack, ::onBackPressed)
  * CircuitCompositionLocals(circuit) {
  *   NavigableCircuitContent(navigator, backstack)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -17,6 +17,8 @@ import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 public fun CircuitContent(
@@ -49,9 +51,9 @@ public fun CircuitContent(
           newRoot: Screen,
           saveState: Boolean,
           restoreState: Boolean,
-        ): List<Screen> {
+        ): ImmutableList<Screen> {
           onNavEvent(NavEvent.ResetRoot(newRoot, saveState, restoreState))
-          return emptyList()
+          return persistentListOf()
         }
 
         override fun pop(result: PopResult?): Screen? {
@@ -61,7 +63,7 @@ public fun CircuitContent(
 
         override fun peek(): Screen = screen
 
-        override fun peekBackStack(): List<Screen> = listOf(screen)
+        override fun peekBackStack(): ImmutableList<Screen> = persistentListOf(screen)
       }
     }
   CircuitContent(screen, navigator, modifier, circuit, unavailableContent)

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -12,6 +12,9 @@ import com.slack.circuit.backstack.isEmpty
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.persistentListOf
 
 /**
  * Creates and remembers a new [Navigator] for navigating within [CircuitContents][CircuitContent].
@@ -64,23 +67,27 @@ internal class NavigatorImpl(
 
   override fun peek(): Screen? = backStack.firstOrNull()?.screen
 
-  override fun peekBackStack(): List<Screen> = backStack.map { it.screen }
+  override fun peekBackStack(): ImmutableList<Screen> = backStack.mapToImmutableList { it.screen }
 
-  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
-    val currentStack = backStack.map(Record::screen)
-
+  override fun resetRoot(
+    newRoot: Screen,
+    saveState: Boolean,
+    restoreState: Boolean,
+  ): ImmutableList<Screen> {
     // Run this in a mutable snapshot (bit like a transaction)
-    Snapshot.withMutableSnapshot {
-      if (saveState) backStack.saveState()
-      // Pop everything off the back stack
-      backStack.popUntil { false }
+    val currentStack =
+      Snapshot.withMutableSnapshot {
+        if (saveState) backStack.saveState()
+        // Pop everything off the back stack
+        val popped = backStack.popUntil { false }.mapToImmutableList { it.screen }
 
-      // If we're not restoring state, or the restore didn't work, we need to push the new root
-      // onto the stack
-      if (!restoreState || !backStack.restoreState(newRoot)) {
-        backStack.push(newRoot)
+        // If we're not restoring state, or the restore didn't work, we need to push the new root
+        // onto the stack
+        if (!restoreState || !backStack.restoreState(newRoot)) {
+          backStack.push(newRoot)
+        }
+        popped
       }
-    }
 
     return currentStack
   }
@@ -105,5 +112,13 @@ internal class NavigatorImpl(
 
   override fun toString(): String {
     return "NavigatorImpl(backStack=$backStack, onRootPop=$onRootPop)"
+  }
+}
+
+private inline fun <T, R> Iterable<T>.mapToImmutableList(transform: (T) -> R): ImmutableList<R> {
+  return persistentListOf<R>().mutate {
+    for (element in this@mapToImmutableList) {
+      it.add(transform(element))
+    }
   }
 }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -14,7 +14,7 @@ import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 
 /**
- * Returns a new [Navigator] for navigating within [CircuitContents][CircuitContent].
+ * Creates and remembers a new [Navigator] for navigating within [CircuitContents][CircuitContent].
  *
  * @param backStack The backing [BackStack] to navigate.
  * @param onRootPop Invoked when the backstack is at root (size 1) and the user presses the back
@@ -26,8 +26,19 @@ public fun rememberCircuitNavigator(
   backStack: BackStack<out Record>,
   onRootPop: () -> Unit,
 ): Navigator {
-  return remember { NavigatorImpl(backStack, onRootPop) }
+  return remember { Navigator(backStack, onRootPop) }
 }
+
+/**
+ * Creates a new [Navigator].
+ *
+ * @param backStack The backing [BackStack] to navigate.
+ * @param onRootPop Invoked when the backstack is at root (size 1) and the user presses the back
+ *   button.
+ * @see NavigableCircuitContent
+ */
+public fun Navigator(backStack: BackStack<out Record>, onRootPop: () -> Unit): Navigator =
+  NavigatorImpl(backStack, onRootPop)
 
 internal class NavigatorImpl(
   private val backStack: BackStack<out Record>,

--- a/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/NavResultTest.kt
+++ b/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/NavResultTest.kt
@@ -113,8 +113,7 @@ class NavResultTest {
     composeTestRule.run {
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack {
-            push(WrapperScreen)
+          val backStack = rememberSaveableBackStack(WrapperScreen) {
             backStackRef = this
           }
           val navigator =
@@ -138,8 +137,7 @@ class NavResultTest {
     lateinit var returnedStack: SaveableBackStack
     setContent {
       CircuitCompositionLocals(circuit) {
-        val backStack = rememberSaveableBackStack {
-          push(TestResultScreen("root", answer = false))
+        val backStack = rememberSaveableBackStack(TestResultScreen("root", answer = false)) {
           returnedStack = this
         }
         val navigator =

--- a/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/NavResultTest.kt
+++ b/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/NavResultTest.kt
@@ -113,9 +113,7 @@ class NavResultTest {
     composeTestRule.run {
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack(WrapperScreen) {
-            backStackRef = this
-          }
+          val backStack = rememberSaveableBackStack(WrapperScreen) { backStackRef = this }
           val navigator =
             rememberCircuitNavigator(
               backStack = backStack,
@@ -137,9 +135,10 @@ class NavResultTest {
     lateinit var returnedStack: SaveableBackStack
     setContent {
       CircuitCompositionLocals(circuit) {
-        val backStack = rememberSaveableBackStack(TestResultScreen("root", answer = false)) {
-          returnedStack = this
-        }
+        val backStack =
+          rememberSaveableBackStack(TestResultScreen("root", answer = false)) {
+            returnedStack = this
+          }
         val navigator =
           rememberCircuitNavigator(
             backStack = backStack,

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -5,6 +5,8 @@ package com.slack.circuit.runtime
 import androidx.compose.runtime.Stable
 import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 /** A Navigator that only supports [goTo]. */
 @Stable
@@ -23,7 +25,7 @@ public interface Navigator : GoToNavigator {
   public fun peek(): Screen?
 
   /** Returns the current back stack. */
-  public fun peekBackStack(): List<Screen>
+  public fun peekBackStack(): ImmutableList<Screen>
 
   /**
    * Clear the existing backstack of [screens][Screen] and navigate to [newRoot].
@@ -76,7 +78,7 @@ public interface Navigator : GoToNavigator {
     newRoot: Screen,
     saveState: Boolean = false,
     restoreState: Boolean = false,
-  ): List<Screen>
+  ): ImmutableList<Screen>
 
   public object NoOp : Navigator {
     override fun goTo(screen: Screen) {}
@@ -85,13 +87,13 @@ public interface Navigator : GoToNavigator {
 
     override fun peek(): Screen? = null
 
-    override fun peekBackStack(): List<Screen> = emptyList()
+    override fun peekBackStack(): ImmutableList<Screen> = persistentListOf()
 
     override fun resetRoot(
       newRoot: Screen,
       saveState: Boolean,
       restoreState: Boolean,
-    ): List<Screen> = emptyList()
+    ): ImmutableList<Screen> = persistentListOf()
   }
 }
 

--- a/circuit-test/src/androidUnitTest/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
+++ b/circuit-test/src/androidUnitTest/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
@@ -20,8 +20,7 @@ class FakeNavigatorTest {
     val oldScreens = navigator.resetRoot(TestScreen3)
 
     assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen1))
-    assertThat(navigator.awaitResetRoot())
-      .isEqualTo(ResetRootEvent(TestScreen3, oldScreens))
+    assertThat(navigator.awaitResetRoot()).isEqualTo(ResetRootEvent(TestScreen3, oldScreens))
     assertThat(navigator.peek()).isEqualTo(TestScreen3)
     assertThat(navigator.peekBackStack()).isEqualTo(listOf(TestScreen3))
   }
@@ -33,8 +32,7 @@ class FakeNavigatorTest {
     val oldScreens = navigator.resetRoot(TestScreen1)
 
     assertThat(oldScreens).containsExactly(TestScreen1)
-    assertThat(navigator.awaitResetRoot())
-      .isEqualTo(ResetRootEvent(TestScreen1, oldScreens))
+    assertThat(navigator.awaitResetRoot()).isEqualTo(ResetRootEvent(TestScreen1, oldScreens))
   }
 }
 

--- a/circuit-test/src/androidUnitTest/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
+++ b/circuit-test/src/androidUnitTest/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
@@ -11,23 +11,26 @@ import org.junit.Test
 class FakeNavigatorTest {
   @Test
   fun `resetRoot - ensure resetRoot returns old screens in proper order`() = runTest {
-    val navigator = FakeNavigator()
-    navigator.goTo(TestScreen1)
+    val navigator = FakeNavigator(TestScreen1)
     navigator.goTo(TestScreen2)
+    assertThat(navigator.peek()).isEqualTo(TestScreen2)
+    assertThat(navigator.peekBackStack()).isEqualTo(listOf(TestScreen2, TestScreen1))
 
     val oldScreens = navigator.resetRoot(TestScreen3)
 
     assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen1))
     assertThat(navigator.awaitResetRoot()).isEqualTo(TestScreen3)
+    assertThat(navigator.peek()).isEqualTo(TestScreen3)
+    assertThat(navigator.peekBackStack()).isEqualTo(listOf(TestScreen3))
   }
 
   @Test
   fun resetRoot() = runTest {
-    val navigator = FakeNavigator()
+    val navigator = FakeNavigator(TestScreen1)
 
     val oldScreens = navigator.resetRoot(TestScreen1)
 
-    assertThat(oldScreens).isEmpty()
+    assertThat(oldScreens).containsExactly(TestScreen1)
     assertThat(navigator.awaitResetRoot()).isEqualTo(TestScreen1)
   }
 }

--- a/circuit-test/src/androidUnitTest/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
+++ b/circuit-test/src/androidUnitTest/kotlin/com/slack/circuit/test/FakeNavigatorTest.kt
@@ -4,6 +4,7 @@ package com.slack.circuit.test
 
 import com.google.common.truth.Truth.assertThat
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.test.FakeNavigator.ResetRootEvent
 import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
 import org.junit.Test
@@ -19,7 +20,8 @@ class FakeNavigatorTest {
     val oldScreens = navigator.resetRoot(TestScreen3)
 
     assertThat(oldScreens).isEqualTo(listOf(TestScreen2, TestScreen1))
-    assertThat(navigator.awaitResetRoot()).isEqualTo(TestScreen3)
+    assertThat(navigator.awaitResetRoot())
+      .isEqualTo(ResetRootEvent(TestScreen3, oldScreens))
     assertThat(navigator.peek()).isEqualTo(TestScreen3)
     assertThat(navigator.peekBackStack()).isEqualTo(listOf(TestScreen3))
   }
@@ -31,7 +33,8 @@ class FakeNavigatorTest {
     val oldScreens = navigator.resetRoot(TestScreen1)
 
     assertThat(oldScreens).containsExactly(TestScreen1)
-    assertThat(navigator.awaitResetRoot()).isEqualTo(TestScreen1)
+    assertThat(navigator.awaitResetRoot())
+      .isEqualTo(ResetRootEvent(TestScreen1, oldScreens))
   }
 }
 

--- a/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -3,9 +3,14 @@
 package com.slack.circuit.test
 
 import app.cash.turbine.Turbine
+import com.slack.circuit.backstack.BackStack
+import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.foundation.Navigator
 import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.resetRoot
 import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.ImmutableList
 
 /**
  * A fake [Navigator] that can be used in tests to record and assert navigation events.
@@ -13,7 +18,7 @@ import com.slack.circuit.runtime.screen.Screen
  * Example
  *
  * ```kotlin
- * val navigator = FakeNavigator()
+ * val navigator = FakeNavigator(FavoritesScreen)
  * val presenter = FavoritesPresenter(navigator)
  *
  * presenter.test {
@@ -24,36 +29,45 @@ import com.slack.circuit.runtime.screen.Screen
  * }
  * ```
  */
-public class FakeNavigator(initialScreen: Screen? = null) : Navigator {
-  private val navigatedScreens = ArrayDeque<Screen>().apply { initialScreen?.let(::add) }
+public class FakeNavigator internal constructor(private val delegate: Navigator) :
+  Navigator by delegate {
+  public constructor(
+    backStack: BackStack<out BackStack.Record>
+  ) : this(
+    // Use a real navigator. This fake more or less just decorates it and intercepts events
+    Navigator(backStack) {}
+  )
+
+  public constructor(
+    root: Screen
+  ) : this(
+    // Use a real back stack
+    SaveableBackStack(root)
+  )
+
+  private val navigatedScreens = Turbine<Screen>()
   private val newRoots = Turbine<Screen>()
   private val pops = Turbine<Unit>()
   private val results = Turbine<PopResult>()
 
   override fun goTo(screen: Screen) {
+    delegate.goTo(screen)
     navigatedScreens.add(screen)
   }
 
   override fun pop(result: PopResult?): Screen? {
     pops.add(Unit)
     result?.let(results::add)
-    return navigatedScreens.removeLastOrNull()
+    return delegate.pop(result)
   }
 
-  override fun peek(): Screen? = navigatedScreens.lastOrNull()
-
-  override fun peekBackStack(): List<Screen> {
-    error("peekBackStack() is not supported in FakeNavigator")
-  }
-
-  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
+  override fun resetRoot(
+    newRoot: Screen,
+    saveState: Boolean,
+    restoreState: Boolean,
+  ): ImmutableList<Screen> {
+    val oldScreens = delegate.resetRoot(newRoot, saveState, restoreState)
     newRoots.add(newRoot)
-    // Note: to simulate popping off the backstack, screens should be returned in the reverse
-    // order that they were added. As the channel returns them in the order they were added, we
-    // need to reverse here before returning.
-    val oldScreens = navigatedScreens.toList().reversed()
-    navigatedScreens.clear()
-
     return oldScreens
   }
 
@@ -62,12 +76,10 @@ public class FakeNavigator(initialScreen: Screen? = null) : Navigator {
    *
    * For non-coroutines users only.
    */
-  public fun takeNextScreen(): Screen = navigatedScreens.removeFirst()
+  public fun takeNextScreen(): Screen = navigatedScreens.takeItem()
 
   /** Awaits the next [Screen] that was navigated to or throws if no screens were navigated to. */
-  // TODO suspend isn't necessary here anymore but left for backwards compatibility
-  @Suppress("RedundantSuspendModifier")
-  public suspend fun awaitNextScreen(): Screen = navigatedScreens.removeFirst()
+  public suspend fun awaitNextScreen(): Screen = navigatedScreens.awaitItem()
 
   /** Awaits the next navigation [resetRoot] or throws if no resets were performed. */
   public suspend fun awaitResetRoot(): Screen = newRoots.awaitItem()
@@ -77,11 +89,11 @@ public class FakeNavigator(initialScreen: Screen? = null) : Navigator {
 
   /** Asserts that all events so far have been consumed. */
   public fun assertIsEmpty() {
-    check(navigatedScreens.isEmpty())
+    navigatedScreens.ensureAllEventsConsumed()
   }
 
   /** Asserts that no events have been emitted. */
   public fun expectNoEvents() {
-    check(navigatedScreens.isEmpty())
+    navigatedScreens.expectNoEvents()
   }
 }

--- a/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -15,6 +15,9 @@ import kotlinx.collections.immutable.ImmutableList
 /**
  * A fake [Navigator] that can be used in tests to record and assert navigation events.
  *
+ * This navigator acts as a real navigator for all intents and purposes, navigating either a given
+ * [BackStack] or using a simple real one under the hood if one isn't provided.
+ *
  * Example
  *
  * ```kotlin

--- a/circuitx/effects/src/androidUnitTest/kotlin/com/slack/circuitx/effects/RememberImpressionNavigatorTest.kt
+++ b/circuitx/effects/src/androidUnitTest/kotlin/com/slack/circuitx/effects/RememberImpressionNavigatorTest.kt
@@ -41,7 +41,7 @@ class RememberImpressionNavigatorTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  private val fakeNavigator = FakeNavigator()
+  private val fakeNavigator = FakeNavigator(TestRootScreen)
   private val registry = RetainedStateRegistry()
   private val composed = MutableStateFlow(true)
 
@@ -127,9 +127,11 @@ class RememberImpressionNavigatorTest {
       // Navigation reset
       onNodeWithTag(TAG_RESET).performClick()
       advanceTimeByAndRun(1)
-      assertEquals(TestResetScreen, fakeNavigator.awaitResetRoot())
+      assertEquals(TestResetScreen, fakeNavigator.awaitResetRoot().newRoot)
     }
   }
+
+  @Parcelize private data object TestRootScreen : Screen
 
   @Parcelize private data object TestGoToScreen : Screen
 

--- a/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
+++ b/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
@@ -86,7 +86,11 @@ private class OnNavEventNavigator(val delegate: Navigator, val onNavEvent: () ->
 
   override fun peekBackStack(): ImmutableList<Screen> = delegate.peekBackStack()
 
-  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): ImmutableList<Screen> {
+  override fun resetRoot(
+    newRoot: Screen,
+    saveState: Boolean,
+    restoreState: Boolean,
+  ): ImmutableList<Screen> {
     onNavEvent()
     return delegate.resetRoot(newRoot, saveState, restoreState)
   }

--- a/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
+++ b/circuitx/effects/src/commonMain/kotlin/com/slack/circuitx/effects/ImpressionEffect.kt
@@ -14,6 +14,7 @@ import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.ImmutableList
 
 /**
  * A side effect that will run an [impression]. This [impression] will run only once until it is
@@ -83,9 +84,9 @@ private class OnNavEventNavigator(val delegate: Navigator, val onNavEvent: () ->
 
   override fun peek(): Screen? = delegate.peek()
 
-  override fun peekBackStack(): List<Screen> = delegate.peekBackStack()
+  override fun peekBackStack(): ImmutableList<Screen> = delegate.peekBackStack()
 
-  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
+  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): ImmutableList<Screen> {
     onNavEvent()
     return delegate.resetRoot(newRoot, saveState, restoreState)
   }

--- a/circuitx/gesture-navigation/src/androidUnitTest/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationRetainedStateTest.kt
+++ b/circuitx/gesture-navigation/src/androidUnitTest/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationRetainedStateTest.kt
@@ -64,7 +64,7 @@ class GestureNavigationRetainedStateTest {
 
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
           val navigator =
             rememberCircuitNavigator(
               backStack = backStack,

--- a/circuitx/gesture-navigation/src/androidUnitTest/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationSaveableStateTest.kt
+++ b/circuitx/gesture-navigation/src/androidUnitTest/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationSaveableStateTest.kt
@@ -64,7 +64,7 @@ class GestureNavigationSaveableStateTest {
 
       setContent {
         CircuitCompositionLocals(circuit) {
-          val backStack = rememberSaveableBackStack { push(TestScreen.ScreenA) }
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
           val navigator =
             rememberCircuitNavigator(
               backStack = backStack,

--- a/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
+++ b/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
@@ -15,6 +15,8 @@ import com.slack.circuit.overlay.OverlayNavigator
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 /**
  * Shows a full screen overlay with the given [screen]. As the name suggests, this overlay takes
@@ -77,9 +79,9 @@ internal class DispatchingOverlayNavigator(
 
   override fun peek(): Screen = currentScreen
 
-  override fun peekBackStack(): List<Screen> = listOf(currentScreen)
+  override fun peekBackStack(): ImmutableList<Screen> = persistentListOf(currentScreen)
 
-  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
+  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): ImmutableList<Screen> {
     error("resetRoot() is not supported in full screen overlays!")
   }
 }

--- a/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
+++ b/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
@@ -81,7 +81,11 @@ internal class DispatchingOverlayNavigator(
 
   override fun peekBackStack(): ImmutableList<Screen> = persistentListOf(currentScreen)
 
-  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): ImmutableList<Screen> {
+  override fun resetRoot(
+    newRoot: Screen,
+    saveState: Boolean,
+    restoreState: Boolean,
+  ): ImmutableList<Screen> {
     error("resetRoot() is not supported in full screen overlays!")
   }
 }

--- a/docs/circuitx.md
+++ b/docs/circuitx.md
@@ -32,7 +32,7 @@ with `rememberAndroidScreenAwareNavigator()`.
 class MainActivity : Activity {
   override fun onCreate(savedInstanceState: Bundle?) {
     setContent {
-      val backStack = rememberSaveableBackStack { push(HomeScreen) }
+      val backStack = rememberSaveableBackStack(root = HomeScreen)
       val navigator = rememberAndroidScreenAwareNavigator(
         rememberCircuitNavigator(backstack), // Decorated navigator
         this@MainActivity

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -10,7 +10,7 @@ A new navigable content surface is handled via the `NavigableCircuitContent` fun
 
 ```kotlin
 setContent {
-  val backStack = rememberSaveableBackStack { push(HomeScreen) }
+  val backStack = rememberSaveableBackStack(root = HomeScreen)
   val navigator = rememberCircuitNavigator(backStack)
   NavigableCircuitContent(navigator, backStack)
 }
@@ -35,7 +35,7 @@ If you want to have custom behavior for when back is pressed on the root screen 
 
 ```kotlin
 setContent {
-  val backStack = rememberSaveableBackStack { push(HomeScreen) }
+  val backStack = rememberSaveableBackStack(root = HomeScreen)
   BackHandler(onBack = { /* do something on root */ })
   // The Navigator's internal BackHandler will take precedence until it is at the root screen.
   val navigator = rememberCircuitNavigator(backstack)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,7 @@ Circuit is designed to make testing as easy as possible. Its core components are
 Circuit will have a test artifact containing APIs to aid testing both presenters and composable UIs:
 
 - `Presenter.test()` - an extension function that bridges the Compose and coroutines world. Use of this function is recommended for testing presenter state emissions and incoming UI events. Under the hood it leverages [Molecule](https://github.com/cashapp/molecule) and [Turbine](https://github.com/cashapp/turbine).
-- `FakeNavigator` - a test fake implementing the Circuit/Navigator interface. Use of this object is recommended when testing screen navigation (ie. goTo, pop/back).
+- `FakeNavigator` - a test fake implementing the `Navigator` interface. Use of this object is recommended when testing screen navigation (ie. goTo, pop/back). This acts as a real navigator and exposes recorded information for testing purposes.
 - `TestEventSink` - a generic test fake for recording and asserting event emissions through an event sink function.
 
 ## Installation

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -286,10 +286,7 @@ This is the most basic way to render a `Screen`. These can be top-level UIs or n
 An app architecture isn't complete without navigation. Circuit provides a simple navigation API that's focused around a simple `BackStack` ([docs](https://slackhq.github.io/circuit/api/0.x/backstack/com.slack.circuit.backstack/-back-stack/index.html)) that is navigated via a `Navigator` interface ([docs]()). In most cases, you can use the built-in `SaveableBackStack` implementation ([docs](https://slackhq.github.io/circuit/api/0.x/backstack/com.slack.circuit.backstack/-saveable-back-stack/index.html)), which is saved and restored in accordance with whatever the platform's `rememberSaveable` implementation is.
 
 ```kotlin title="Creating a backstack and navigator"
-val backStack = rememberSaveableBackStack { 
-  // Push your root screen
-  push(InboxScreen)
-}
+val backStack = rememberSaveableBackStack(root = InboxScreen)
 val navigator = rememberCircuitNavigator(backStack) {
   // Do something when the root screen is popped, usually exiting the app
 }
@@ -306,10 +303,7 @@ This composable will automatically manage the backstack and navigation for you, 
 Like with `Circuit`, this is usually a one-time setup in your application at its primary entry point.
 
 ```kotlin title="Putting it all together"
-val backStack = rememberSaveableBackStack {
-  // Push your root screen
-  push(InboxScreen)
-}
+val backStack = rememberSaveableBackStack(root = InboxScreen)
 val navigator = rememberCircuitNavigator(backStack) {
   // Do something when the root screen is popped, usually exiting the app
 }

--- a/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
+++ b/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
@@ -151,7 +151,7 @@ fun main() = application {
     onCloseRequest = ::exitApplication,
   ) {
     val initialBackStack = persistentListOf<Screen>(DesktopCounterScreen)
-    val backStack = rememberSaveableBackStack { initialBackStack.forEach(::push) }
+    val backStack = rememberSaveableBackStack(initialBackStack)
     val navigator = rememberCircuitNavigator(backStack, ::exitApplication)
 
     val circuit: Circuit =

--- a/samples/star/src/androidMain/kotlin/com/slack/circuit/star/MainActivity.kt
+++ b/samples/star/src/androidMain/kotlin/com/slack/circuit/star/MainActivity.kt
@@ -68,9 +68,7 @@ class MainActivity @Inject constructor(private val circuit: Circuit) : AppCompat
       StarTheme {
         // TODO why isn't the windowBackground enough so we don't need to do this?
         Surface(color = MaterialTheme.colorScheme.background) {
-          val backStack = rememberSaveableBackStack {
-            initialBackstack.forEach { screen -> push(screen) }
-          }
+          val backStack = rememberSaveableBackStack(initialBackstack)
           val circuitNavigator = rememberCircuitNavigator(backStack)
           val navigator = rememberAndroidScreenAwareNavigator(circuitNavigator, this::goTo)
           CircuitCompositionLocals(circuit) {

--- a/samples/star/src/androidUnitTest/kotlin/com/slack/circuit/star/home/HomePresenterTest.kt
+++ b/samples/star/src/androidUnitTest/kotlin/com/slack/circuit/star/home/HomePresenterTest.kt
@@ -17,7 +17,7 @@ import org.robolectric.RobolectricTestRunner
 class HomePresenterTest {
   @Test
   fun changeIndices() = runTest {
-    moleculeFlow(RecompositionMode.Immediate) { HomePresenter(FakeNavigator()) }
+    moleculeFlow(RecompositionMode.Immediate) { HomePresenter(FakeNavigator(HomeScreen)) }
       .test {
         // Initial index is 0.
         val firstState = awaitItem()

--- a/samples/star/src/androidUnitTest/kotlin/com/slack/circuit/star/petdetail/PetDetailPresenterTest.kt
+++ b/samples/star/src/androidUnitTest/kotlin/com/slack/circuit/star/petdetail/PetDetailPresenterTest.kt
@@ -18,12 +18,11 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PetDetailPresenterTest {
-  private val navigator = FakeNavigator()
-
   @Test
   fun `present - emit loading state then no animal state`() = runTest {
     val repository = TestRepository(emptyList())
     val screen = PetDetailScreen(123L, "key")
+    val navigator = FakeNavigator(screen)
     val presenter = PetDetailPresenter(screen, navigator, repository)
 
     presenter.test {
@@ -37,6 +36,7 @@ class PetDetailPresenterTest {
     val animal = PetListPresenterTest.animal
     val repository = TestRepository(listOf(animal))
     val screen = PetDetailScreen(animal.id, animal.primaryPhotoUrl)
+    val navigator = FakeNavigator(screen)
     val presenter = PetDetailPresenter(screen, navigator, repository)
 
     presenter.test {
@@ -55,6 +55,7 @@ class PetDetailPresenterTest {
     val animal = PetListPresenterTest.animal
     val repository = TestRepository(listOf(animal))
     val screen = PetDetailScreen(animal.id, animal.primaryPhotoUrl)
+    val navigator = FakeNavigator(screen)
     val presenter = PetDetailPresenter(screen, navigator, repository)
 
     presenter.test {

--- a/samples/star/src/androidUnitTest/kotlin/com/slack/circuit/star/petlist/PetListPresenterTest.kt
+++ b/samples/star/src/androidUnitTest/kotlin/com/slack/circuit/star/petlist/PetListPresenterTest.kt
@@ -24,7 +24,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class PetListPresenterTest {
-  private val navigator = FakeNavigator()
+  private val navigator = FakeNavigator(PetListScreen)
 
   @Test
   fun `present - emit loading state then no animals state`() = runTest {

--- a/samples/star/src/jvmMain/kotlin/com/slack/circuit/star/main.kt
+++ b/samples/star/src/jvmMain/kotlin/com/slack/circuit/star/main.kt
@@ -40,7 +40,7 @@ fun main() {
   SingletonImageLoader.setSafe { component.imageLoader }
   application {
     val initialBackStack = persistentListOf<Screen>(HomeScreen)
-    val backStack = rememberSaveableBackStack { initialBackStack.forEach(::push) }
+    val backStack = rememberSaveableBackStack(initialBackStack)
     val circuitNavigator = rememberCircuitNavigator(backStack, ::exitApplication)
     val navigator =
       remember(circuitNavigator) {

--- a/samples/tutorial/src/androidMain/kotlin/com/slack/circuit/tutorial/impl/MainActivityImpl.kt
+++ b/samples/tutorial/src/androidMain/kotlin/com/slack/circuit/tutorial/impl/MainActivityImpl.kt
@@ -23,7 +23,7 @@ fun MainActivity.tutorialOnCreate() {
       .build()
   setContent {
     MaterialTheme {
-      val backStack = rememberSaveableBackStack { push(InboxScreen) }
+      val backStack = rememberSaveableBackStack(InboxScreen)
       val navigator = rememberCircuitNavigator(backStack)
       CircuitCompositionLocals(circuit) {
         NavigableCircuitContent(navigator = navigator, backStack = backStack)

--- a/samples/tutorial/src/jvmMain/kotlin/com/slack/circuit/tutorial/impl/main.kt
+++ b/samples/tutorial/src/jvmMain/kotlin/com/slack/circuit/tutorial/impl/main.kt
@@ -24,7 +24,7 @@ fun main() {
   application {
     Window(title = "Tutorial", onCloseRequest = ::exitApplication) {
       MaterialTheme {
-        val backStack = rememberSaveableBackStack { push(InboxScreen) }
+        val backStack = rememberSaveableBackStack(InboxScreen)
         val navigator = rememberCircuitNavigator(backStack, ::exitApplication)
         CircuitCompositionLocals(circuit) {
           NavigableCircuitContent(navigator = navigator, backStack = backStack)


### PR DESCRIPTION
See the CHANGELOG.md files for highlights, but in short: this PR significantly improves the `FakeNavigator` API and streamlines our `SaveableBackStack` init to no longer allow empty stacks. `FakeNavigator` now just uses a real back stack under the hood, making it behave more realistically and more or less just act as a recording layer over it. It also supports custom back stacks.