### PR TITLE
Add a test to verify state restoration when using resetRoot

### DIFF
--- a/circuitx/gesture-navigation/src/androidUnitTest/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationStateTest.kt
+++ b/circuitx/gesture-navigation/src/androidUnitTest/kotlin/com/slack/circuitx/gesturenavigation/GestureNavigationStateTest.kt
@@ -20,6 +20,8 @@ import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
 import com.slack.circuit.internal.test.TestContentTags.TAG_INCREASE_COUNT
 import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
 import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import com.slack.circuit.internal.test.TestContentTags.TAG_RESET_ROOT_ALPHA
+import com.slack.circuit.internal.test.TestContentTags.TAG_RESET_ROOT_BETA
 import com.slack.circuit.internal.test.TestCountPresenter.RememberType
 import com.slack.circuit.internal.test.TestScreen
 import com.slack.circuit.internal.test.createTestCircuit
@@ -79,7 +81,7 @@ class GestureNavigationStateTest(
   }
 
   @Test
-  fun retainedStateScopedToBackstack() {
+  fun stateScopedToBackstack() {
     composeTestRule.run {
       val circuit = createTestCircuit(useKeys = useKeys, rememberType = rememberType)
 
@@ -165,6 +167,132 @@ class GestureNavigationStateTest(
       onTopNavigationRecordNodeWithTag(TAG_GO_NEXT).performClick()
       onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("B")
       onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+
+  @Test
+  fun stateScopedToBackstack_resetRoots() {
+    composeTestRule.run {
+      val circuit =
+        createTestCircuit(
+          useKeys = useKeys,
+          rememberType = rememberType,
+          saveStateOnRootChange = true,
+          restoreStateOnRootChange = true,
+        )
+
+      setContent {
+        CircuitCompositionLocals(circuit) {
+          val backStack = rememberSaveableBackStack(TestScreen.RootAlpha)
+          val navigator =
+            rememberCircuitNavigator(
+              backStack = backStack,
+              onRootPop = {}, // no-op for tests
+            )
+          NavigableCircuitContent(
+            navigator = navigator,
+            backStack = backStack,
+            decoration =
+              remember {
+                when (decorationOption) {
+                  GestureNavDecorationOption.AndroidPredictiveBack -> {
+                    AndroidPredictiveBackNavigationDecoration(onBackInvoked = navigator::pop)
+                  }
+                  GestureNavDecorationOption.Cupertino -> {
+                    CupertinoGestureNavigationDecoration(onBackInvoked = navigator::pop)
+                  }
+                }
+              },
+          )
+        }
+      }
+
+      // Current: Root Alpha. Navigate to Screen A
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("Root Alpha")
+      onTopNavigationRecordNodeWithTag(TAG_GO_NEXT).performClick()
+
+      // Current: Screen A. Increase count to 1
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      println("Increasing A")
+      onTopNavigationRecordNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Increase count to 1
+      println("Going to B")
+      onTopNavigationRecordNodeWithTag(TAG_GO_NEXT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      println("Increasing B")
+      onTopNavigationRecordNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen C. Increase count to 1
+      println("Going to C")
+      onTopNavigationRecordNodeWithTag(TAG_GO_NEXT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      println("Increasing C")
+      onTopNavigationRecordNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Pop to Screen B. Increase count from 1 to 2.
+      println("Pop to B")
+      pop()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("1")
+      println("Increasing B")
+      onTopNavigationRecordNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Navigate to Screen C. Assert that it's state was not retained
+      println("Go to C")
+      onTopNavigationRecordNodeWithTag(TAG_GO_NEXT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Pop to Screen B. Assert that it's state was retained
+      println("Popping to B")
+      pop()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // So at this point:
+      // Active: Root Alpha, Screen A (count: 1), Screen B: (count: 2)
+      // Retained: empty
+
+      // Let's switch to Root B
+      onTopNavigationRecordNodeWithTag(TAG_RESET_ROOT_BETA).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("Root Beta")
+
+      // Navigate to Screen A, and increase count to 2
+      onTopNavigationRecordNodeWithTag(TAG_GO_NEXT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onTopNavigationRecordNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // So at this point:
+      // Active: Root Beta, Screen A (count: 2)
+      // Retained: Root Alpha, Screen A (count: 1), Screen B: (count: 2)
+
+      // Let's switch back to Root Alpha
+      onTopNavigationRecordNodeWithTag(TAG_RESET_ROOT_ALPHA).performClick()
+      // Root Alpha should now be active. The top record for Root Alpha is Screen B: (count: 2)
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Pop to Screen A
+      pop()
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Let's switch back to Root B
+      onTopNavigationRecordNodeWithTag(TAG_RESET_ROOT_BETA).performClick()
+      // Root Beta should now be active. The top record for Root Beta  is Screen A: (count: 2)
+      onTopNavigationRecordNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onTopNavigationRecordNodeWithTag(TAG_COUNT).assertTextEquals("2")
     }
   }
 }


### PR DESCRIPTION
This follows on from the tests in `NavigableCircuitSaveableStateTest` but this time run with the GestureNavigationDecoration impls. Everything seems to be working, via both pops and gestures.