### PR TITLE
Small improvements for using circuit in previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 - **New**: Promote `NoOpRetainedStateRegistry` to public API for use in testing and previews.
 - **New**: Add `CircuitPreview` helper function for composable previews that contain Circuit content.
+- **Enhancement**: When running under `LocalInspectionMode`, Circuit's default `onUnavailableContent` now shows a simpler non-intrusive placeholder UI instead.
 
 0.23.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 --------------
 
 - **New**: Promote `NoOpRetainedStateRegistry` to public API for use in testing and previews.
+- **New**: Add `CircuitPreview` helper function for composable previews that contain Circuit content.
 
 0.23.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **New**: Promote `NoOpRetainedStateRegistry` to public API for use in testing and previews.
+
 0.23.0
 ------
 

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -5,7 +5,6 @@
 package com.slack.circuit.codegen
 
 import com.google.auto.service.AutoService
-import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.getConstructors

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -315,7 +315,6 @@ private class CircuitSymbolProcessor(
   /** Computes the data needed to generate a factory. */
   // Detekt and ktfmt don't agree on whether or not the rectangle rule makes for readable code.
   @Suppress("ComplexMethod", "LongMethod", "ReturnCount")
-  @OptIn(KspExperimental::class)
   private fun computeFactoryData(
     annotatedElement: KSAnnotated,
     symbols: CircuitSymbols,

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/Circuit.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.TextStyle
 import com.slack.circuit.backstack.NavDecoration
 import com.slack.circuit.runtime.CircuitContext
@@ -267,11 +268,20 @@ public class Circuit private constructor(builder: Builder) {
 
 private val UnavailableContent: @Composable (screen: Screen, modifier: Modifier) -> Unit =
   { screen, modifier ->
-    BasicText(
-      "Route not available: $screen",
-      modifier.background(Color.Red),
-      style = TextStyle(color = Color.Yellow),
-    )
+    if (LocalInspectionMode.current) {
+      // In previews/tests, use a plainer placeholder
+      BasicText(
+        text = "⚡️CircuitScreen(${screen::class.simpleName})",
+        modifier = modifier.background(Color.Gray),
+        style = TextStyle(color = Color.Black),
+      )
+    } else {
+      BasicText(
+        text = "Route not available: $screen",
+        modifier = modifier.background(Color.Red),
+        style = TextStyle(color = Color.Yellow),
+      )
+    }
   }
 
 /** The [Circuit] used in this context. */

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitCompositionLocals.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/CircuitCompositionLocals.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.slack.circuit.retained.LocalRetainedStateRegistry
+import com.slack.circuit.retained.NoOpRetainedStateRegistry
 import com.slack.circuit.retained.RetainedStateRegistry
 import com.slack.circuit.retained.continuityRetainedStateRegistry
 import com.slack.circuit.runtime.CircuitContext
@@ -35,3 +36,28 @@ internal val LocalCircuitContext = compositionLocalOf<CircuitContext?> { null }
 
 /** CompositionLocal with a current [Circuit] instance. */
 public val LocalCircuit: ProvidableCompositionLocal<Circuit?> = staticCompositionLocalOf { null }
+
+private val EMPTY_CIRCUIT = Circuit.Builder().build()
+
+/**
+ * A composable function that provides no-op/empty Circuit composition locals that can be safely
+ * used within a `@Preview` composable.
+ *
+ * Example:
+ * ```kotlin
+ * @Preview
+ * fun ListItemPreview() {
+ *   CircuitPreview {
+ *     ListItem()
+ *   }
+ * }
+ * ```
+ */
+@Composable
+public fun CircuitPreview(content: @Composable () -> Unit) {
+  CircuitCompositionLocals(
+    circuit = EMPTY_CIRCUIT,
+    retainedStateRegistry = NoOpRetainedStateRegistry,
+    content = content,
+  )
+}

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/NoOpRetainedStateRegistry.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/NoOpRetainedStateRegistry.kt
@@ -1,0 +1,23 @@
+// Copyright (C) 2024 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.retained
+
+/** A no-op [RetainedStateRegistry]. Should generally only be used for testing and previews. */
+public object NoOpRetainedStateRegistry : RetainedStateRegistry {
+  override fun consumeValue(key: String): Any? = null
+
+  override fun registerValue(
+    key: String,
+    valueProvider: RetainedValueProvider,
+  ): RetainedStateRegistry.Entry = NoOpEntry
+
+  override fun saveAll() {}
+
+  override fun saveValue(key: String) {}
+
+  override fun forgetUnclaimedValues() {}
+
+  private object NoOpEntry : RetainedStateRegistry.Entry {
+    override fun unregister() {}
+  }
+}

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RememberRetained.kt
@@ -219,8 +219,8 @@ public fun <T> rememberRetained(
   rememberRetained(*inputs, saver = mutableStateSaver(stateSaver), key = key, init = init)
 
 /**
- * A simple proxy to [rememberRetained] that uses the default [autoSaver] for [saver] and a more
- * explicit name.
+ * A simple proxy to [rememberRetained] that uses the default [autoSaver] for [stateSaver] and a
+ * more explicit name.
  *
  * @see rememberRetained
  */

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/RetainedStateRegistry.kt
@@ -152,19 +152,3 @@ internal class RetainedStateRegistryImpl(retained: MutableMap<String, List<Any?>
     retained.clear()
   }
 }
-
-internal object NoOpRetainedStateRegistry : RetainedStateRegistry {
-  override fun consumeValue(key: String): Any? = null
-
-  override fun registerValue(key: String, valueProvider: RetainedValueProvider): Entry = NoOpEntry
-
-  override fun saveAll() {}
-
-  override fun saveValue(key: String) {}
-
-  override fun forgetUnclaimedValues() {}
-
-  private object NoOpEntry : Entry {
-    override fun unregister() {}
-  }
-}

--- a/samples/counter/apps/build.gradle.kts
+++ b/samples/counter/apps/build.gradle.kts
@@ -1,6 +1,5 @@
 // Copyright (C) 2022 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
-import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {

--- a/samples/counter/apps/build.gradle.kts
+++ b/samples/counter/apps/build.gradle.kts
@@ -58,11 +58,12 @@ kotlin {
         implementation(libs.androidx.compose.integration.materialThemeAdapter)
         implementation(libs.androidx.compose.material.icons)
         implementation(libs.androidx.compose.accompanist.systemUi)
+        implementation(libs.androidx.compose.ui.tooling)
       }
     }
     wasmJsMain {
       dependencies {
-        @OptIn(ExperimentalComposeLibrary::class) implementation(compose.components.resources)
+        implementation(compose.components.resources)
         implementation(compose.ui)
         implementation(compose.runtime)
       }

--- a/samples/star/coil-rule/src/commonMain/kotlin/com/slack/circuit/sample/coil/test/FakeImageLoader.kt
+++ b/samples/star/coil-rule/src/commonMain/kotlin/com/slack/circuit/sample/coil/test/FakeImageLoader.kt
@@ -4,7 +4,6 @@ package com.slack.circuit.sample.coil.test
 
 import coil3.ComponentRegistry
 import coil3.ImageLoader
-import coil3.annotation.ExperimentalCoilApi
 import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
 import coil3.request.Disposable
@@ -20,7 +19,6 @@ import kotlinx.coroutines.CompletableDeferred
  *
  * This delegates everything to a backing [FakeImageLoaderEngine] that intercepts all calls.
  */
-@OptIn(ExperimentalCoilApi::class)
 internal class FakeImageLoader(engine: FakeImageLoaderEngine) : ImageLoader {
 
   override val defaults = Defaults.DEFAULT


### PR DESCRIPTION
Resolves #1572 along the way. This adds three new changes

- A new `CircuitPreview` composable helper that handles setting no-op locals for Circuit contents potentially contained in the previewed composable.
- Make the default `onUnavailableContent` composable check `LocalInspectionMode` and, if true, show a simpler placeholder for this UI rather than a missing route error.

Some small other cleanups along the way

<img width="455" alt="Screenshot 2024-08-12 at 2 15 20 PM" src="https://github.com/user-attachments/assets/f0cfafb9-6bb9-444d-a4cf-192505694945">
<img width="319" alt="Screenshot 2024-08-12 at 2 15 23 PM" src="https://github.com/user-attachments/assets/60e7245d-aa08-4c47-8707-3bbd91530c9b">
