### PR TITLE
Make RememberObservers in nested registries work

### DIFF
--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -158,17 +158,24 @@ private class RetainableHolder<T>(
     Value(value = requireNotNull(value) { "Value should be initialized" }, inputs = inputs)
 
   fun saveIfRetainable() {
-    val v = value
-    if (registry != null && !canRetainChecker.canRetain(registry!!)) {
+    val v = value ?: return
+    val reg = registry ?: return
+
+    if (!canRetainChecker.canRetain(reg)) {
       entry?.unregister()
-      // If value is a RememberObserver, we notify that it has been forgotten
-      if (v is RememberObserver) v.onForgotten()
+      when (v) {
+        // If value is a RememberObserver, we notify that it has been forgotten.
+        is RememberObserver -> v.onForgotten()
+        // Or if its a registry, we need to tell it to clear, which will forward the 'forgotten'
+        // call onto its values
+        is RetainedStateRegistryImpl -> v.clear()
+      }
     } else if (v is RetainedStateRegistry) {
       // If the value is a RetainedStateRegistry, we need to take care to retain it.
       // First we tell it to saveAll, to retain it's values. Then we need to tell the host
       // registry to retain the child registry.
       v.saveAll()
-      registry?.saveValue(key)
+      reg.saveValue(key)
     }
   }
 
@@ -194,5 +201,5 @@ private class RetainableHolder<T>(
     return value.takeIf { inputs.contentEquals(this.inputs) }
   }
 
-  class Value<T>(val value: T, val inputs: Array<out Any?>)
+  class Value<T>(override val value: T, val inputs: Array<out Any?>) : RetainedValueHolder<T>
 }

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -168,7 +168,12 @@ private class RetainableHolder<T>(
         is RememberObserver -> v.onForgotten()
         // Or if its a registry, we need to tell it to clear, which will forward the 'forgotten'
         // call onto its values
-        is RetainedStateRegistryImpl -> v.clear()
+        is RetainedStateRegistry -> {
+          // First we saveAll, which flattens down the value providers to our retained list
+          v.saveAll()
+          // Now we drop all retained values
+          v.forgetUnclaimedValues()
+        }
       }
     } else if (v is RetainedStateRegistry) {
       // If the value is a RetainedStateRegistry, we need to take care to retain it.

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
@@ -137,24 +137,12 @@ internal class RetainedStateRegistryImpl(retained: MutableMap<String, List<Any?>
   }
 
   override fun forgetUnclaimedValues() {
-    clearRetained()
-  }
-
-  /** Should this be public API on RetainedStateRegistry? */
-  internal fun clear() {
-    // First we saveAll, which flattens down the value providers to our retained list
-    saveAll()
-    // Now we clear the retained list
-    clearRetained()
-  }
-
-  private fun clearRetained() {
     fun clearValue(value: Any?) {
       when (value) {
         // If we get a RetainedHolder value, need to unwrap and call again
         is RetainedValueHolder<*> -> clearValue(value.value)
         // Dispatch the call to nested registries
-        is RetainedStateRegistryImpl -> value.clearRetained()
+        is RetainedStateRegistry -> value.forgetUnclaimedValues()
         // Dispatch onForgotten calls if the value is a RememberObserver
         is RememberObserver -> value.onForgotten()
       }

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedValueProvider.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedValueProvider.kt
@@ -8,5 +8,14 @@ package com.slack.circuit.retained
  * Only defined as a top-level interface to allow non-JS targets to extend `() -> Any?`.
  */
 public expect fun interface RetainedValueProvider {
+  /**
+   * Returns the retained value. If the value is wrapped in a holder class, this class should
+   * implement [RetainedValueHolder].
+   */
   public fun invoke(): Any?
+}
+
+/** Interface that allows [RetainedStateRegistry] to unwrap any values held underneath. */
+public interface RetainedValueHolder<T> {
+  public val value: T
 }


### PR DESCRIPTION
At the moment `RememberObserver` support for retained state only works if it is added directly to the root retained registry. That works fine in our simple test, but `NavigableCircuitContent` adds a much more complex retained registry system, which uses multiple levels of registries.

This PR fixes this, adding support for nested registries. I've confirmed that this works as expected in Tivi.