### PR TITLE
Add withCompositionLocalProvider to avoid backward writes

### DIFF
--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -131,6 +131,14 @@ tasks
     }
   }
 
+tasks.withType<Test>().configureEach {
+  // Without this PausableStateTest will deadlock, timeout and fail. Seems to be related to when
+  // it is ran at the same time as other tests. PausableStateTest is pretty innocuous, so seems
+  // to be test infra related. Best guess is that ComposeTestRule doesn't like content which calls
+  // a composable with a return value. Needs more investigation.
+  setForkEvery(1)
+}
+
 android {
   namespace = "com.slack.circuit.foundation"
   defaultConfig { testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner" }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/PausableStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/PausableStateTest.kt
@@ -1,0 +1,104 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val TEST_TAG = "count"
+private const val EXPECTED_RECOMPOSITIONS = 3
+
+@RunWith(ComposeUiTestRunner::class)
+class PausableStateTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun presentWithLifecycle_dataClass() = runTest {
+    val presenter = DataClassPresenter()
+    with(composeTestRule) {
+      setContent {
+        val state = presenter.presentWithLifecycle()
+        BasicText(
+          text = "${state.count}",
+          modifier = Modifier.testTag(TEST_TAG).clickable { state.eventSink() },
+        )
+      }
+      with(onNodeWithTag(TEST_TAG)) {
+        assertTextEquals("0")
+        performClick()
+        assertTextEquals("1")
+        performClick()
+        assertTextEquals("2")
+      }
+      assertEquals(EXPECTED_RECOMPOSITIONS, presenter.compositionCount)
+    }
+  }
+
+  @Test
+  fun presentWithLifecycle_class() = runTest {
+    val presenter = ClassPresenter()
+    with(composeTestRule) {
+      setContent {
+        val state = presenter.presentWithLifecycle()
+        BasicText(
+          text = "${state.count}",
+          modifier = Modifier.testTag(TEST_TAG).clickable { state.eventSink() },
+        )
+      }
+      with(onNodeWithTag(TEST_TAG)) {
+        assertTextEquals("0")
+        performClick()
+        assertTextEquals("1")
+        performClick()
+        assertTextEquals("2")
+      }
+      assertEquals(EXPECTED_RECOMPOSITIONS, presenter.compositionCount)
+    }
+  }
+
+  class DataClassPresenter : Presenter<DataClassPresenter.TestState> {
+    var compositionCount = 0
+
+    @Composable
+    override fun present(): TestState {
+      var count by remember { mutableIntStateOf(0) }
+      SideEffect { compositionCount++ }
+      return TestState(count = count) { count++ }
+    }
+
+    data class TestState(val count: Int, val eventSink: () -> Unit) : CircuitUiState
+  }
+
+  class ClassPresenter : Presenter<ClassPresenter.TestState> {
+    var compositionCount = 0
+
+    @Composable
+    override fun present(): TestState {
+      var count by remember { mutableIntStateOf(0) }
+      SideEffect { compositionCount++ }
+      return TestState(count = count) { count++ }
+    }
+
+    class TestState(val count: Int, val eventSink: () -> Unit) : CircuitUiState
+  }
+}

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/PausableState.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/PausableState.kt
@@ -76,7 +76,7 @@ public fun <T> pausableState(
         state.value = it
       }
   } else {
-    // Else, we just omitted the last recorded state instance
+    // Else, we just emit the last stored state instance
     state.value!!
   }
 }

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/SaveableStateHolder.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/SaveableStateHolder.kt
@@ -11,14 +11,8 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 
 /**
- * Allows to save the state defined with [rememberSaveable] for the subtree before disposing it to
- * make it possible to compose it back next time with the restored state. It allows different
- * navigation patterns to keep the ui state like scroll position for the currently not composed
- * screens from the backstack.
- *
- * The content should be composed using [SaveableStateProvider] while providing a key representing
- * this content. Next time [SaveableStateProvider] will be used with the same key its state will be
- * restored.
+ * This is a copy of [androidx.compose.runtime.saveable.SaveableStateHolder], tweaked so that
+ * [SaveableStateProvider] returns a value.
  */
 internal interface SaveableStateHolder {
   /**

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/SaveableStateHolder.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/SaveableStateHolder.kt
@@ -1,0 +1,117 @@
+// Copyright (C) 2020 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+/**
+ * Allows to save the state defined with [rememberSaveable] for the subtree before disposing it to
+ * make it possible to compose it back next time with the restored state. It allows different
+ * navigation patterns to keep the ui state like scroll position for the currently not composed
+ * screens from the backstack.
+ *
+ * The content should be composed using [SaveableStateProvider] while providing a key representing
+ * this content. Next time [SaveableStateProvider] will be used with the same key its state will be
+ * restored.
+ */
+internal interface SaveableStateHolder {
+  /**
+   * Put your content associated with a [key] inside the [content]. This will automatically save all
+   * the states defined with [rememberSaveable] before disposing the content and will restore the
+   * states when you compose with this key again.
+   *
+   * @param key to be used for saving and restoring the states for the subtree. Note that on Android
+   *   you can only use types which can be stored inside the Bundle.
+   */
+  @Composable fun <R> SaveableStateProvider(key: Any, content: @Composable () -> R): R
+
+  /** Removes the saved state associated with the passed [key]. */
+  fun removeState(key: Any)
+}
+
+/** Creates and remembers the instance of [SaveableStateHolder]. */
+@Composable
+internal fun rememberSaveableStateHolderWithReturn(): SaveableStateHolder =
+  rememberSaveable(saver = SaveableStateHolderImpl.Saver) { SaveableStateHolderImpl() }
+    .apply { parentSaveableStateRegistry = LocalSaveableStateRegistry.current }
+
+private class SaveableStateHolderImpl(
+  private val savedStates: MutableMap<Any, Map<String, List<Any?>>> = mutableMapOf()
+) : SaveableStateHolder {
+  private val registryHolders = mutableMapOf<Any, RegistryHolder>()
+  var parentSaveableStateRegistry: SaveableStateRegistry? = null
+
+  @Composable
+  override fun <R> SaveableStateProvider(key: Any, content: @Composable () -> R): R {
+    val registryHolder = remember {
+      require(parentSaveableStateRegistry?.canBeSaved(key) ?: true) {
+        "Type of the key $key is not supported. On Android you can only use types " +
+          "which can be stored inside the Bundle."
+      }
+      RegistryHolder(key)
+    }
+
+    val result =
+      withCompositionLocalProvider(
+        LocalSaveableStateRegistry provides registryHolder.registry,
+        content = content,
+      )
+
+    DisposableEffect(Unit) {
+      require(key !in registryHolders) { "Key $key was used multiple times " }
+      savedStates -= key
+      registryHolders[key] = registryHolder
+      onDispose {
+        registryHolder.saveTo(savedStates)
+        registryHolders -= key
+      }
+    }
+
+    return result
+  }
+
+  private fun saveAll(): MutableMap<Any, Map<String, List<Any?>>>? {
+    val map = savedStates.toMutableMap()
+    registryHolders.values.forEach { it.saveTo(map) }
+    return map.ifEmpty { null }
+  }
+
+  override fun removeState(key: Any) {
+    val registryHolder = registryHolders[key]
+    if (registryHolder != null) {
+      registryHolder.shouldSave = false
+    } else {
+      savedStates -= key
+    }
+  }
+
+  inner class RegistryHolder(val key: Any) {
+    var shouldSave = true
+    val registry: SaveableStateRegistry =
+      SaveableStateRegistry(savedStates[key]) {
+        parentSaveableStateRegistry?.canBeSaved(it) ?: true
+      }
+
+    fun saveTo(map: MutableMap<Any, Map<String, List<Any?>>>) {
+      if (shouldSave) {
+        val savedData = registry.performSave()
+        if (savedData.isEmpty()) {
+          map -= key
+        } else {
+          map[key] = savedData
+        }
+      }
+    }
+  }
+
+  companion object {
+    val Saver: Saver<SaveableStateHolderImpl, *> =
+      Saver(save = { it.saveAll() }, restore = { SaveableStateHolderImpl(it) })
+  }
+}


### PR DESCRIPTION
This allows us to optimize pausableState, and migrate away from a mutable state to store the last emitted state. We now simply return the returned value, and store it in a simple mutable holder, avoiding unnecessary recompositions due to backward writes.

Unfortunately we had to copy in `SaveableStateHolder` and tweak it to return a value from `SaveableStateProvider`.

I've imported `PausableStateTest` from #1449 and verified that this fixes recompositions for classes which implement equality, and those which don't.