### PR TITLE
Navigator - Pass `PopResult` to `onRootPop`

### DIFF
--- a/circuit-foundation/src/androidMain/kotlin/com/slack/circuit/foundation/Navigator.android.kt
+++ b/circuit-foundation/src/androidMain/kotlin/com/slack/circuit/foundation/Navigator.android.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import com.slack.circuit.backstack.BackStack
 import com.slack.circuit.backstack.BackStack.Record
 import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.screen.PopResult
 
 /**
  * Returns a new [Navigator] for navigating within [CircuitContents][CircuitContent]. Delegates
@@ -34,11 +35,11 @@ public fun rememberCircuitNavigator(
 }
 
 @Composable
-private fun backDispatcherRootPop(): () -> Unit {
+private fun backDispatcherRootPop(): (result: PopResult?) -> Unit {
   val onBackPressedDispatcher =
     LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
       ?: error("No OnBackPressedDispatcherOwner found, unable to handle root navigation pops.")
-  return onBackPressedDispatcher::onBackPressed
+  return { onBackPressedDispatcher.onBackPressed() }
 }
 
 private fun onBack(backStack: BackStack<out Record>, navigator: Navigator): () -> Unit = {

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -27,7 +27,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 public fun rememberCircuitNavigator(
   backStack: BackStack<out Record>,
-  onRootPop: () -> Unit,
+  onRootPop: (result: PopResult?) -> Unit,
 ): Navigator {
   return remember { Navigator(backStack, onRootPop) }
 }
@@ -40,12 +40,14 @@ public fun rememberCircuitNavigator(
  *   button.
  * @see NavigableCircuitContent
  */
-public fun Navigator(backStack: BackStack<out Record>, onRootPop: () -> Unit): Navigator =
-  NavigatorImpl(backStack, onRootPop)
+public fun Navigator(
+  backStack: BackStack<out Record>,
+  onRootPop: (result: PopResult?) -> Unit,
+): Navigator = NavigatorImpl(backStack, onRootPop)
 
 internal class NavigatorImpl(
   private val backStack: BackStack<out Record>,
-  private val onRootPop: () -> Unit,
+  private val onRootPop: (result: PopResult?) -> Unit,
 ) : Navigator {
 
   init {
@@ -58,7 +60,7 @@ internal class NavigatorImpl(
 
   override fun pop(result: PopResult?): Screen? {
     if (backStack.isAtRoot) {
-      onRootPop()
+      onRootPop(result)
       return null
     }
 

--- a/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
+++ b/samples/counter/apps/src/jvmMain/kotlin/com/slack/circuit/sample/counter/desktop/DesktopCounterCircuit.kt
@@ -152,7 +152,7 @@ fun main() = application {
   ) {
     val initialBackStack = persistentListOf<Screen>(DesktopCounterScreen)
     val backStack = rememberSaveableBackStack(initialBackStack)
-    val navigator = rememberCircuitNavigator(backStack, ::exitApplication)
+    val navigator = rememberCircuitNavigator(backStack) { exitApplication() }
 
     val circuit: Circuit =
       Circuit.Builder()

--- a/samples/star/src/jvmMain/kotlin/com/slack/circuit/star/main.kt
+++ b/samples/star/src/jvmMain/kotlin/com/slack/circuit/star/main.kt
@@ -41,7 +41,7 @@ fun main() {
   application {
     val initialBackStack = persistentListOf<Screen>(HomeScreen)
     val backStack = rememberSaveableBackStack(initialBackStack)
-    val circuitNavigator = rememberCircuitNavigator(backStack, ::exitApplication)
+    val circuitNavigator = rememberCircuitNavigator(backStack) { exitApplication() }
     val navigator =
       remember(circuitNavigator) {
         object : Navigator by circuitNavigator {

--- a/samples/tutorial/src/jvmMain/kotlin/com/slack/circuit/tutorial/impl/main.kt
+++ b/samples/tutorial/src/jvmMain/kotlin/com/slack/circuit/tutorial/impl/main.kt
@@ -25,7 +25,7 @@ fun main() {
     Window(title = "Tutorial", onCloseRequest = ::exitApplication) {
       MaterialTheme {
         val backStack = rememberSaveableBackStack(InboxScreen)
-        val navigator = rememberCircuitNavigator(backStack, ::exitApplication)
+        val navigator = rememberCircuitNavigator(backStack) { exitApplication() }
         CircuitCompositionLocals(circuit) {
           NavigableCircuitContent(navigator = navigator, backStack = backStack)
         }


### PR DESCRIPTION
For some cases (mostly interop) it's useful to pass the `PopResult` to the default `onRootPop` lambda. 