### PR TITLE
Prototype support for kotlin-inject

### DIFF
--- a/circuit-codegen-annotations/build.gradle.kts
+++ b/circuit-codegen-annotations/build.gradle.kts
@@ -10,7 +10,13 @@ kotlin {
   // region KMP Targets
   androidTarget { publishLibraryVariants("release") }
   jvm()
-  // Anvil/Dagger does not support iOS targets
+  iosX64()
+  iosArm64()
+  iosSimulatorArm64()
+  js {
+    moduleName = property("POM_ARTIFACT_ID").toString()
+    nodejs()
+  }
   // endregion
 
   applyDefaultHierarchyTemplate()

--- a/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/MergeCircuitComponent.kt
+++ b/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/MergeCircuitComponent.kt
@@ -1,0 +1,10 @@
+package com.slack.circuit.codegen.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * TODO
+ */
+@Target(AnnotationTarget.CLASS)
+@Suppress("unused")
+public annotation class MergeCircuitComponent<ParentComponent>(val scope: KClass<*>)

--- a/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/MergeCircuitComponent.kt
+++ b/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/MergeCircuitComponent.kt
@@ -5,6 +5,4 @@ package com.slack.circuit.codegen.annotations
 import kotlin.reflect.KClass
 
 /** TODO */
-@Target(AnnotationTarget.CLASS)
-@Suppress("unused")
-public annotation class MergeCircuitComponent<ParentComponent>(val scope: KClass<*>)
+@Target(AnnotationTarget.CLASS) public annotation class MergeCircuitComponent(val scope: KClass<*>)

--- a/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/MergeCircuitComponent.kt
+++ b/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/MergeCircuitComponent.kt
@@ -1,10 +1,10 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen.annotations
 
 import kotlin.reflect.KClass
 
-/**
- * TODO
- */
+/** TODO */
 @Target(AnnotationTarget.CLASS)
 @Suppress("unused")
 public annotation class MergeCircuitComponent<ParentComponent>(val scope: KClass<*>)

--- a/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/internal/KotlinInjectHint.kt
+++ b/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/internal/KotlinInjectHint.kt
@@ -1,11 +1,11 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen.annotations.internal
 
 import com.slack.circuit.runtime.InternalCircuitApi
 import kotlin.reflect.KClass
 
-/**
- * TODO
- */
+/** TODO */
 @Target(AnnotationTarget.CLASS)
 @Suppress("unused")
 @InternalCircuitApi

--- a/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/internal/KotlinInjectHint.kt
+++ b/circuit-codegen-annotations/src/commonMain/kotlin/com/slack/circuit/codegen/annotations/internal/KotlinInjectHint.kt
@@ -1,0 +1,13 @@
+package com.slack.circuit.codegen.annotations.internal
+
+import com.slack.circuit.runtime.InternalCircuitApi
+import kotlin.reflect.KClass
+
+/**
+ * TODO
+ */
+@Target(AnnotationTarget.CLASS)
+@Suppress("unused")
+@InternalCircuitApi
+@Repeatable
+public annotation class KotlinInjectHint(val scope: KClass<*>)

--- a/circuit-codegen-annotations/src/iosMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.ios.kt
+++ b/circuit-codegen-annotations/src/iosMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.ios.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen.annotations
 
 import com.slack.circuit.runtime.screen.Screen

--- a/circuit-codegen-annotations/src/iosMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.ios.kt
+++ b/circuit-codegen-annotations/src/iosMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.ios.kt
@@ -1,0 +1,16 @@
+package com.slack.circuit.codegen.annotations
+
+import com.slack.circuit.runtime.screen.Screen
+import kotlin.reflect.KClass
+
+/**
+ * iOS-specific [CircuitInject].
+ *
+ * For more general information about this annotation, see
+ * [com.slack.circuit.codegen.annotations.CircuitInject]
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public actual annotation class CircuitInject(
+  actual val screen: KClass<out Screen>,
+  actual val scope: KClass<*>,
+)

--- a/circuit-codegen-annotations/src/jsMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.js.kt
+++ b/circuit-codegen-annotations/src/jsMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.js.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen.annotations
 
 import com.slack.circuit.runtime.screen.Screen

--- a/circuit-codegen-annotations/src/jsMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.js.kt
+++ b/circuit-codegen-annotations/src/jsMain/kotlin/com/slack/circuit/codegen/annotations/CircuitInject.js.kt
@@ -1,0 +1,16 @@
+package com.slack.circuit.codegen.annotations
+
+import com.slack.circuit.runtime.screen.Screen
+import kotlin.reflect.KClass
+
+/**
+ * JS-specific [CircuitInject].
+ *
+ * For more general information about this annotation, see
+ * [com.slack.circuit.codegen.annotations.CircuitInject]
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public actual annotation class CircuitInject(
+  actual val screen: KClass<out Screen>,
+  actual val scope: KClass<*>,
+)

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
@@ -12,8 +12,15 @@ internal object CircuitNames {
   const val CIRCUIT_RUNTIME_SCREEN_PACKAGE = "$CIRCUIT_RUNTIME_BASE_PACKAGE.screen"
   const val CIRCUIT_RUNTIME_PRESENTER_PACKAGE = "$CIRCUIT_RUNTIME_BASE_PACKAGE.presenter"
   val MODIFIER = ClassName("androidx.compose.ui", "Modifier")
+  const val CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE = "com.slack.circuit.codegen.annotations"
   val CIRCUIT_INJECT_ANNOTATION =
-    ClassName("com.slack.circuit.codegen.annotations", "CircuitInject")
+    ClassName(CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE, "CircuitInject")
+  val MERGE_CIRCUIT_COMPONENT_ANNOTATION =
+    ClassName(CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE, "MergeCircuitComponent")
+  val KOTLIN_INJECT_HINT_ANNOTATION =
+    ClassName("$CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE.internal", "KotlinInjectHint")
+  val INTERNAL_CIRCUIT_API_ANNOTATION =
+    ClassName("com.slack.circuit.runtime", "InternalCircuitApi")
   val CIRCUIT_PRESENTER = ClassName(CIRCUIT_RUNTIME_PRESENTER_PACKAGE, "Presenter")
   val CIRCUIT_PRESENTER_FACTORY = CIRCUIT_PRESENTER.nestedClass("Factory")
   val CIRCUIT_UI = ClassName(CIRCUIT_RUNTIME_UI_PACKAGE, "Ui")
@@ -31,4 +38,12 @@ internal object CircuitNames {
   const val MODULE = "Module"
   const val FACTORY = "Factory"
   const val CIRCUIT_CODEGEN_MODE = "circuit.codegen.mode"
+
+  object KotlinInject {
+    private const val ANNOTATIONS_PACKAGE = "me.tatarka.inject.annotations"
+    val INJECT = ClassName(ANNOTATIONS_PACKAGE, "Inject")
+    val COMPONENT = ClassName(ANNOTATIONS_PACKAGE, "Component")
+    val PROVIDES = ClassName(ANNOTATIONS_PACKAGE, "Provides")
+    val INTO_SET = ClassName(ANNOTATIONS_PACKAGE, "IntoSet")
+  }
 }

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen
 
 import com.squareup.kotlinpoet.ClassName
@@ -13,14 +15,12 @@ internal object CircuitNames {
   const val CIRCUIT_RUNTIME_PRESENTER_PACKAGE = "$CIRCUIT_RUNTIME_BASE_PACKAGE.presenter"
   val MODIFIER = ClassName("androidx.compose.ui", "Modifier")
   const val CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE = "com.slack.circuit.codegen.annotations"
-  val CIRCUIT_INJECT_ANNOTATION =
-    ClassName(CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE, "CircuitInject")
+  val CIRCUIT_INJECT_ANNOTATION = ClassName(CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE, "CircuitInject")
   val MERGE_CIRCUIT_COMPONENT_ANNOTATION =
     ClassName(CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE, "MergeCircuitComponent")
   val KOTLIN_INJECT_HINT_ANNOTATION =
     ClassName("$CIRCUIT_CODEGEN_ANNOTATIONS_PACKAGE.internal", "KotlinInjectHint")
-  val INTERNAL_CIRCUIT_API_ANNOTATION =
-    ClassName("com.slack.circuit.runtime", "InternalCircuitApi")
+  val INTERNAL_CIRCUIT_API_ANNOTATION = ClassName("com.slack.circuit.runtime", "InternalCircuitApi")
   val CIRCUIT_PRESENTER = ClassName(CIRCUIT_RUNTIME_PRESENTER_PACKAGE, "Presenter")
   val CIRCUIT_PRESENTER_FACTORY = CIRCUIT_PRESENTER.nestedClass("Factory")
   val CIRCUIT_UI = ClassName(CIRCUIT_RUNTIME_UI_PACKAGE, "Ui")
@@ -29,12 +29,11 @@ internal object CircuitNames {
   val SCREEN = ClassName(CIRCUIT_RUNTIME_SCREEN_PACKAGE, "Screen")
   val NAVIGATOR = ClassName(CIRCUIT_RUNTIME_BASE_PACKAGE, "Navigator")
   val CIRCUIT_CONTEXT = ClassName(CIRCUIT_RUNTIME_BASE_PACKAGE, "CircuitContext")
-   val DAGGER_MODULE = ClassName(DAGGER_PACKAGE, "Module")
-   val DAGGER_BINDS = ClassName(DAGGER_PACKAGE, "Binds")
-   val DAGGER_INSTALL_IN = ClassName(DAGGER_HILT_PACKAGE, "InstallIn")
-   val DAGGER_ORIGINATING_ELEMENT =
-     ClassName(DAGGER_HILT_CODEGEN_PACKAGE, "OriginatingElement")
-   val DAGGER_INTO_SET = ClassName(DAGGER_MULTIBINDINGS_PACKAGE, "IntoSet")
+  val DAGGER_MODULE = ClassName(DAGGER_PACKAGE, "Module")
+  val DAGGER_BINDS = ClassName(DAGGER_PACKAGE, "Binds")
+  val DAGGER_INSTALL_IN = ClassName(DAGGER_HILT_PACKAGE, "InstallIn")
+  val DAGGER_ORIGINATING_ELEMENT = ClassName(DAGGER_HILT_CODEGEN_PACKAGE, "OriginatingElement")
+  val DAGGER_INTO_SET = ClassName(DAGGER_MULTIBINDINGS_PACKAGE, "IntoSet")
   const val MODULE = "Module"
   const val FACTORY = "Factory"
   const val CIRCUIT_CODEGEN_MODE = "circuit.codegen.mode"

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
@@ -1,0 +1,34 @@
+package com.slack.circuit.codegen
+
+import com.squareup.kotlinpoet.ClassName
+
+internal object CircuitNames {
+  const val CIRCUIT_RUNTIME_BASE_PACKAGE = "com.slack.circuit.runtime"
+  const val DAGGER_PACKAGE = "dagger"
+  const val DAGGER_HILT_PACKAGE = "$DAGGER_PACKAGE.hilt"
+  const val DAGGER_HILT_CODEGEN_PACKAGE = "$DAGGER_HILT_PACKAGE.codegen"
+  const val DAGGER_MULTIBINDINGS_PACKAGE = "$DAGGER_PACKAGE.multibindings"
+  const val CIRCUIT_RUNTIME_UI_PACKAGE = "$CIRCUIT_RUNTIME_BASE_PACKAGE.ui"
+  const val CIRCUIT_RUNTIME_SCREEN_PACKAGE = "$CIRCUIT_RUNTIME_BASE_PACKAGE.screen"
+  const val CIRCUIT_RUNTIME_PRESENTER_PACKAGE = "$CIRCUIT_RUNTIME_BASE_PACKAGE.presenter"
+  val MODIFIER = ClassName("androidx.compose.ui", "Modifier")
+  val CIRCUIT_INJECT_ANNOTATION =
+    ClassName("com.slack.circuit.codegen.annotations", "CircuitInject")
+  val CIRCUIT_PRESENTER = ClassName(CIRCUIT_RUNTIME_PRESENTER_PACKAGE, "Presenter")
+  val CIRCUIT_PRESENTER_FACTORY = CIRCUIT_PRESENTER.nestedClass("Factory")
+  val CIRCUIT_UI = ClassName(CIRCUIT_RUNTIME_UI_PACKAGE, "Ui")
+  val CIRCUIT_UI_FACTORY = CIRCUIT_UI.nestedClass("Factory")
+  val CIRCUIT_UI_STATE = ClassName(CIRCUIT_RUNTIME_BASE_PACKAGE, "CircuitUiState")
+  val SCREEN = ClassName(CIRCUIT_RUNTIME_SCREEN_PACKAGE, "Screen")
+  val NAVIGATOR = ClassName(CIRCUIT_RUNTIME_BASE_PACKAGE, "Navigator")
+  val CIRCUIT_CONTEXT = ClassName(CIRCUIT_RUNTIME_BASE_PACKAGE, "CircuitContext")
+   val DAGGER_MODULE = ClassName(DAGGER_PACKAGE, "Module")
+   val DAGGER_BINDS = ClassName(DAGGER_PACKAGE, "Binds")
+   val DAGGER_INSTALL_IN = ClassName(DAGGER_HILT_PACKAGE, "InstallIn")
+   val DAGGER_ORIGINATING_ELEMENT =
+     ClassName(DAGGER_HILT_CODEGEN_PACKAGE, "OriginatingElement")
+   val DAGGER_INTO_SET = ClassName(DAGGER_MULTIBINDINGS_PACKAGE, "IntoSet")
+  const val MODULE = "Module"
+  const val FACTORY = "Factory"
+  const val CIRCUIT_CODEGEN_MODE = "circuit.codegen.mode"
+}

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -209,7 +209,7 @@ private class CircuitSymbolProcessor(
 
   /** Computes the data needed to generate a factory. */
   // Detekt and ktfmt don't agree on whether or not the rectangle rule makes for readable code.
-  @Suppress("ComplexMethod", "LongMethod", "ReturnCount")
+  @Suppress("ComplexMethod", "LongMethod", "ReturnCount", "LongParameterList")
   @OptIn(KspExperimental::class)
   private fun computeFactoryData(
     annotatedElement: KSAnnotated,

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen
 
 import com.google.devtools.ksp.processing.Resolver

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
@@ -7,6 +7,8 @@ internal class CircuitSymbols private constructor(resolver: Resolver) {
   val circuitUiState = resolver.loadKSType(CircuitNames.CIRCUIT_UI_STATE.canonicalName)
   val screen = resolver.loadKSType(CircuitNames.SCREEN.canonicalName)
   val navigator = resolver.loadKSType(CircuitNames.NAVIGATOR.canonicalName)
+  val presenterFactory = resolver.loadKSType(CircuitNames.CIRCUIT_PRESENTER_FACTORY.canonicalName)
+  val uiFactory = resolver.loadKSType(CircuitNames.CIRCUIT_UI_FACTORY.canonicalName)
 
   companion object {
     fun create(resolver: Resolver): CircuitSymbols? {

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
@@ -1,0 +1,21 @@
+package com.slack.circuit.codegen
+
+import com.google.devtools.ksp.processing.Resolver
+
+internal class CircuitSymbols private constructor(resolver: Resolver) {
+  val modifier = resolver.loadKSType(CircuitNames.MODIFIER.canonicalName)
+  val circuitUiState = resolver.loadKSType(CircuitNames.CIRCUIT_UI_STATE.canonicalName)
+  val screen = resolver.loadKSType(CircuitNames.SCREEN.canonicalName)
+  val navigator = resolver.loadKSType(CircuitNames.NAVIGATOR.canonicalName)
+
+  companion object {
+    fun create(resolver: Resolver): CircuitSymbols? {
+      @Suppress("SwallowedException")
+      return try {
+        CircuitSymbols(resolver)
+      } catch (e: IllegalStateException) {
+        null
+      }
+    }
+  }
+}

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
@@ -1,0 +1,127 @@
+package com.slack.circuit.codegen
+
+import com.google.devtools.ksp.processing.JvmPlatformInfo
+import com.google.devtools.ksp.processing.PlatformInfo
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+
+internal enum class CodegenMode {
+  /**
+   * The Anvil Codegen mode
+   *
+   * This mode annotates generated factory types with [ContributesMultibinding], allowing for Anvil
+   * to automatically wire the generated class up to Dagger's multibinding system within a given
+   * scope (e.g. AppScope).
+   *
+   * ```kotlin
+   * @ContributesMultibinding(AppScope::class)
+   * public class FavoritesPresenterFactory @Inject constructor(
+   *   private val factory: FavoritesPresenter.Factory,
+   * ) : Presenter.Factory { ... }
+   * ```
+   */
+  ANVIL {
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
+      // Anvil only supports JVM & Android
+      return platforms.all { it is JvmPlatformInfo }
+    }
+
+    override fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {
+      builder.addAnnotation(
+        AnnotationSpec.builder(ContributesMultibinding::class).addMember("%T::class", scope).build()
+      )
+    }
+  },
+
+  /**
+   * The Hilt Codegen mode
+   *
+   * This mode provides an additional type, a Hilt module, which binds the generated factory, wiring
+   * up multibinding in the Hilt DI framework. The scope provided via [CircuitInject] is used to
+   * define the dagger component the factory provider is installed in.
+   *
+   * ```kotlin
+   * @Module
+   * @InstallIn(SingletonComponent::class)
+   * @OriginatingElement(topLevelClass = FavoritesPresenter::class)
+   * public abstract class FavoritesPresenterFactoryModule {
+   *   @Binds
+   *   @IntoSet
+   *   public abstract
+   *       fun bindFavoritesPresenterFactory(favoritesPresenterFactory: FavoritesPresenterFactory):
+   *       Presenter.Factory
+   * }
+   * ```
+   */
+  HILT {
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
+      // Hilt only supports JVM & Android
+      return platforms.all { it is JvmPlatformInfo }
+    }
+
+    override fun produceAdditionalTypeSpec(
+      factory: ClassName,
+      factoryType: FactoryType,
+      scope: TypeName,
+      topLevelClass: ClassName?,
+    ): TypeSpec {
+      val moduleAnnotations =
+        listOfNotNull(
+          AnnotationSpec.builder(CircuitNames.DAGGER_MODULE).build(),
+          AnnotationSpec.builder(CircuitNames.DAGGER_INSTALL_IN).addMember("%T::class", scope).build(),
+          topLevelClass?.let {
+            AnnotationSpec.builder(CircuitNames.DAGGER_ORIGINATING_ELEMENT)
+              .addMember("%L = %T::class", "topLevelClass", topLevelClass)
+              .build()
+          },
+        )
+
+      val providerAnnotations =
+        listOf(
+          AnnotationSpec.builder(CircuitNames.DAGGER_BINDS).build(),
+          AnnotationSpec.builder(CircuitNames.DAGGER_INTO_SET).build(),
+        )
+
+      val providerReturns =
+        if (factoryType == FactoryType.UI) {
+          CircuitNames.CIRCUIT_UI_FACTORY
+        } else {
+          CircuitNames.CIRCUIT_PRESENTER_FACTORY
+        }
+
+      val factoryName = factory.simpleName
+
+      val providerSpec =
+        FunSpec.builder("bind${factoryName}")
+          .addModifiers(KModifier.ABSTRACT)
+          .addAnnotations(providerAnnotations)
+          .addParameter(name = factoryName.replaceFirstChar { it.lowercase() }, type = factory)
+          .returns(providerReturns)
+          .build()
+
+      return TypeSpec.classBuilder(factory.peerClass(factoryName + CircuitNames.MODULE))
+        .addModifiers(KModifier.ABSTRACT)
+        .addAnnotations(moduleAnnotations)
+        .addFunction(providerSpec)
+        .build()
+    }
+  };
+
+  open fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {}
+
+  open fun produceAdditionalTypeSpec(
+    factory: ClassName,
+    factoryType: FactoryType,
+    scope: TypeName,
+    topLevelClass: ClassName?,
+  ): TypeSpec? {
+    return null
+  }
+
+  abstract fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean
+}

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen
 
 import com.google.devtools.ksp.processing.JvmPlatformInfo

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
@@ -110,7 +110,20 @@ internal enum class CodegenMode {
         .addFunction(providerSpec)
         .build()
     }
-  };
+  },
+  KOTLIN_INJECT {
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean = true
+
+    override fun produceAdditionalTypeSpec(
+      factory: ClassName,
+      factoryType: FactoryType,
+      scope: TypeName,
+      topLevelClass: ClassName?
+    ): TypeSpec? {
+      TODO()
+    }
+  }
+  ;
 
   open fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {}
 

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/FactoryType.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/FactoryType.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen
 
 internal enum class FactoryType {

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/FactoryType.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/FactoryType.kt
@@ -1,0 +1,6 @@
+package com.slack.circuit.codegen
+
+internal enum class FactoryType {
+  PRESENTER,
+  UI
+}

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/InstantiationType.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/InstantiationType.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen
 
 internal enum class InstantiationType {

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/InstantiationType.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/InstantiationType.kt
@@ -1,0 +1,6 @@
+package com.slack.circuit.codegen
+
+internal enum class InstantiationType {
+  FUNCTION,
+  CLASS
+}

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/KspUtil.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/KspUtil.kt
@@ -1,0 +1,100 @@
+package com.slack.circuit.codegen
+
+import com.google.devtools.ksp.getVisibility
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.Visibility
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.joinToCode
+import com.squareup.kotlinpoet.ksp.toTypeName
+
+internal fun Resolver.loadKSType(name: String): KSType =
+  loadOptionalKSType(name) ?: error("Could not find $name in classpath")
+
+internal fun Resolver.loadOptionalKSType(name: String?): KSType? {
+  if (name == null) return null
+  return getClassDeclarationByName(getKSNameFromString(name))?.asType(emptyList())
+}
+
+internal inline fun KSDeclaration.checkVisibility(logger: KSPLogger, returnBody: () -> Unit) {
+  if (!getVisibility().isVisible) {
+    logger.error("CircuitInject is not applicable to private or local functions and classes.", this)
+    returnBody()
+  }
+}
+
+internal fun KSDeclaration.topLevelDeclaration(): KSDeclaration {
+  return parentDeclaration?.topLevelDeclaration() ?: this
+}
+
+internal val Visibility.isVisible: Boolean
+  get() = this != Visibility.PRIVATE && this != Visibility.LOCAL
+
+internal data class AssistedType(val factoryName: String, val type: TypeName, val name: String)
+
+/**
+ * Returns a [CodeBlock] representation of all named assisted parameters on this
+ * [KSFunctionDeclaration] to be used in generated invocation code.
+ *
+ * Example: this function
+ *
+ * ```kotlin
+ * @Composable
+ * fun HomePresenter(screen: Screen, navigator: Navigator)
+ * ```
+ *
+ * Yields this CodeBlock: `screen = screen, navigator = navigator`
+ */
+internal fun KSFunctionDeclaration.assistedParameters(
+  symbols: CircuitSymbols,
+  logger: KSPLogger,
+  screenType: KSType,
+  allowNavigator: Boolean,
+): CodeBlock {
+  return buildSet {
+    for (param in parameters) {
+      fun <E> MutableSet<E>.addOrError(element: E) {
+        val added = add(element)
+        if (!added) {
+          logger.error("Multiple parameters of type $element are not allowed.", param)
+        }
+      }
+
+      val type = param.type.resolve()
+      when {
+        type.isInstanceOf(symbols.screen) -> {
+          if (screenType.isSameDeclarationAs(type)) {
+            addOrError(AssistedType("screen", type.toTypeName(), param.name!!.getShortName()))
+          } else {
+            logger.error("Screen type mismatch. Expected $screenType but found $type", param)
+          }
+        }
+        type.isInstanceOf(symbols.navigator) -> {
+          if (allowNavigator) {
+            addOrError(AssistedType("navigator", type.toTypeName(), param.name!!.getShortName()))
+          } else {
+            logger.error(
+              "Navigator type mismatch. Navigators are not injectable on this type.",
+              param,
+            )
+          }
+        }
+      }
+    }
+  }
+    .toList()
+    .map { CodeBlock.of("${it.name} = ${it.factoryName}") }
+    .joinToCode(",·")
+}
+
+internal fun KSType.isSameDeclarationAs(type: KSType): Boolean {
+  return this.declaration == type.declaration
+}
+
+internal fun KSType.isInstanceOf(type: KSType): Boolean {
+  return type.isAssignableFrom(this)
+}

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
@@ -108,7 +108,7 @@ public class MergeCircuitComponentProcessor(
     val deferred = mutableListOf<KSAnnotated>()
     for (mergeComponent in mergeCircuitComponents) {
       val scope = mergeComponent.scope
-      val contributedFactories = hints[scope] ?: emptySet()
+      val contributedFactories = hints[scope].orEmpty()
       val annotated = mergeComponent.annotated
       if (contributedFactories.isEmpty()) {
         // TODO what if we never get contributions in multiple rounds?

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
@@ -49,20 +49,17 @@ public class MergeCircuitComponentProcessor(
           CodegenMode.KOTLIN_INJECT.name,
           ignoreCase = true,
         ) ?: false
-      environment.logger.warn("Circuit KotlinInject codegen enabled: $enabled")
       return MergeCircuitComponentProcessor(enabled, environment.codeGenerator, environment.logger)
     }
   }
 
   override fun process(resolver: Resolver): List<KSAnnotated> {
-    logger.warn("Processing merge circuit components")
     if (!enabled) return emptyList()
     // Get all merge circuit component annotations
     val mergeCircuitComponents =
       resolver
         .getSymbolsWithAnnotation(CircuitNames.MERGE_CIRCUIT_COMPONENT_ANNOTATION.canonicalName)
         .filterIsInstance<KSClassDeclaration>()
-        .onEach { logger.warn("Found merge circuit component: $it") }
         .map {
           val mergeAnnotation =
             it.getAnnotationsByType(CircuitNames.MERGE_CIRCUIT_COMPONENT_ANNOTATION).first()
@@ -85,7 +82,6 @@ public class MergeCircuitComponentProcessor(
     resolver
       .getSymbolsWithAnnotation(CircuitNames.KOTLIN_INJECT_HINT_ANNOTATION.canonicalName)
       .filterIsInstance<KSClassDeclaration>()
-      .onEach { logger.warn("Found kotlin inject hint: $it") }
       .forEach { clazz ->
         clazz
           .getAnnotationsByType(CircuitNames.KOTLIN_INJECT_HINT_ANNOTATION)
@@ -104,13 +100,12 @@ public class MergeCircuitComponentProcessor(
       val contributedFactories = hints[scope] ?: emptySet()
       val annotated = mergeComponent.annotated
       if (contributedFactories.isEmpty()) {
-        logger.warn("No contributed factories found for scope $scope", annotated)
+        // TODO what if we never get contributions in multiple rounds?
         deferred += annotated
         continue
       }
 
       val parentComponent = mergeComponent.parentComponent
-      logger.warn("Generating component for scope $scope with parent component $parentComponent")
       generate(symbols, annotated, contributedFactories, parentComponent)
     }
     return deferred

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.codegen.kotlininject
 
 import com.google.auto.service.AutoService
@@ -33,9 +35,7 @@ import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import kotlin.reflect.KClass
 
-/**
- * TODO
- */
+/** TODO */
 public class MergeCircuitComponentProcessor(
   private val enabled: Boolean,
   private val codeGenerator: CodeGenerator,
@@ -62,9 +62,7 @@ public class MergeCircuitComponentProcessor(
       resolver
         .getSymbolsWithAnnotation(CircuitNames.MERGE_CIRCUIT_COMPONENT_ANNOTATION.canonicalName)
         .filterIsInstance<KSClassDeclaration>()
-        .onEach {
-          logger.warn("Found merge circuit component: $it")
-        }
+        .onEach { logger.warn("Found merge circuit component: $it") }
         .map {
           val mergeAnnotation =
             it.getAnnotationsByType(CircuitNames.MERGE_CIRCUIT_COMPONENT_ANNOTATION).first()
@@ -87,9 +85,7 @@ public class MergeCircuitComponentProcessor(
     resolver
       .getSymbolsWithAnnotation(CircuitNames.KOTLIN_INJECT_HINT_ANNOTATION.canonicalName)
       .filterIsInstance<KSClassDeclaration>()
-      .onEach {
-        logger.warn("Found kotlin inject hint: $it")
-      }
+      .onEach { logger.warn("Found kotlin inject hint: $it") }
       .forEach { clazz ->
         clazz
           .getAnnotationsByType(CircuitNames.KOTLIN_INJECT_HINT_ANNOTATION)

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/kotlininject/MergeCircuitComponentProcessor.kt
@@ -1,0 +1,237 @@
+package com.slack.circuit.codegen.kotlininject
+
+import com.google.auto.service.AutoService
+import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.slack.circuit.codegen.CircuitNames
+import com.slack.circuit.codegen.CircuitSymbols
+import com.slack.circuit.codegen.CodegenMode
+import com.slack.circuit.codegen.getAnnotationsByType
+import com.slack.circuit.codegen.isInstanceOf
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ksp.TypeParameterResolver
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.writeTo
+import kotlin.reflect.KClass
+
+/**
+ * TODO
+ */
+public class MergeCircuitComponentProcessor(
+  private val enabled: Boolean,
+  private val codeGenerator: CodeGenerator,
+  private val logger: KSPLogger,
+) : SymbolProcessor {
+  @AutoService(SymbolProcessorProvider::class)
+  public class Provider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+      val enabled =
+        environment.options[CircuitNames.CIRCUIT_CODEGEN_MODE]?.equals(
+          CodegenMode.KOTLIN_INJECT.name,
+          ignoreCase = true,
+        ) ?: false
+      environment.logger.warn("Circuit KotlinInject codegen enabled: $enabled")
+      return MergeCircuitComponentProcessor(enabled, environment.codeGenerator, environment.logger)
+    }
+  }
+
+  override fun process(resolver: Resolver): List<KSAnnotated> {
+    logger.warn("Processing merge circuit components")
+    if (!enabled) return emptyList()
+    // Get all merge circuit component annotations
+    val mergeCircuitComponents =
+      resolver
+        .getSymbolsWithAnnotation(CircuitNames.MERGE_CIRCUIT_COMPONENT_ANNOTATION.canonicalName)
+        .filterIsInstance<KSClassDeclaration>()
+        .onEach {
+          logger.warn("Found merge circuit component: $it")
+        }
+        .map {
+          val mergeAnnotation =
+            it.getAnnotationsByType(CircuitNames.MERGE_CIRCUIT_COMPONENT_ANNOTATION).first()
+          val scopeType = mergeAnnotation.arguments.first().value as KSType
+          val scope = (scopeType.declaration as KSClassDeclaration).toClassName()
+          // Read the ParentComponent off the generic type (which is stored on
+          // annotationType.element)
+          val parentComponent =
+            mergeAnnotation.annotationType.element!!
+              .typeArguments[0]
+              .toTypeName(TypeParameterResolver.EMPTY)
+          MergeComponentData(scope, parentComponent, it)
+        }
+        .toList()
+
+    if (mergeCircuitComponents.isEmpty()) return emptyList()
+
+    // Get all kotlin inject hints, associate by scope
+    val hints: MutableMap<ClassName, MutableSet<KSClassDeclaration>> = mutableMapOf()
+    resolver
+      .getSymbolsWithAnnotation(CircuitNames.KOTLIN_INJECT_HINT_ANNOTATION.canonicalName)
+      .filterIsInstance<KSClassDeclaration>()
+      .onEach {
+        logger.warn("Found kotlin inject hint: $it")
+      }
+      .forEach { clazz ->
+        clazz
+          .getAnnotationsByType(CircuitNames.KOTLIN_INJECT_HINT_ANNOTATION)
+          .map {
+            val type = it.arguments.first().value as KSType
+            val decl = type.declaration as KSClassDeclaration
+            decl.toClassName()
+          }
+          .forEach { scope -> hints.getOrPut(scope, ::mutableSetOf).add(clazz) }
+      }
+
+    val symbols = CircuitSymbols.create(resolver) ?: return emptyList()
+    val deferred = mutableListOf<KSAnnotated>()
+    for (mergeComponent in mergeCircuitComponents) {
+      val scope = mergeComponent.scope
+      val contributedFactories = hints[scope] ?: emptySet()
+      val annotated = mergeComponent.annotated
+      if (contributedFactories.isEmpty()) {
+        logger.warn("No contributed factories found for scope $scope", annotated)
+        deferred += annotated
+        continue
+      }
+
+      val parentComponent = mergeComponent.parentComponent
+      logger.warn("Generating component for scope $scope with parent component $parentComponent")
+      generate(symbols, annotated, contributedFactories, parentComponent)
+    }
+    return deferred
+  }
+
+  private fun generate(
+    symbols: CircuitSymbols,
+    annotated: KSClassDeclaration,
+    contributedFactories: Set<KSClassDeclaration>,
+    parentComponent: TypeName,
+  ) {
+    val annotatedClassName = annotated.toClassName()
+
+    // Generate the component implementation
+    /*
+    @Component
+    abstract class AppScopeCircuitComponentImpl(
+      @Component
+      public val parentComponent: ParentComponent,
+    ): AppScopeCircuitComponent {
+
+      protected val OtherScreenPresenterFactory.bind: Presenter.Factory
+        @Provides
+        @IntoSet
+        get() = this
+
+      protected val MyScreenFactory.bind: Ui.Factory
+        @Provides
+        @IntoSet
+        get() = this
+    }
+    */
+    val componentImplName = "${annotatedClassName.simpleName}Impl"
+    val componentImpl =
+      TypeSpec.classBuilder(componentImplName)
+        .addAnnotation(CircuitNames.KotlinInject.COMPONENT)
+        .addModifiers(KModifier.ABSTRACT)
+        .addSuperinterface(annotatedClassName)
+        .primaryConstructor(
+          FunSpec.constructorBuilder()
+            .addParameter(
+              ParameterSpec.builder("parentComponent", parentComponent)
+                .addAnnotation(CircuitNames.KotlinInject.COMPONENT)
+                .build()
+            )
+            .build()
+        )
+        .addProperty(
+          PropertySpec.builder("parentComponent", parentComponent)
+            .initializer("parentComponent")
+            .build()
+        )
+        .addOriginatingKSFile(annotated.containingFile!!)
+        .apply {
+          contributedFactories.forEach { contributedFactory ->
+            val factoryType = contributedFactory.toClassName()
+            val factoryKsType = contributedFactory.asType(emptyList())
+            val factorySuperType =
+              when {
+                factoryKsType.isInstanceOf(symbols.presenterFactory) -> {
+                  CircuitNames.CIRCUIT_PRESENTER_FACTORY
+                }
+                factoryKsType.isInstanceOf(symbols.uiFactory) -> {
+                  CircuitNames.CIRCUIT_UI_FACTORY
+                }
+                else -> {
+                  logger.error(
+                    "Contributed factory $factoryType is not a Presenter.Factory or Ui.Factory",
+                    contributedFactory,
+                  )
+                  return@forEach
+                }
+              }
+            val factoryProperty =
+              PropertySpec.builder("bind", factorySuperType)
+                .addModifiers(KModifier.PROTECTED)
+                .receiver(factoryType)
+                .getter(
+                  FunSpec.getterBuilder()
+                    .addAnnotation(CircuitNames.KotlinInject.PROVIDES)
+                    .addAnnotation(CircuitNames.KotlinInject.INTO_SET)
+                    .addStatement("return this")
+                    .build()
+                )
+                .addOriginatingKSFile(contributedFactory.containingFile!!)
+                .build()
+            addProperty(factoryProperty)
+          }
+        }
+        .build()
+
+    /*
+    internal fun KClass<AppScopeCircuitComponent>.create(parentComponent: ParentComponent): AppScopeCircuitComponent =
+        AppScopeCircuitComponentImpl::class.create(parentComponent)
+     */
+    val createFunction =
+      FunSpec.builder("create")
+        .receiver(KClass::class.asClassName().parameterizedBy(annotatedClassName))
+        .addParameter("parentComponent", parentComponent)
+        .returns(annotatedClassName)
+        .addStatement(
+          "return %T::class.create(parentComponent)",
+          ClassName(annotatedClassName.packageName, componentImplName),
+        )
+        .addOriginatingKSFile(annotated.containingFile!!)
+        .build()
+
+    FileSpec.builder(annotatedClassName.packageName, componentImplName)
+      .addType(componentImpl)
+      .addFunction(createFunction)
+      .build()
+      .writeTo(codeGenerator, aggregating = true)
+  }
+}
+
+internal data class MergeComponentData(
+  val scope: ClassName,
+  val parentComponent: TypeName,
+  val annotated: KSClassDeclaration,
+)

--- a/circuit-codegen/src/test/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorTest.kt
+++ b/circuit-codegen/src/test/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorTest.kt
@@ -96,7 +96,7 @@ class CircuitSymbolProcessorTest {
           @ContributesMultibinding(AppScope::class)
           public class HomeFactory @Inject constructor() : Ui.Factory {
             override fun create(screen: Screen, context: CircuitContext): Ui<*>? = when (screen) {
-              HomeScreen -> ui<CircuitUiState> { _, modifier -> Home(modifier = modifier) }
+              is HomeScreen -> ui<CircuitUiState> { _, modifier -> Home(modifier = modifier) }
               else -> null
             }
           }
@@ -234,7 +234,7 @@ class CircuitSymbolProcessorTest {
           @ContributesMultibinding(AppScope::class)
           public class HomeFactory @Inject constructor() : Ui.Factory {
             override fun create(screen: Screen, context: CircuitContext): Ui<*>? = when (screen) {
-              HomeScreen -> ui<HomeScreen.State> { state, modifier -> Home(state = state, modifier = modifier) }
+              is HomeScreen -> ui<HomeScreen.State> { state, modifier -> Home(state = state, modifier = modifier) }
               else -> null
             }
           }
@@ -534,7 +534,7 @@ class CircuitSymbolProcessorTest {
               navigator: Navigator,
               context: CircuitContext,
             ): Presenter<*>? = when (screen) {
-              HomeScreen -> presenterOf { HomePresenter() }
+              is HomeScreen -> presenterOf { HomePresenter() }
               else -> null
             }
           }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/di/CircuitComponent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/di/CircuitComponent.kt
@@ -1,0 +1,22 @@
+package com.slack.circuit.foundation.di
+
+import com.slack.circuit.foundation.Circuit
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.ui.Ui
+
+/**
+ * A simple interface that exposes [uiFactories] and [presenterFactories]. This can be useful for DI
+ * frameworks that expose multibindings for factories.
+ */
+public interface CircuitComponent {
+  public val uiFactories: Set<Ui.Factory>
+  public val presenterFactories: Set<Presenter.Factory>
+}
+
+/**
+ * Returns a new [Circuit.Builder] initialized with this [CircuitComponent.uiFactories] and
+ * [CircuitComponent.presenterFactories] added.
+ */
+public fun CircuitComponent.circuitBuilder(): Circuit.Builder {
+  return Circuit.Builder().addPresenterFactories(presenterFactories).addUiFactories(uiFactories)
+}

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/di/CircuitComponent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/di/CircuitComponent.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.foundation.di
 
 import com.slack.circuit.foundation.Circuit

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -21,6 +21,10 @@ style:
     ignoreAnnotated:
       - 'Preview'
       - 'androidx.compose.desktop.ui.tooling.preview.Preview'
+  UnusedPrivateProperty:
+    ignoreAnnotated:
+      - 'Component'
+      - 'me.tatarka.inject.annotations.Component'
   # This rule ends up causing more style issues than not
   OptionalWhenBraces:
     active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ jdk = "21"
 jvmTarget = "11"
 kct = "0.4.0"
 kotlin = "1.9.22"
+kotlinInject = "0.6.3"
 kotlinpoet = "1.16.0"
 kotlinx-coroutines = "1.7.3"
 ksp = "1.9.22-1.0.17"
@@ -220,6 +221,10 @@ jsoup = "org.jsoup:jsoup:1.17.2"
 junit = "junit:junit:4.13.2"
 kct = { module = "dev.zacsweers.kctfork:core", version.ref = "kct" }
 kct-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kct" }
+
+kotlin-inject-compiler-ksp = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlinInject" }
+kotlin-inject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime", version.ref = "kotlinInject" }
+
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.5.0"
 kotlinx-immutable = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.7"
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet"}

--- a/samples/kotlin-inject/build.gradle.kts
+++ b/samples/kotlin-inject/build.gradle.kts
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.ksp)
@@ -18,12 +20,12 @@ dependencies {
   ksp(libs.kotlin.inject.compiler.ksp)
 }
 
-//dependencies {
+// dependencies {
 //  for (target in kspTargets) {
 //    val targetConfigSuffix = if (target == "Metadata") "CommonMainMetadata" else target
 //    add("ksp${targetConfigSuffix}", projects.circuitCodegen)
 //  }
-//}
+// }
 
 ksp {
   arg("circuit.codegen.lenient", "true")

--- a/samples/kotlin-inject/build.gradle.kts
+++ b/samples/kotlin-inject/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.compose)
+}
+
+dependencies {
+  implementation(projects.circuitCodegenAnnotations)
+  implementation(projects.circuitFoundation)
+  implementation(libs.kotlin.inject.runtime)
+
+  implementation(compose.desktop.currentOs)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.runtime)
+  implementation(libs.compose.material.material3)
+
+  ksp(projects.circuitCodegen)
+  ksp(libs.kotlin.inject.compiler.ksp)
+}
+
+//dependencies {
+//  for (target in kspTargets) {
+//    val targetConfigSuffix = if (target == "Metadata") "CommonMainMetadata" else target
+//    add("ksp${targetConfigSuffix}", projects.circuitCodegen)
+//  }
+//}
+
+ksp {
+  arg("circuit.codegen.lenient", "true")
+  arg("circuit.codegen.mode", "kotlin_inject")
+}

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppComponent.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppComponent.kt
@@ -7,6 +7,7 @@ import me.tatarka.inject.annotations.Provides
 
 @Component
 abstract class AppComponent {
+  @Suppress("FunctionOnlyReturningConstant")
   @Provides
   fun providesString(): String {
     return "Injected String!"

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppComponent.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppComponent.kt
@@ -1,0 +1,14 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.joshafeinberg.circuitkotlininject.sample
+
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Provides
+
+@Component
+abstract class AppComponent {
+  @Provides
+  fun providesString(): String {
+    return "Injected String!"
+  }
+}

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScope.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScope.kt
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.joshafeinberg.circuitkotlininject.sample
+
+import me.tatarka.inject.annotations.Scope
+
+@Scope annotation class AppScope

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScopeCircuitComponent.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScopeCircuitComponent.kt
@@ -6,5 +6,6 @@ import com.slack.circuit.codegen.annotations.MergeCircuitComponent
 import com.slack.circuit.foundation.di.CircuitComponent
 import me.tatarka.inject.annotations.Component
 
+@Suppress("UNUSED_PARAMETER")
 @MergeCircuitComponent(AppScope::class)
 abstract class AppScopeCircuitComponent(@Component appComponent: AppComponent) : CircuitComponent

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScopeCircuitComponent.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScopeCircuitComponent.kt
@@ -4,6 +4,7 @@ package com.joshafeinberg.circuitkotlininject.sample
 
 import com.slack.circuit.codegen.annotations.MergeCircuitComponent
 import com.slack.circuit.foundation.di.CircuitComponent
+import me.tatarka.inject.annotations.Component
 
-@MergeCircuitComponent<AppComponent>(AppScope::class)
-interface AppScopeCircuitComponent : CircuitComponent
+@MergeCircuitComponent(AppScope::class)
+abstract class AppScopeCircuitComponent(@Component appComponent: AppComponent) : CircuitComponent

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScopeCircuitComponent.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/AppScopeCircuitComponent.kt
@@ -1,0 +1,9 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.joshafeinberg.circuitkotlininject.sample
+
+import com.slack.circuit.codegen.annotations.MergeCircuitComponent
+import com.slack.circuit.foundation.di.CircuitComponent
+
+@MergeCircuitComponent<AppComponent>(AppScope::class)
+interface AppScopeCircuitComponent : CircuitComponent

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
@@ -9,18 +9,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.codegen.annotations.MergeCircuitComponent
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.CircuitContent
-import com.slack.circuit.foundation.di.CircuitComponent
 import com.slack.circuit.foundation.di.circuitBuilder
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import me.tatarka.inject.annotations.Assisted
-import me.tatarka.inject.annotations.Component
-import me.tatarka.inject.annotations.Provides
-import me.tatarka.inject.annotations.Scope
 
 fun main() = application {
   val appComponent = remember { AppComponent::class.create() }
@@ -33,19 +28,6 @@ fun main() = application {
     CircuitCompositionLocals(circuit) { CircuitContent(MyScreen) }
   }
 }
-
-@Component
-abstract class AppComponent {
-  @Provides
-  fun providesString(): String {
-    return "Injected String!"
-  }
-}
-
-@MergeCircuitComponent<AppComponent>(AppScope::class)
-interface AppScopeCircuitComponent : CircuitComponent
-
-@Scope annotation class AppScope
 
 @CircuitInject(MyScreen::class, AppScope::class)
 @Composable

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
@@ -1,0 +1,67 @@
+package com.joshafeinberg.circuitkotlininject.sample
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.codegen.annotations.MergeCircuitComponent
+import com.slack.circuit.foundation.CircuitCompositionLocals
+import com.slack.circuit.foundation.CircuitContent
+import com.slack.circuit.foundation.di.CircuitComponent
+import com.slack.circuit.foundation.di.circuitBuilder
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Provides
+import me.tatarka.inject.annotations.Scope
+
+fun main() = application {
+  val parentComponent = remember { ParentComponent::class.create() }
+  val circuit = remember {
+    val circuitComponent = AppScopeCircuitComponent::class.create(parentComponent)
+    circuitComponent.circuitBuilder().build()
+  }
+
+  Window(onCloseRequest = ::exitApplication, title = "Sample") {
+    CircuitCompositionLocals(circuit) { CircuitContent(MyScreen) }
+  }
+}
+
+@Component
+abstract class ParentComponent {
+  @Provides
+  fun providesString(): String {
+    return "Injected String!"
+  }
+}
+
+@MergeCircuitComponent<ParentComponent>(AppScope::class)
+interface AppScopeCircuitComponent : CircuitComponent
+
+@Scope annotation class AppScope
+
+@CircuitInject(MyScreen::class, AppScope::class)
+@Composable
+fun MyScreen(state: MyScreen.State, modifier: Modifier = Modifier) {
+  Text(state.visibleString, modifier = modifier)
+}
+
+data object MyScreen : Screen {
+  data class State(val visibleString: String) : CircuitUiState
+}
+
+@CircuitInject(MyScreen::class, AppScope::class)
+class MyScreenPresenter(
+  private val injectedString: String,
+  @Suppress("unused") @Assisted private val screen: MyScreen,
+) : Presenter<MyScreen.State> {
+  @Composable
+  override fun present(): MyScreen.State {
+    return MyScreen.State(injectedString)
+  }
+}

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.joshafeinberg.circuitkotlininject.sample
 
 import androidx.compose.material3.Text

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/Main.kt
@@ -23,9 +23,9 @@ import me.tatarka.inject.annotations.Provides
 import me.tatarka.inject.annotations.Scope
 
 fun main() = application {
-  val parentComponent = remember { ParentComponent::class.create() }
+  val appComponent = remember { AppComponent::class.create() }
   val circuit = remember {
-    val circuitComponent = AppScopeCircuitComponent::class.create(parentComponent)
+    val circuitComponent = AppScopeCircuitComponent::class.create(appComponent)
     circuitComponent.circuitBuilder().build()
   }
 
@@ -35,14 +35,14 @@ fun main() = application {
 }
 
 @Component
-abstract class ParentComponent {
+abstract class AppComponent {
   @Provides
   fun providesString(): String {
     return "Injected String!"
   }
 }
 
-@MergeCircuitComponent<ParentComponent>(AppScope::class)
+@MergeCircuitComponent<AppComponent>(AppScope::class)
 interface AppScopeCircuitComponent : CircuitComponent
 
 @Scope annotation class AppScope

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/other/OtherScreen.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/other/OtherScreen.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.joshafeinberg.circuitkotlininject.sample.other
 
 import androidx.compose.material3.Text

--- a/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/other/OtherScreen.kt
+++ b/samples/kotlin-inject/src/main/java/com/joshafeinberg/circuitkotlininject/sample/other/OtherScreen.kt
@@ -1,0 +1,28 @@
+package com.joshafeinberg.circuitkotlininject.sample.other
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.joshafeinberg.circuitkotlininject.sample.AppScope
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+
+@CircuitInject(OtherScreen::class, AppScope::class)
+@Composable
+fun OtherScreen(modifier: Modifier = Modifier) {
+  Text("Other Screen", modifier = modifier)
+}
+
+data object OtherScreen : Screen {
+  data object OtherScreenState : CircuitUiState
+}
+
+@CircuitInject(OtherScreen::class, AppScope::class)
+class OtherScreenPresenter : Presenter<OtherScreen.OtherScreenState> {
+  @Composable
+  override fun present(): OtherScreen.OtherScreenState {
+    return OtherScreen.OtherScreenState
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -227,6 +227,7 @@ include(
   ":samples:counter:apps",
   ":samples:counter:mosaic",
   ":samples:interop",
+  ":samples:kotlin-inject",
   ":samples:star",
   ":samples:star:apk",
   ":samples:star:benchmark",


### PR DESCRIPTION
This adds code gen support for @evant's https://github.com/evant/kotlin-inject

Adapting from @joshafeinberg's prior prototyping in https://github.com/joshafeinberg/CircuitKotlinInject

This works by introducing an `@MergeCircuitComponent` annotation that can be used on a scoped "circuit component" interface that code gen then processes and generates a kotlin-inject-compatible component impl for, aggregating bound UI and presenter factories within the module.

Pros: multiplatform!
Cons: aggregating processor, no cross-module hinting like anvil and hilt do

**Example**
```kotlin
// Given an existing app component
@Component
abstract class AppComponent {
  // ...
}

// Write a merged circuit component that extends from it
// The generic type is the parent component
// The argument is the scope key
@MergeCircuitComponent(AppScope::class)
abstract class AppScopeCircuitComponent(@Component appComponent: AppComponent) : CircuitComponent

// Usage
val appComponent = AppComponent::class.create()
val circuitComponent = AppScopeCircuitComponent::class.create(appComponent)
val circuit = circuitComponent.newBuilder().build()
```

Everything else works the same before as far as using `@CircuitInject`.

**TODO**
- Docs
- Tests
- API improvements
  - Should we make a separate runtime for the CircuitComponent and new annotations?
  - Can we further abstract the code gen mode specifics from the Circuit processor? Currently we do custom handling for assisted types
- Inexplicable, generated code doesn't seem able to smart-cast data object types to their type when passing it as an assisted param