### PR TITLE
Implement support for stateless UIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Changelog
 --------------
 
 - **New**: Add WASM targets.
-- **New**: Add `FakeNavigator` functions to check for the lack of pop/resetRoot events
-- **New**: Add `FakeNavigator` constructor param to add additional screens to the backstack
+- **New**: Add `FakeNavigator` functions to check for the lack of pop/resetRoot events.
+- **New**: Add `FakeNavigator` constructor param to add additional screens to the backstack.
+- **New**: Add support for static UIs. In some cases, a UI may not need a presenter to compute or manage its state. Examples of this include UIs that are stateless or can derive their state from a single static input or an input [Screen]'s properties. In these cases, make your _screen_ implement the `StaticScreen` interface. When a `StaticScreen` is used, Circuit will internally allow the UI to run on its own and won't connect it to a presenter if no presenter is provided.
 - **Behaviour Change**: `NavigatorImpl.goTo` no longer navigates if the `Screen` is equal to `Navigator.peek()`.
 - **Behaviour Change**: `Presenter.present` is now annotated with `@ComposableTarget("presenter")`. This helps prevent use of Compose UI in the presentation logic as the compiler will emit a warning if you do. Note this does not appear in the IDE, so it's recommended to use `allWarningsAsErrors` to fail the build on this event.
 - **Change**: `Navigator.goTo` now returns a Bool indicating navigation success.

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
@@ -16,7 +16,7 @@ import com.slack.circuit.runtime.InternalCircuitApi
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import com.slack.circuit.runtime.screen.StatelessScreen
+import com.slack.circuit.runtime.screen.StaticScreen
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
 
@@ -96,9 +96,9 @@ public class Circuit private constructor(builder: Builder) {
       }
     }
 
-    // If it's stateless, gracefully fall back and return a stateless presenter and assume this is a
+    // If it's static, gracefully fall back and return a stateless presenter and assume this is a
     // UI-only screen. We still try giving other presenter factories
-    if (screen is StatelessScreen) {
+    if (screen is StaticScreen) {
       return statelessPresenter<CircuitUiState>()
     }
 

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitContent.kt
@@ -133,22 +133,30 @@ public fun <UiState : CircuitUiState> CircuitContent(
   // different inputs (but thus same presenter instance type) and you need this to recompose with
   // a different presenter.
   key(key) {
-    DisposableEffect(screen) {
-      eventListener.onStartPresent()
+    // Static UI can be rendered directly, no presenter ever needs to be connected
+    if (ui is StaticUi) {
+      // TODO anything we want to send to the event listener here for state?
+      DisposableEffect(screen) {
+        eventListener.onStartContent()
+        onDispose(eventListener::onDisposeContent)
+      }
+      ui.Content(modifier)
+    } else {
+      DisposableEffect(screen) {
+        eventListener.onStartPresent()
+        onDispose(eventListener::onDisposePresent)
+      }
 
-      onDispose { eventListener.onDisposePresent() }
+      val state = presenter.present()
+
+      // TODO not sure why stateFlow + LaunchedEffect + distinctUntilChanged doesn't work here
+      SideEffect { eventListener.onState(state) }
+      DisposableEffect(screen) {
+        eventListener.onStartContent()
+        onDispose(eventListener::onDisposeContent)
+      }
+      ui.Content(state, modifier)
     }
-
-    val state = presenter.present()
-
-    // TODO not sure why stateFlow + LaunchedEffect + distinctUntilChanged doesn't work here
-    SideEffect { eventListener.onState(state) }
-    DisposableEffect(screen) {
-      eventListener.onStartContent()
-
-      onDispose { eventListener.onDisposeContent() }
-    }
-    ui.Content(state, modifier)
   }
 
 /**

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/StaticContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/StaticContent.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.foundation
 
 import androidx.compose.runtime.Composable

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/StaticContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/StaticContent.kt
@@ -1,0 +1,52 @@
+package com.slack.circuit.foundation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Modifier
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.ui.Ui
+import kotlin.LazyThreadSafetyMode.NONE
+
+/** TODO doc */
+@Suppress("UNCHECKED_CAST")
+public fun <UiState : CircuitUiState> statelessPresenter(): Presenter<UiState> =
+  STATELESS as Presenter<UiState>
+
+/**
+ * Simple presenter that always returns the same [computedState]. This is useful for UIs that are
+ * static and only ever use their initial state.
+ *
+ * For UIs that are completely stateless, use [Circuit.Builder.addStaticUi] or [statelessPresenter].
+ */
+internal class StaticPresenter<UiState : CircuitUiState>(computeState: () -> UiState) :
+  Presenter<CircuitUiState> {
+
+  private val computedState: UiState by lazy(NONE, computeState)
+
+  @ReadOnlyComposable @Composable override fun present(): UiState = computedState
+}
+
+/**
+ * Singleton instance of a stateless presenter, which is a [StaticPresenter] that produces no usable
+ * state. This is never actually used at runtime, just exists for internal wiring convenience.
+ */
+private val STATELESS = StaticPresenter<CircuitUiState> { StatelessUiState }
+
+@Immutable internal object StatelessUiState : CircuitUiState
+
+/**
+ * Simple marker class so we can optimize in [CircuitContent] when the UI is static. This allows us
+ * to check for it and avoid ever calling the presenter.
+ */
+internal class StaticUi(private val delegate: @Composable (Modifier) -> Unit) :
+  Ui<StatelessUiState> {
+
+  @Composable fun Content(modifier: Modifier) = Content(StatelessUiState, modifier)
+
+  @Composable
+  override fun Content(state: StatelessUiState, modifier: Modifier) {
+    delegate(modifier)
+  }
+}

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/StaticContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/StaticContent.kt
@@ -11,9 +11,8 @@ import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
 import kotlin.LazyThreadSafetyMode.NONE
 
-/** TODO doc */
 @Suppress("UNCHECKED_CAST")
-public fun <UiState : CircuitUiState> statelessPresenter(): Presenter<UiState> =
+internal fun <UiState : CircuitUiState> statelessPresenter(): Presenter<UiState> =
   STATELESS as Presenter<UiState>
 
 /**

--- a/circuit-runtime-screen/src/androidMain/kotlin/com/slack/circuit/runtime/screen/Screen.android.kt
+++ b/circuit-runtime-screen/src/androidMain/kotlin/com/slack/circuit/runtime/screen/Screen.android.kt
@@ -6,4 +6,5 @@ import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen : Parcelable
+
 @Immutable public actual interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/androidMain/kotlin/com/slack/circuit/runtime/screen/Screen.android.kt
+++ b/circuit-runtime-screen/src/androidMain/kotlin/com/slack/circuit/runtime/screen/Screen.android.kt
@@ -6,4 +6,4 @@ import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen : Parcelable
-@Immutable public actual interface StatelessScreen : Screen
+@Immutable public actual interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/androidMain/kotlin/com/slack/circuit/runtime/screen/Screen.android.kt
+++ b/circuit-runtime-screen/src/androidMain/kotlin/com/slack/circuit/runtime/screen/Screen.android.kt
@@ -6,3 +6,4 @@ import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen : Parcelable
+@Immutable public actual interface StatelessScreen : Screen

--- a/circuit-runtime-screen/src/browserMain/kotlin/com/slack/circuit/runtime/screen/Screen.js.kt
+++ b/circuit-runtime-screen/src/browserMain/kotlin/com/slack/circuit/runtime/screen/Screen.js.kt
@@ -5,3 +5,4 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
+@Immutable public actual interface StatelessScreen : Screen

--- a/circuit-runtime-screen/src/browserMain/kotlin/com/slack/circuit/runtime/screen/Screen.js.kt
+++ b/circuit-runtime-screen/src/browserMain/kotlin/com/slack/circuit/runtime/screen/Screen.js.kt
@@ -5,4 +5,5 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
+
 @Immutable public actual interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/browserMain/kotlin/com/slack/circuit/runtime/screen/Screen.js.kt
+++ b/circuit-runtime-screen/src/browserMain/kotlin/com/slack/circuit/runtime/screen/Screen.js.kt
@@ -5,4 +5,4 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
-@Immutable public actual interface StatelessScreen : Screen
+@Immutable public actual interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/commonMain/kotlin/com/slack/circuit/runtime/screen/Screen.kt
+++ b/circuit-runtime-screen/src/commonMain/kotlin/com/slack/circuit/runtime/screen/Screen.kt
@@ -30,3 +30,6 @@ import androidx.compose.runtime.Immutable
  * ```
  */
 @Immutable public expect interface Screen
+
+/** TODO doc */
+public expect interface StatelessScreen : Screen

--- a/circuit-runtime-screen/src/commonMain/kotlin/com/slack/circuit/runtime/screen/Screen.kt
+++ b/circuit-runtime-screen/src/commonMain/kotlin/com/slack/circuit/runtime/screen/Screen.kt
@@ -31,5 +31,71 @@ import androidx.compose.runtime.Immutable
  */
 @Immutable public expect interface Screen
 
-/** TODO doc */
+/**
+ * A marker interface that indicates that this [Screen] only ever has static content and does not
+ * require a presenter to compute or manage its state. This is useful for UIs that either have no
+ * state or can derive their state solely from static inputs or the [Screen] key itself.
+ *
+ * **Stateless UI**
+ *
+ * ```kotlin
+ * data object ProfileScreen : StaticScreen
+ *
+ * @Composable
+ * fun Profile(modifier: Modifier = Modifier) {
+ *   Text("Jane", modifier = modifier)
+ * }
+ *
+ * val circuit = Circuit.Builder()
+ *   .addUi<ProfileScreen> { _, modifier -> Profile(modifier) }
+ *   .build()
+ * ```
+ *
+ * **Static UI**
+ *
+ * ```kotlin
+ * data object ProfileScreen : StaticScreen
+ *
+ * @Composable
+ * fun Profile(name: String, modifier: Modifier = Modifier) {
+ *   Text(name, modifier = modifier)
+ * }
+ *
+ * val circuit = Circuit.Builder()
+ *   .addUi<ProfileScreen> { _, modifier ->
+ *     // The UI's input is handled in the factory in this case
+ *     Profile("Jane", modifier)
+ *   }
+ *   .build()
+ * ```
+ *
+ * **Static UI w/ Screen data**
+ *
+ * ```kotlin
+ * data class ProfileScreen(val name: String) : StaticScreen
+ *
+ * @Composable
+ * fun Profile(name: String, modifier: Modifier = Modifier) {
+ *   Text(name, modifier = modifier)
+ * }
+ *
+ * val circuit = Circuit.Builder()
+ *   .addUi<ProfileScreen> { screen, modifier ->
+ *     Profile(screen.name, modifier)
+ *   }
+ *   .build()
+ * ```
+ *
+ * **Static UI w/ Screen input + code gen**
+ *
+ * ```kotlin
+ * data class ProfileScreen(val name: String) : StaticScreen
+ *
+ * @CircuitInject(ProfileScreen::class, AppScope::class)
+ * @Composable
+ * fun Profile(screen: ProfileScreen, modifier: Modifier = Modifier) {
+ *   Text(screen.name, modifier = modifier)
+ * }
+ * ```
+ */
 public expect interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/commonMain/kotlin/com/slack/circuit/runtime/screen/Screen.kt
+++ b/circuit-runtime-screen/src/commonMain/kotlin/com/slack/circuit/runtime/screen/Screen.kt
@@ -32,4 +32,4 @@ import androidx.compose.runtime.Immutable
 @Immutable public expect interface Screen
 
 /** TODO doc */
-public expect interface StatelessScreen : Screen
+public expect interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/iosMain/kotlin/com/slack/circuit/runtime/screen/Screen.ios.kt
+++ b/circuit-runtime-screen/src/iosMain/kotlin/com/slack/circuit/runtime/screen/Screen.ios.kt
@@ -5,3 +5,4 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
+@Immutable public actual interface StatelessScreen : Screen

--- a/circuit-runtime-screen/src/iosMain/kotlin/com/slack/circuit/runtime/screen/Screen.ios.kt
+++ b/circuit-runtime-screen/src/iosMain/kotlin/com/slack/circuit/runtime/screen/Screen.ios.kt
@@ -5,4 +5,5 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
+
 @Immutable public actual interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/iosMain/kotlin/com/slack/circuit/runtime/screen/Screen.ios.kt
+++ b/circuit-runtime-screen/src/iosMain/kotlin/com/slack/circuit/runtime/screen/Screen.ios.kt
@@ -5,4 +5,4 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
-@Immutable public actual interface StatelessScreen : Screen
+@Immutable public actual interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/jvmMain/kotlin/com/slack/circuit/runtime/screen/Screen.jvm.kt
+++ b/circuit-runtime-screen/src/jvmMain/kotlin/com/slack/circuit/runtime/screen/Screen.jvm.kt
@@ -5,3 +5,4 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
+@Immutable public actual interface StatelessScreen : Screen

--- a/circuit-runtime-screen/src/jvmMain/kotlin/com/slack/circuit/runtime/screen/Screen.jvm.kt
+++ b/circuit-runtime-screen/src/jvmMain/kotlin/com/slack/circuit/runtime/screen/Screen.jvm.kt
@@ -5,4 +5,5 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
+
 @Immutable public actual interface StaticScreen : Screen

--- a/circuit-runtime-screen/src/jvmMain/kotlin/com/slack/circuit/runtime/screen/Screen.jvm.kt
+++ b/circuit-runtime-screen/src/jvmMain/kotlin/com/slack/circuit/runtime/screen/Screen.jvm.kt
@@ -5,4 +5,4 @@ package com.slack.circuit.runtime.screen
 import androidx.compose.runtime.Immutable
 
 @Immutable public actual interface Screen
-@Immutable public actual interface StatelessScreen : Screen
+@Immutable public actual interface StaticScreen : Screen

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -37,3 +37,7 @@ private fun PreviewFavorites() = Favorites(FavoritesState(listOf("Reeses", "Lola
 @Composable
 private fun PreviewEmptyFavorites() = Favorites(FavoritesState(listOf()))
 ```
+
+## Static UI
+
+In some cases, a UI may not need a presenter to compute or manage its state. Examples of this include UIs that are stateless or can derive their state from a single static input or an input [Screen]'s properties. In these cases, make your _screen_ implement the `StaticScreen` interface. When a `StaticScreen` is used, Circuit will internally allow the UI to run on its own and won't connect it to a presenter if no presenter is provided.

--- a/samples/star/src/commonMain/kotlin/com/slack/circuit/star/home/AboutScreen.kt
+++ b/samples/star/src/commonMain/kotlin/com/slack/circuit/star/home/AboutScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.runtime.screen.StatelessScreen
+import com.slack.circuit.runtime.screen.StaticScreen
 import com.slack.circuit.star.common.Strings
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.parcel.CommonParcelize
@@ -28,7 +28,7 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 
 @CommonParcelize
-data object AboutScreen : StatelessScreen
+data object AboutScreen : StaticScreen
 
 @OptIn(ExperimentalResourceApi::class)
 @CircuitInject(screen = AboutScreen::class, scope = AppScope::class)

--- a/samples/star/src/commonMain/kotlin/com/slack/circuit/star/home/AboutScreen.kt
+++ b/samples/star/src/commonMain/kotlin/com/slack/circuit/star/home/AboutScreen.kt
@@ -27,8 +27,7 @@ import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 
-@CommonParcelize
-data object AboutScreen : StaticScreen
+@CommonParcelize data object AboutScreen : StaticScreen
 
 @OptIn(ExperimentalResourceApi::class)
 @CircuitInject(screen = AboutScreen::class, scope = AppScope::class)

--- a/samples/star/src/commonMain/kotlin/com/slack/circuit/star/home/AboutScreen.kt
+++ b/samples/star/src/commonMain/kotlin/com/slack/circuit/star/home/AboutScreen.kt
@@ -19,8 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.runtime.CircuitUiState
-import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.runtime.screen.StatelessScreen
 import com.slack.circuit.star.common.Strings
 import com.slack.circuit.star.di.AppScope
 import com.slack.circuit.star.parcel.CommonParcelize
@@ -29,13 +28,7 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 
 @CommonParcelize
-data object AboutScreen : Screen {
-  object State : CircuitUiState
-}
-
-@CircuitInject(screen = AboutScreen::class, scope = AppScope::class)
-@Composable
-fun AboutPresenter(): AboutScreen.State = AboutScreen.State
+data object AboutScreen : StatelessScreen
 
 @OptIn(ExperimentalResourceApi::class)
 @CircuitInject(screen = AboutScreen::class, scope = AppScope::class)


### PR DESCRIPTION
Rehash of #565. This implements support for an optimized stateless UI. These UIs either have no state or derive their state from the screen inputs.

There's three parts to this:
1. The introduction of internal `StaticPresenter` and `StaticUi` classes. The former is just a presenter that always returns the same, lazily-computed state value. The latter is a UI that always renders the same initial static value (which can be derived from a Screen input or otherwise). Internally in `CircuitContent`, `StaticUi` UIs have a different code path that never wires up the presenter and instead just renders the UI directly and only the UI.
2. The introduction of a "stateless" presenter, which is just a singleton `StaticPresenter` instance that can be reused for circuit's internal wiring.
3. The introduction of a `StaticScreen` interface, which is a marker interface to indicate that a given screen is stateless and thus may not have a presenter. `Circuit` internally checks this and will just return the stateless presenter singleton upon these cases.

The `AboutScreen` in the STAR sample has been updated for this use case. This is particularly useful for small isolated screens where the `Screen` class alone can be the only input but a `CircuitContent` is still desirable for indirection.

I left some toe-holds for possibly exposing some of these APIs down the line, but kept things limited for now.