### PR TITLE
Remember keys in rememberSaveableBackStack

### DIFF
--- a/backstack/build.gradle.kts
+++ b/backstack/build.gradle.kts
@@ -60,6 +60,14 @@ kotlin {
         implementation(libs.uuid)
       }
     }
+    commonTest {
+      dependencies {
+        implementation(libs.coroutines.test)
+        implementation(libs.kotlin.test)
+        implementation(libs.molecule.runtime)
+        implementation(libs.turbine)
+      }
+    }
     val androidMain by getting {
       dependencies {
         implementation(libs.androidx.lifecycle.viewModel.compose)

--- a/backstack/src/commonJvmTest/kotlin/com/slack/circuit/backstack/RememberSaveableBackstackTest.kt
+++ b/backstack/src/commonJvmTest/kotlin/com/slack/circuit/backstack/RememberSaveableBackstackTest.kt
@@ -1,0 +1,76 @@
+package com.slack.circuit.backstack
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.cash.molecule.RecompositionMode
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.runtime.screen.Screen
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+class RememberSaveableBackstackTest {
+
+    @Test
+    fun backStackStartsWithRootScreen() = runTest {
+        moleculeFlow(RecompositionMode.Immediate) {
+            val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+            backStack.entryList.toList()
+        }.test {
+            assertEquals(awaitItem().first().screen, TestScreen.ScreenA)
+        }
+    }
+
+    @Test
+    fun rememberSaveableBackStackReturnsSameInstanceWithSameParams() = runTest {
+        val rootScreen by mutableStateOf<Screen>(TestScreen.ScreenA)
+        var dummyData by mutableStateOf(false)
+        moleculeFlow(RecompositionMode.Immediate) {
+            dummyData
+            rememberSaveableBackStack(rootScreen)
+        }.test {
+            val firstStack = awaitItem()
+            dummyData = true // Force a recomposition
+            val secondStack = awaitItem()
+
+            assertSame(firstStack, secondStack)
+        }
+    }
+
+    @Test
+    fun rememberSaveableBackStackReturnsNewInstanceWithChangedRoot() = runTest {
+        var rootScreen by mutableStateOf<Screen>(TestScreen.ScreenA)
+        moleculeFlow(RecompositionMode.Immediate) {
+            rememberSaveableBackStack(rootScreen)
+        }.test {
+            val firstStack = awaitItem()
+            rootScreen = TestScreen.ScreenB
+            val secondStack = awaitItem()
+
+            assertNotSame(firstStack, secondStack)
+            assertEquals(firstStack.entryList.first().screen, TestScreen.ScreenA)
+            assertEquals(secondStack.entryList.first().screen, TestScreen.ScreenB)
+        }
+    }
+
+    @Test
+    fun rememberSaveableBackStackStartedWithListReturnsNewInstanceWithChangedRoot() = runTest {
+        var rootScreens by mutableStateOf<List<Screen>>(listOf(TestScreen.ScreenA))
+        moleculeFlow(RecompositionMode.Immediate) {
+            rememberSaveableBackStack(rootScreens)
+        }.test {
+            val firstStack = awaitItem()
+            rootScreens = listOf(TestScreen.ScreenB)
+            val secondStack = awaitItem()
+
+            assertNotSame(firstStack, secondStack)
+            assertEquals(firstStack.entryList.first().screen, TestScreen.ScreenA)
+            assertEquals(secondStack.entryList.first().screen, TestScreen.ScreenB)
+        }
+    }
+}

--- a/backstack/src/commonJvmTest/kotlin/com/slack/circuit/backstack/RememberSaveableBackstackTest.kt
+++ b/backstack/src/commonJvmTest/kotlin/com/slack/circuit/backstack/RememberSaveableBackstackTest.kt
@@ -8,69 +8,67 @@ import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.slack.circuit.internal.test.TestScreen
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.coroutines.test.runTest
-import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
 class RememberSaveableBackstackTest {
 
-    @Test
-    fun backStackStartsWithRootScreen() = runTest {
-        moleculeFlow(RecompositionMode.Immediate) {
-            val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
-            backStack.entryList.toList()
-        }.test {
-            assertEquals(awaitItem().first().screen, TestScreen.ScreenA)
-        }
-    }
+  @Test
+  fun backStackStartsWithRootScreen() = runTest {
+    moleculeFlow(RecompositionMode.Immediate) {
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+        backStack.entryList.toList()
+      }
+      .test { assertEquals(awaitItem().first().screen, TestScreen.ScreenA) }
+  }
 
-    @Test
-    fun rememberSaveableBackStackReturnsSameInstanceWithSameParams() = runTest {
-        val rootScreen by mutableStateOf<Screen>(TestScreen.ScreenA)
-        var dummyData by mutableStateOf(false)
-        moleculeFlow(RecompositionMode.Immediate) {
-            dummyData
-            rememberSaveableBackStack(rootScreen)
-        }.test {
-            val firstStack = awaitItem()
-            dummyData = true // Force a recomposition
-            val secondStack = awaitItem()
+  @Test
+  fun rememberSaveableBackStackReturnsSameInstanceWithSameParams() = runTest {
+    val rootScreen by mutableStateOf<Screen>(TestScreen.ScreenA)
+    var dummyData by mutableStateOf(false)
+    moleculeFlow(RecompositionMode.Immediate) {
+        dummyData
+        rememberSaveableBackStack(rootScreen)
+      }
+      .test {
+        val firstStack = awaitItem()
+        dummyData = true // Force a recomposition
+        val secondStack = awaitItem()
 
-            assertSame(firstStack, secondStack)
-        }
-    }
+        assertSame(firstStack, secondStack)
+      }
+  }
 
-    @Test
-    fun rememberSaveableBackStackReturnsNewInstanceWithChangedRoot() = runTest {
-        var rootScreen by mutableStateOf<Screen>(TestScreen.ScreenA)
-        moleculeFlow(RecompositionMode.Immediate) {
-            rememberSaveableBackStack(rootScreen)
-        }.test {
-            val firstStack = awaitItem()
-            rootScreen = TestScreen.ScreenB
-            val secondStack = awaitItem()
+  @Test
+  fun rememberSaveableBackStackReturnsNewInstanceWithChangedRoot() = runTest {
+    var rootScreen by mutableStateOf<Screen>(TestScreen.ScreenA)
+    moleculeFlow(RecompositionMode.Immediate) { rememberSaveableBackStack(rootScreen) }
+      .test {
+        val firstStack = awaitItem()
+        rootScreen = TestScreen.ScreenB
+        val secondStack = awaitItem()
 
-            assertNotSame(firstStack, secondStack)
-            assertEquals(firstStack.entryList.first().screen, TestScreen.ScreenA)
-            assertEquals(secondStack.entryList.first().screen, TestScreen.ScreenB)
-        }
-    }
+        assertNotSame(firstStack, secondStack)
+        assertEquals(firstStack.entryList.first().screen, TestScreen.ScreenA)
+        assertEquals(secondStack.entryList.first().screen, TestScreen.ScreenB)
+      }
+  }
 
-    @Test
-    fun rememberSaveableBackStackStartedWithListReturnsNewInstanceWithChangedRoot() = runTest {
-        var rootScreens by mutableStateOf<List<Screen>>(listOf(TestScreen.ScreenA))
-        moleculeFlow(RecompositionMode.Immediate) {
-            rememberSaveableBackStack(rootScreens)
-        }.test {
-            val firstStack = awaitItem()
-            rootScreens = listOf(TestScreen.ScreenB)
-            val secondStack = awaitItem()
+  @Test
+  fun rememberSaveableBackStackStartedWithListReturnsNewInstanceWithChangedRoot() = runTest {
+    var rootScreens by mutableStateOf<List<Screen>>(listOf(TestScreen.ScreenA))
+    moleculeFlow(RecompositionMode.Immediate) { rememberSaveableBackStack(rootScreens) }
+      .test {
+        val firstStack = awaitItem()
+        rootScreens = listOf(TestScreen.ScreenB)
+        val secondStack = awaitItem()
 
-            assertNotSame(firstStack, secondStack)
-            assertEquals(firstStack.entryList.first().screen, TestScreen.ScreenA)
-            assertEquals(secondStack.entryList.first().screen, TestScreen.ScreenB)
-        }
-    }
+        assertNotSame(firstStack, secondStack)
+        assertEquals(firstStack.entryList.first().screen, TestScreen.ScreenA)
+        assertEquals(secondStack.entryList.first().screen, TestScreen.ScreenB)
+      }
+  }
 }

--- a/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
+++ b/backstack/src/commonMain/kotlin/com/slack/circuit/backstack/SaveableBackStack.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.channels.Channel
 /**
  * Creates and remembers a [SaveableBackStack] with the given [root] screen.
  *
+ * If [root] changes, a new backstack will be created.
+ *
  * @param init optional initializer callback to perform extra initialization logic.
  */
 @Composable
@@ -38,16 +40,17 @@ public fun rememberSaveableBackStack(
   root: Screen,
   init: SaveableBackStack.() -> Unit = {},
 ): SaveableBackStack =
-  rememberSaveable(saver = SaveableBackStack.Saver) { SaveableBackStack(root).apply(init) }
+  rememberSaveable(root, saver = SaveableBackStack.Saver) { SaveableBackStack(root).apply(init) }
 
 /**
  * Creates and remembers a [SaveableBackStack] filled with the given [initialScreens].
- * [initialScreens] must not be empty.
+ *
+ * [initialScreens] must not be empty. If [initialScreens] changes, a new backstack will be created.
  */
 @Composable
 public fun rememberSaveableBackStack(initialScreens: List<Screen>): SaveableBackStack {
   require(initialScreens.isNotEmpty()) { "Initial input screens cannot be empty!" }
-  return rememberSaveable(saver = SaveableBackStack.Saver) {
+  return rememberSaveable(initialScreens, saver = SaveableBackStack.Saver) {
     SaveableBackStack(null).apply {
       for (screen in initialScreens) {
         push(screen)

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitChangeRootScreenTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitChangeRootScreenTest.kt
@@ -1,0 +1,51 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestCountPresenter
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.createTestCircuit
+import com.slack.circuit.runtime.screen.Screen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(ComposeUiTestRunner::class)
+class NavigableCircuitChangeRootScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun navigableCircuitContentUpdatesWhenRootScreenChanges() {
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.Standard)
+    var rootScreen by mutableStateOf<Screen>(TestScreen.ScreenA)
+    composeTestRule.setContent {
+      CircuitCompositionLocals(circuit) {
+        val backStack = rememberSaveableBackStack(rootScreen)
+        val navigator = rememberCircuitNavigator(backStack = backStack)
+        NavigableCircuitContent(navigator = navigator, backStack = backStack)
+      }
+    }
+    composeTestRule.run {
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      // Navigate to Screen B
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+
+      // Update root
+      rootScreen = TestScreen.ScreenC
+
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+    }
+  }
+}


### PR DESCRIPTION
Updates `rememberSaveableBackStack` to use use the initial root screen(s) as keys.

Before this, you could never get a new backstack when using `rememberSaveableBackStack`. This blocks using navigable Circuits within views that may have their root screen change, such as a ComposeView in a RecyclerView or other XML layout that has data being rebound.

This includes a small test suite to cover both remember cases and `NavigableCircuitContent`.