### PR TITLE
Fix `pausableState` causing extra compositions

### DIFF
--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/PausableStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/PausableStateTest.kt
@@ -1,0 +1,70 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val TEST_TAG = "count"
+private const val EXPECTED_RECOMPOSITIONS = 3
+
+@RunWith(ComposeUiTestRunner::class)
+class PausableStateTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun presentWithLifecycleShouldNotLoop() = runTest {
+    val presenter = TestPresenter()
+    with(composeTestRule) {
+      setContent {
+        val state = presenter.presentWithLifecycle()
+        BasicText(
+          text = "${state.count}",
+          modifier = Modifier.testTag(TEST_TAG).clickable { state.eventSink() },
+        )
+      }
+      with(onNodeWithTag(TEST_TAG)) {
+        assertTextEquals("0")
+        performClick()
+        assertTextEquals("1")
+        performClick()
+        assertTextEquals("2")
+      }
+      assertEquals(EXPECTED_RECOMPOSITIONS, presenter.compositionCount)
+    }
+  }
+
+  class TestPresenter : Presenter<TestState> {
+
+    var compositionCount = 0
+
+    @Composable
+    override fun present(): TestState {
+      var count by remember { mutableIntStateOf(0) }
+      SideEffect { compositionCount++ }
+      return TestState(count = count) { count++ }
+    }
+  }
+
+  data class TestState(val count: Int, val eventSink: () -> Unit) : CircuitUiState
+}


### PR DESCRIPTION
Using `pausableState` with a presenter caused an extra recomposition after each state changed.
If the state object wasn't equatable it'd get stuck in a constant recomposition loop. 

Best I can determine, this has to do with the way the `mutableStateOf` is initially observed? 