### PR TITLE
Return PopResult from OverlayHost.showFullScreenOverlay()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **Change**: `OverlayHost.showFullScreenOverlay` now returns the PopResult? that was popped by the screen.
+
 0.22.1
 ------
 

--- a/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
+++ b/circuit-overlay/src/commonMain/kotlin/com/slack/circuit/overlay/Overlay.kt
@@ -62,7 +62,7 @@ public interface OverlayHost {
    * }
    * ```
    */
-  public val currentOverlayData: OverlayHostData<Any>?
+  public val currentOverlayData: OverlayHostData<Any?>?
 
   /**
    * Shows the given [overlay] and suspends until the overlay is finished with a [Result]. The
@@ -74,7 +74,7 @@ public interface OverlayHost {
    * This function should only be called from UI contexts and _not_ presenters, as overlays are a UI
    * concern.
    */
-  public suspend fun <Result : Any> show(overlay: Overlay<Result>): Result
+  public suspend fun <Result : Any?> show(overlay: Overlay<Result>): Result
 }
 
 /** Returns a remembered an [OverlayHost] that can be used to show overlays. */
@@ -88,18 +88,18 @@ private class OverlayHostImpl : OverlayHost {
    */
   private val mutex = Mutex()
 
-  override var currentOverlayData: OverlayHostData<Any>? by mutableStateOf(null)
+  override var currentOverlayData: OverlayHostData<Any?>? by mutableStateOf(null)
     private set
 
-  override suspend fun <T : Any> show(overlay: Overlay<T>): T =
+  override suspend fun <T : Any?> show(overlay: Overlay<T>): T =
     mutex.withLock {
       try {
         return suspendCancellableCoroutine { continuation ->
           @Suppress("UNCHECKED_CAST")
           currentOverlayData =
             OverlayHostDataImpl(
-              overlay as Overlay<Any>,
-              continuation as CancellableContinuation<Any>,
+              overlay as Overlay<Any?>,
+              continuation as CancellableContinuation<Any?>,
             )
         }
       } finally {
@@ -113,7 +113,7 @@ private class OverlayHostImpl : OverlayHost {
  * implemented by consumers!
  */
 @Stable
-public interface OverlayHostData<Result : Any> {
+public interface OverlayHostData<Result : Any?> {
   /** The [Overlay] that is currently being shown. Read-only. */
   public val overlay: Overlay<Result>
 
@@ -124,7 +124,7 @@ public interface OverlayHostData<Result : Any> {
   public fun finish(result: Result)
 }
 
-private class OverlayHostDataImpl<T : Any>(
+private class OverlayHostDataImpl<T : Any?>(
   override val overlay: Overlay<T>,
   private val continuation: CancellableContinuation<T>,
 ) : OverlayHostData<T> {
@@ -156,7 +156,7 @@ private class OverlayHostDataImpl<T : Any>(
  * result when they are done.
  */
 @Stable
-public fun interface OverlayNavigator<Result : Any> {
+public fun interface OverlayNavigator<Result : Any?> {
   /** Called by the [Overlay] with a [result] it's done. */
   public fun finish(result: Result)
 }
@@ -171,7 +171,7 @@ public fun interface OverlayNavigator<Result : Any> {
  * example: `BottomSheetOverlay`, `ModalOverlay`, `TooltipOverlay`, etc.
  */
 @Stable
-public interface Overlay<Result : Any> {
+public interface Overlay<Result : Any?> {
   @Composable public fun Content(navigator: OverlayNavigator<Result>)
 }
 
@@ -181,7 +181,7 @@ public interface Overlay<Result : Any> {
  * [AnimatedContent] is executed with with [AnimatedVisibilityScope] so that child animations can be
  * coordinated with the overlay's animations.
  */
-public abstract class AnimatedOverlay<Result : Any>(
+public abstract class AnimatedOverlay<Result : Any?>(
   public val enterTransition: EnterTransition,
   public val exitTransition: ExitTransition,
 ) : Overlay<Result> {

--- a/circuitx/overlays/src/androidMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.android.kt
+++ b/circuitx/overlays/src/androidMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.android.kt
@@ -3,8 +3,9 @@
 package com.slack.circuitx.overlays
 
 import com.slack.circuit.overlay.OverlayHost
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 
-public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen) {
-  show(FullScreenOverlay(screen) { rememberConditionalSystemUiColors() })
+public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen): PopResult? {
+  return show(FullScreenOverlay(screen) { rememberConditionalSystemUiColors() })
 }

--- a/circuitx/overlays/src/browserMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.js.kt
+++ b/circuitx/overlays/src/browserMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.js.kt
@@ -3,8 +3,9 @@
 package com.slack.circuitx.overlays
 
 import com.slack.circuit.overlay.OverlayHost
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 
-public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen) {
-  show(FullScreenOverlay(screen))
+public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen): PopResult? {
+  return show(FullScreenOverlay(screen))
 }

--- a/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
+++ b/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.kt
@@ -22,7 +22,7 @@ import kotlinx.collections.immutable.persistentListOf
  * Shows a full screen overlay with the given [screen]. As the name suggests, this overlay takes
  * over the entire available screen space available to the current [OverlayHost].
  */
-public expect suspend fun OverlayHost.showFullScreenOverlay(screen: Screen)
+public expect suspend fun OverlayHost.showFullScreenOverlay(screen: Screen): PopResult?
 
 /**
  * A simple overlay that renders a given [screen] in a [CircuitContent] with backhandling support
@@ -31,7 +31,7 @@ public expect suspend fun OverlayHost.showFullScreenOverlay(screen: Screen)
 internal class FullScreenOverlay<S : Screen>(
   private val screen: S,
   private val callbacks: @Composable () -> Callbacks = { Callbacks.NoOp },
-) : Overlay<Unit> {
+) : Overlay<PopResult?> {
   /** Simple callbacks for when a [FullScreenOverlay] is shown and finished. */
   @Stable
   internal interface Callbacks {
@@ -47,7 +47,7 @@ internal class FullScreenOverlay<S : Screen>(
   }
 
   @Composable
-  override fun Content(navigator: OverlayNavigator<Unit>) {
+  override fun Content(navigator: OverlayNavigator<PopResult?>) {
     val callbacks = key(callbacks) { callbacks() }
     val dispatchingNavigator = remember {
       DispatchingOverlayNavigator(screen, navigator, callbacks::onFinish)
@@ -64,7 +64,7 @@ internal class FullScreenOverlay<S : Screen>(
  */
 internal class DispatchingOverlayNavigator(
   private val currentScreen: Screen,
-  private val overlayNavigator: OverlayNavigator<Unit>,
+  private val overlayNavigator: OverlayNavigator<PopResult?>,
   private val onPop: () -> Unit,
 ) : Navigator {
   override fun goTo(screen: Screen): Boolean {
@@ -72,7 +72,7 @@ internal class DispatchingOverlayNavigator(
   }
 
   override fun pop(result: PopResult?): Screen? {
-    overlayNavigator.finish(Unit)
+    overlayNavigator.finish(result)
     onPop()
     return null
   }

--- a/circuitx/overlays/src/iosMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.ios.kt
+++ b/circuitx/overlays/src/iosMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.ios.kt
@@ -3,8 +3,9 @@
 package com.slack.circuitx.overlays
 
 import com.slack.circuit.overlay.OverlayHost
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 
-public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen) {
-  show(FullScreenOverlay(screen))
+public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen): PopResult? {
+  return show(FullScreenOverlay(screen))
 }

--- a/circuitx/overlays/src/jvmMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.jvm.kt
+++ b/circuitx/overlays/src/jvmMain/kotlin/com/slack/circuitx/overlays/FullScreenOverlay.jvm.kt
@@ -3,8 +3,9 @@
 package com.slack.circuitx.overlays
 
 import com.slack.circuit.overlay.OverlayHost
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 
-public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen) {
-  show(FullScreenOverlay(screen))
+public actual suspend fun OverlayHost.showFullScreenOverlay(screen: Screen): PopResult? {
+  return show(FullScreenOverlay(screen))
 }


### PR DESCRIPTION
`showFullScreenOverlay()` now returns the PopResult that was popped by the shown Screen. 

I had to change `Overlay`'s generic parameter from `Any` to `Any?` to account for the nullable PopResult. I couldn't think of any obvious reason for why overlays shouldn't be able to also return null values. This shouldn't be a breaking change, as the generic parameter is now less restrictive!?