### PR TITLE
Navigator popRoot extension

### DIFF
--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
@@ -5,9 +5,12 @@ package com.slack.circuit.foundation
 import com.google.common.truth.Truth.assertThat
 import com.slack.circuit.backstack.SaveableBackStack
 import com.slack.circuit.internal.test.Parcelize
+import com.slack.circuit.runtime.popRoot
 import com.slack.circuit.runtime.popUntil
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import org.junit.Test
@@ -100,5 +103,30 @@ class NavigatorTest {
     val navigator = NavigatorImpl(backStack) { fail() }
 
     assertEquals(TestScreen2, navigator.peek())
+  }
+
+  @Test
+  fun popRootWithResult() {
+    var onRootResult: PopResult? = null
+    var onRootPopped = false
+    val expectedRootResult = object : PopResult {}
+    val backStack = SaveableBackStack(TestScreen)
+    backStack.push(TestScreen2)
+    backStack.push(TestScreen3)
+
+    val navigator =
+      NavigatorImpl(backStack) {
+        onRootResult = it
+        onRootPopped = true
+      }
+
+    assertThat(backStack).hasSize(3)
+
+    navigator.popRoot(expectedRootResult)
+
+    assertTrue(onRootPopped)
+    assertSame(expectedRootResult, onRootResult)
+    assertThat(backStack).hasSize(1)
+    assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen)
   }
 }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigatorTest.kt
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith
 
 @Parcelize private data object TestScreen3 : Screen
 
+@Parcelize private data object TestPopResult : PopResult
+
 @RunWith(ComposeUiTestRunner::class)
 class NavigatorTest {
   @Test
@@ -109,7 +111,6 @@ class NavigatorTest {
   fun popRootWithResult() {
     var onRootResult: PopResult? = null
     var onRootPopped = false
-    val expectedRootResult = object : PopResult {}
     val backStack = SaveableBackStack(TestScreen)
     backStack.push(TestScreen2)
     backStack.push(TestScreen3)
@@ -122,10 +123,10 @@ class NavigatorTest {
 
     assertThat(backStack).hasSize(3)
 
-    navigator.popRoot(expectedRootResult)
+    navigator.popRoot(TestPopResult)
 
     assertTrue(onRootPopped)
-    assertSame(expectedRootResult, onRootResult)
+    assertSame(TestPopResult, onRootResult)
     assertThat(backStack).hasSize(1)
     assertThat(backStack.topRecord?.screen).isEqualTo(TestScreen)
   }

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -123,3 +123,13 @@ public inline fun Navigator.resetRoot(
 public fun Navigator.popUntil(predicate: (Screen) -> Boolean) {
   while (peek()?.let(predicate) == false) pop() ?: break // Break on root pop
 }
+
+/** Calls [Navigator.pop] until the root screen and passes [result] to the root pop. */
+public fun Navigator.popRoot(result: PopResult? = null) {
+  var backStackSize = peekBackStack().size
+  while (backStackSize > 1) {
+    backStackSize--
+    pop()
+  }
+  pop(result)
+}


### PR DESCRIPTION
Navigator extension to pop the entire back stack, and then pass the result on to the `onRootPop` handler. 
Also useful to pop/exit a circuit. 