### PR TITLE
Add maxConcurrentDevices property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,9 +21,14 @@ android.useAndroidX=true
 # Force use of the latest android lint version
 android.experimental.lint.version=8.3.0-alpha07
 
+# Helps make baseline profile generation more reliable
+# https://issuetracker.google.com/issues/287312019
+android.experimental.testOptions.managedDevices.maxConcurrentDevices=1
+
 # Suppress warnings about experimental AGP properties we're using
 # Ironically, this property itself is also experimental, so we have to suppress it too.
 android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,\
+  android.experimental.testOptions.managedDevices.maxConcurrentDevices,\
   android.experimental.testOptions.emulatorSnapshots.maxSnapshotsForTestFailures,\
   android.experimental.lint.version
 


### PR DESCRIPTION
This workaround from https://issuetracker.google.com/issues/287312019 was able to finally generate baseline profiles locally