### PR TITLE
Enable RememberObserver to work with rememberRetained

### DIFF
--- a/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
@@ -284,27 +284,30 @@ class RetainedTest {
 
   @Test
   fun rememberObserver() {
-    val subject = object : RememberObserver {
-      var onRememberCalled: Int = 0
-        private set
-      var onForgottenCalled: Int = 0
-        private set
+    val subject =
+      object : RememberObserver {
+        var onRememberCalled: Int = 0
+          private set
 
-      override fun onAbandoned() = Unit
+        var onForgottenCalled: Int = 0
+          private set
 
-      override fun onForgotten() {
-        onForgottenCalled++
+        override fun onAbandoned() = Unit
+
+        override fun onForgotten() {
+          onForgottenCalled++
+        }
+
+        override fun onRemembered() {
+          onRememberCalled++
+        }
       }
 
-      override fun onRemembered() {
-        onRememberCalled++
+    val content =
+      @Composable {
+        rememberRetained { subject }
+        Unit
       }
-    }
-
-    val content = @Composable {
-      rememberRetained { subject }
-      Unit
-    }
     setActivityContent(content)
 
     assertThat(subject.onRememberCalled).isEqualTo(1)

--- a/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
+++ b/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedTest.kt
@@ -311,21 +311,22 @@ class RetainedTest {
     setActivityContent(content)
 
     assertThat(subject.onRememberCalled).isEqualTo(1)
-    // Restart the activity
-    scenario.recreate()
-    // Assert that the observer was not forgotten
     assertThat(subject.onForgottenCalled).isEqualTo(0)
 
+    // Restart the activity
+    scenario.recreate()
     // Compose our content again
     setActivityContent(content)
 
-    // TODO: this should be 1
-    assertThat(subject.onRememberCalled).isEqualTo(2)
+    // Assert that onRemembered was not called again
+    assertThat(subject.onRememberCalled).isEqualTo(1)
     assertThat(subject.onForgottenCalled).isEqualTo(0)
 
     // Now finish the Activity
     scenario.close()
+
     // Assert that the observer was forgotten
+    assertThat(subject.onRememberCalled).isEqualTo(1)
     assertThat(subject.onForgottenCalled).isEqualTo(1)
   }
 

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -149,18 +149,25 @@ private class RetainableHolder<T>(
     // If the value is a RetainedStateRegistry, we need to take care to retain it.
     // First we tell it to saveAll, to retain it's values. Then we need to tell the host
     // registry to retain the child registry.
-    if (value is RetainedStateRegistry) {
-      (value as RetainedStateRegistry).saveAll()
+    val v = value
+    if (v is RetainedStateRegistry) {
+      v.saveAll()
       registry?.saveValue(key)
     }
 
     if (registry != null && !canRetainChecker.canRetain(registry!!)) {
       entry?.unregister()
+      // If value is a RememberObserver, we notify that it has been forgotten
+      if (v is RememberObserver) v.onForgotten()
     }
   }
 
   override fun onRemembered() {
     register()
+
+    // If value is a RememberObserver, we notify that it has remembered
+    val v = value
+    if (v is RememberObserver) v.onRemembered()
   }
 
   override fun onForgotten() {

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -95,7 +95,14 @@ public fun <T : Any> rememberRetained(vararg inputs: Any?, key: String? = null, 
       val restored = registry.consumeValue(finalKey) as? RetainableHolder.Value<*>
       val finalValue = restored?.value ?: init()
       val finalInputs = restored?.inputs ?: inputs
-      RetainableHolder(registry, canRetainChecker, finalKey, finalValue, finalInputs, restored != null)
+      RetainableHolder(
+        registry = registry,
+        canRetainChecker = canRetainChecker,
+        key = finalKey,
+        value = finalValue,
+        inputs = finalInputs,
+        hasBeenRestored = restored != null,
+      )
     }
   val value = holder.getValueIfInputsAreEqual(inputs) ?: init()
   SideEffect { holder.update(registry, finalKey, value, inputs) }

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
@@ -3,6 +3,7 @@
 package com.slack.circuit.retained
 
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.slack.circuit.retained.RetainedStateRegistry.Entry
 
@@ -143,6 +144,8 @@ internal class RetainedStateRegistryImpl(retained: MutableMap<String, List<Any?>
   }
 
   override fun forgetUnclaimedValues() {
+    // Notify any RememberObservers that it has been forgotten
+    retained.asSequence().filterIsInstance<RememberObserver>().forEach { it.onForgotten() }
     retained.clear()
   }
 }


### PR DESCRIPTION
This PR manually calls `RememberObserver` calls as appropriate when used in `rememberRetained`. The semantics of `rememberRetained` are obviously different to `remember`, so we call them at different times:

-  `onRemembered` will be called the first time that the retained item is first `remember`ed. The difference here is that we will **not** call `onRemembered` again once a the object is restored and remembered back into composition.
- `onForgotten` will be called only once the retained state is cleared from both composition and any retained registries.
- Thus, the logical lifecycle is maintained of created (`onRemembered` called), through to being no longer retained/remembered (`onForgotten` called).
- We do not call `onAbandoned` as retained state doesn't meet the contract of the function.

I did think about creating a `RetainedObserver` interface, but figured that using the existing `RememberObserver`, even with slightly different semantics, is a better solution.

This has a variety of use-cases, but I have been playing around with a `rememberRetainedCorotineScope` in Tivi: https://github.com/chrisbanes/tivi/pull/1763