### PR TITLE
Deprecate assertIsEmpty/expectNoEvents, add versions for all event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Changelog
 --------------
 
 - **New**: Add WASM targets.
-- **New**: FakeNavigator methods to check for the lack of pop/resetRoot events
+- **New**: Add `FakeNavigator` functions to check for the lack of pop/resetRoot events
 - **Behaviour Change**: `NavigatorImpl.goTo` no longer navigates if the `Screen` is equal to `Navigator.peek()`.
 - **Behaviour Change**: `Presenter.present` is now annotated with `@ComposableTarget("presenter")`. This helps prevent use of Compose UI in the presentation logic as the compiler will emit a warning if you do. Note this does not appear in the IDE, so it's recommended to use `allWarningsAsErrors` to fail the build on this event.
 - **Change**: `Navigator.goTo` now returns a Bool indicating navigation success.
-- **Deprecation**: FakeNavigator.assertIsEmpty and expectNoEvents (use the specific event type methods instead)
+- **Deprecation**: `FakeNavigator.assertIsEmpty` and `expectNoEvents` (use the specific event type methods instead)
 - Mark `Presenter.Factory` as `@Stable`.
 - Mark `Ui.Factory` as `@Stable`.
 - Mark `CircuitContext` as `@Stable`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ Changelog
 --------------
 
 - **New**: Add WASM targets.
+- **New**: FakeNavigator methods to check for the lack of pop/resetRoot events
 - **Behaviour Change**: `NavigatorImpl.goTo` no longer navigates if the `Screen` is equal to `Navigator.peek()`.
 - **Behaviour Change**: `Presenter.present` is now annotated with `@ComposableTarget("presenter")`. This helps prevent use of Compose UI in the presentation logic as the compiler will emit a warning if you do. Note this does not appear in the IDE, so it's recommended to use `allWarningsAsErrors` to fail the build on this event.
 - **Change**: `Navigator.goTo` now returns a Bool indicating navigation success.
+- **Deprecation**: FakeNavigator.assertIsEmpty and expectNoEvents (use the specific event type methods instead)
 - Mark `Presenter.Factory` as `@Stable`.
 - Mark `Ui.Factory` as `@Stable`.
 - Mark `CircuitContext` as `@Stable`.

--- a/circuit-test/build.gradle.kts
+++ b/circuit-test/build.gradle.kts
@@ -1,6 +1,5 @@
 // Copyright (C) 2024 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
-import org.jetbrains.dokka.DokkaDefaults.moduleName
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 // Copyright (C) 2022 Slack Technologies, LLC

--- a/circuit-test/build.gradle.kts
+++ b/circuit-test/build.gradle.kts
@@ -1,5 +1,6 @@
 // Copyright (C) 2024 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.dokka.DokkaDefaults.moduleName
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 // Copyright (C) 2022 Slack Technologies, LLC
@@ -57,6 +58,7 @@ kotlin {
           implementation(libs.junit)
           implementation(libs.truth)
           implementation(libs.testing.testParameterInjector)
+          implementation(project(":internal-test-utils"))
         }
       }
     val jvmTest by getting { dependsOn(commonJvmTest) }

--- a/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
+++ b/circuit-test/src/commonMain/kotlin/com/slack/circuit/test/FakeNavigator.kt
@@ -93,14 +93,46 @@ public class FakeNavigator internal constructor(private val delegate: Navigator)
   /** Awaits the next navigation [pop] event or throws if no pops are performed. */
   public suspend fun awaitPop(): PopEvent = popEvents.awaitItem()
 
-  /** Asserts that all events so far have been consumed. */
+  /** Asserts that all goTo events so far have been consumed. */
+  @Deprecated(
+    "Only checks for goToEvents, use assertGoToIsEmpty instead",
+    replaceWith = ReplaceWith("assertGoToIsEmpty()"),
+  )
   public fun assertIsEmpty() {
     goToEvents.ensureAllEventsConsumed()
   }
 
-  /** Asserts that no events have been emitted. */
+  public fun assertGoToIsEmpty() {
+    goToEvents.ensureAllEventsConsumed()
+  }
+
+  public fun assertPopIsEmpty() {
+    popEvents.ensureAllEventsConsumed()
+  }
+
+  public fun assertResetRootIsEmpty() {
+    resetRootEvents.ensureAllEventsConsumed()
+  }
+
+  /** Asserts that no goTo events have been emitted. */
+  @Deprecated(
+    "Only checks for goToEvents, use expectNoGoToEvents instead",
+    replaceWith = ReplaceWith("expectNoGoToEvents()"),
+  )
   public fun expectNoEvents() {
     goToEvents.expectNoEvents()
+  }
+
+  public fun expectNoGoToEvents() {
+    goToEvents.expectNoEvents()
+  }
+
+  public fun expectNoPopEvents() {
+    popEvents.expectNoEvents()
+  }
+
+  public fun expectNoResetRootEvents() {
+    resetRootEvents.expectNoEvents()
   }
 
   /** Represents a recorded [Navigator.goTo] event. */

--- a/circuit-test/src/jvmTest/kotlin/com/slack/circuit/test/PresenterWithFakeNavigatorTest.kt
+++ b/circuit-test/src/jvmTest/kotlin/com/slack/circuit/test/PresenterWithFakeNavigatorTest.kt
@@ -1,0 +1,76 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.test
+
+import androidx.compose.runtime.Composable
+import com.google.common.truth.Truth.assertThat
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class PresenterWithFakeNavigatorTest {
+  @Test
+  fun tacoPresenter() = runTest {
+    val navigator = FakeNavigator(TestScreen.ScreenA)
+    val presenter = TacoPresenter(navigator = navigator)
+    presenter.test {
+      val eventSink = awaitItem().eventSink
+      eventSink.invoke(TacoEvent.TacoNoOp)
+      navigator.expectNoGoToEvents()
+      navigator.expectNoPopEvents()
+      navigator.expectNoResetRootEvents()
+
+      eventSink.invoke(TacoEvent.TacoPop)
+      val pop = navigator.awaitPop()
+      assertThat(pop.poppedScreen).isNull() // Already at root
+      navigator.expectNoGoToEvents()
+      navigator.expectNoPopEvents()
+      navigator.expectNoResetRootEvents()
+
+      eventSink.invoke(TacoEvent.TacoGoTo(TestScreen.ScreenB))
+      val goTo = navigator.awaitNextGoTo()
+      assertThat(goTo.screen).isEqualTo(TestScreen.ScreenB)
+      assertThat(goTo.success).isTrue()
+      navigator.expectNoGoToEvents()
+      navigator.expectNoPopEvents()
+      navigator.expectNoResetRootEvents()
+
+      eventSink.invoke(TacoEvent.TacoResetRoot(TestScreen.ScreenC))
+      val resetRoot = navigator.awaitResetRoot()
+      assertThat(resetRoot.newRoot).isEqualTo(TestScreen.ScreenC)
+      navigator.expectNoGoToEvents()
+      navigator.expectNoPopEvents()
+      navigator.expectNoResetRootEvents()
+    }
+  }
+}
+
+private sealed interface TacoEvent : CircuitUiEvent {
+  data object TacoNoOp : TacoEvent
+
+  data object TacoPop : TacoEvent
+
+  data class TacoGoTo(val screen: Screen) : TacoEvent
+
+  data class TacoResetRoot(val screen: Screen) : TacoEvent
+}
+
+private data class TacoState(val eventSink: (TacoEvent) -> Unit) : CircuitUiState
+
+private class TacoPresenter(val navigator: Navigator) : Presenter<TacoState> {
+  @Composable override fun present(): TacoState = TacoState(eventSink = ::handleEvent)
+
+  private fun handleEvent(event: TacoEvent) {
+    when (event) {
+      TacoEvent.TacoPop -> navigator.pop()
+      TacoEvent.TacoNoOp -> Unit
+      is TacoEvent.TacoGoTo -> navigator.goTo(event.screen)
+      is TacoEvent.TacoResetRoot -> navigator.resetRoot(event.screen)
+    }
+  }
+}


### PR DESCRIPTION
Sometimes it's nice to be able to assert that you _haven't_ gotten a pop event.  The API previously didn't allow this.  Also noticed that assertIsEmpty and expectNoEvents were only operating on the goToEvents turbine.  I don't feel strongly about the "deprecate and add multiple methods" approach, I'd also be fine with just keeping the top-level methods and just adding calls to popEvents/resetRootEvents