### PR TITLE
Check canRetainCheck when saving RetainedStateRegistry

### DIFF
--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
@@ -99,7 +99,7 @@ public interface BackStack<R : Record> : Iterable<R> {
    * @param includeSaved Whether to also check if the record is contained by any saved back stack
    *   state. See [saveState].
    */
-  public fun containsRecord(record: Record, includeSaved: Boolean): Boolean
+  public fun containsRecord(record: R, includeSaved: Boolean): Boolean
 
   @Stable
   public interface Record {

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/BackStack.kt
@@ -93,6 +93,14 @@ public interface BackStack<R : Record> : Iterable<R> {
    */
   public fun restoreState(screen: Screen): Boolean
 
+  /**
+   * Whether the back stack contains the given [record].
+   *
+   * @param includeSaved Whether to also check if the record is contained by any saved back stack
+   *   state. See [saveState].
+   */
+  public fun containsRecord(record: Record, includeSaved: Boolean): Boolean
+
   @Stable
   public interface Record {
     /**

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -127,6 +127,19 @@ internal constructor(
     return false
   }
 
+  override fun containsRecord(record: BackStack.Record, includeSaved: Boolean): Boolean {
+    // If it's in the main entry list, return true
+    if (record in entryList) return true
+
+    if (includeSaved && stateStore.isNotEmpty()) {
+      // If we're checking our saved lists too, iterate through them and check
+      for (stored in stateStore.values) {
+        if (record in stored) return true
+      }
+    }
+    return false
+  }
+
   public data class Record(
     override val screen: Screen,
     val args: Map<String, Any?> = emptyMap(),

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -127,7 +127,7 @@ internal constructor(
     return false
   }
 
-  override fun containsRecord(record: BackStack.Record, includeSaved: Boolean): Boolean {
+  override fun containsRecord(record: Record, includeSaved: Boolean): Boolean {
     // If it's in the main entry list, return true
     if (record in entryList) return true
 

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -34,7 +34,6 @@ import com.slack.circuit.backstack.NavDecoration
 import com.slack.circuit.backstack.ProvidedValues
 import com.slack.circuit.backstack.isEmpty
 import com.slack.circuit.backstack.providedValuesForBackStack
-import com.slack.circuit.foundation.NavigatorDefaults.DefaultDecoration.backward
 import com.slack.circuit.retained.CanRetainChecker
 import com.slack.circuit.retained.LocalCanRetainChecker
 import com.slack.circuit.retained.LocalRetainedStateRegistry
@@ -108,7 +107,9 @@ public fun NavigableCircuitContent(
       // contains the record
       val record = provider.record
       val recordInBackStackRetainChecker =
-        remember(backStack, record) { CanRetainChecker { record in backStack } }
+        remember(backStack, record) {
+          CanRetainChecker { backStack.containsRecord(record, includeSaved = true) }
+        }
 
       CompositionLocalProvider(LocalCanRetainChecker provides recordInBackStackRetainChecker) {
         // Remember the `providedValues` lookup because this composition can live longer than

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -47,9 +47,9 @@ import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
-public fun NavigableCircuitContent(
+public fun <R : Record> NavigableCircuitContent(
   navigator: Navigator,
-  backStack: BackStack<out Record>,
+  backStack: BackStack<R>,
   modifier: Modifier = Modifier,
   circuit: Circuit = requireNotNull(LocalCircuit.current),
   providedValues: ImmutableMap<out Record, ProvidedValues> = providedValuesForBackStack(backStack),
@@ -137,15 +137,15 @@ public fun NavigableCircuitContent(
 
 /** A simple holder class for a [record] and its associated [content]. */
 @Immutable
-public class RecordContentProvider(
-  public val record: Record,
-  internal val content: @Composable (Record) -> Unit,
+public class RecordContentProvider<R : Record>(
+  public val record: R,
+  internal val content: @Composable (R) -> Unit,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || this::class != other::class) return false
 
-    other as RecordContentProvider
+    other as RecordContentProvider<*>
 
     if (record != other.record) return false
     if (content != other.content) return false
@@ -163,12 +163,12 @@ public class RecordContentProvider(
 }
 
 @Composable
-private fun BackStack<out Record>.buildCircuitContentProviders(
+private fun <R : Record> BackStack<R>.buildCircuitContentProviders(
   navigator: Navigator,
   circuit: Circuit,
   unavailableRoute: @Composable (screen: Screen, modifier: Modifier) -> Unit,
-): ImmutableList<RecordContentProvider> {
-  val previousContentProviders = remember { mutableMapOf<String, RecordContentProvider>() }
+): ImmutableList<RecordContentProvider<R>> {
+  val previousContentProviders = remember { mutableMapOf<String, RecordContentProvider<R>>() }
 
   val lastNavigator by rememberUpdatedState(navigator)
   val lastCircuit by rememberUpdatedState(circuit)

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -158,19 +158,17 @@ private class RetainableHolder<T>(
     Value(value = requireNotNull(value) { "Value should be initialized" }, inputs = inputs)
 
   fun saveIfRetainable() {
-    // If the value is a RetainedStateRegistry, we need to take care to retain it.
-    // First we tell it to saveAll, to retain it's values. Then we need to tell the host
-    // registry to retain the child registry.
     val v = value
-    if (v is RetainedStateRegistry) {
-      v.saveAll()
-      registry?.saveValue(key)
-    }
-
     if (registry != null && !canRetainChecker.canRetain(registry!!)) {
       entry?.unregister()
       // If value is a RememberObserver, we notify that it has been forgotten
       if (v is RememberObserver) v.onForgotten()
+    } else if (v is RetainedStateRegistry) {
+      // If the value is a RetainedStateRegistry, we need to take care to retain it.
+      // First we tell it to saveAll, to retain it's values. Then we need to tell the host
+      // registry to retain the child registry.
+      v.saveAll()
+      registry?.saveValue(key)
     }
   }
 

--- a/samples/star/src/androidMain/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
+++ b/samples/star/src/androidMain/kotlin/com/slack/circuit/star/imageviewer/ImageViewerScreen.kt
@@ -152,7 +152,7 @@ class ImageViewerAwareNavDecoration(
   ) {
     val firstArg = args.firstOrNull()
     val decoration =
-      if (firstArg is RecordContentProvider && firstArg.record.screen is ImageViewerScreen) {
+      if (firstArg is RecordContentProvider<*> && firstArg.record.screen is ImageViewerScreen) {
         NavigatorDefaults.EmptyDecoration
       } else {
         defaultNavDecoration


### PR DESCRIPTION
This is mostly @alexvanyo's work from #1253. Unfortunately I couldn't find a way for a PR from a fork to be based on another PR from a different fork.

My changes add the relevant fixes to make sure that saved/restored back stacks (aka back stacks) work with the changes. Primarily this is so that we check both the current back stack _and_ saved backstacks when determining whether we can retain state.

Fixes #1252