### PR TITLE
Make presenter tests use distinctUntilChanged by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,9 @@ jobs:
 
       - run: brew install swiftlint
 
-      - name: Run lint on iOS samples
-        run: bundle exec fastlane ios lint
+# TODO re-enable once fastlane fixes it https://github.com/fastlane/fastlane/issues/22191
+#      - name: Run lint on iOS samples
+#        run: bundle exec fastlane ios lint
 
       - name: Run iOS Simulator tests
         id: gradle-ios-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **Behavior change**: `presenterTestOf` and `Presenter.test` have a new optional `moleculeFlowTransformer` parameter that allows for advanced filtering of the `Flow` returned out of the underlying `moleculeFlow`. By default, this now runs a `distinctUntilChanged` operator.
+
 0.23.1
 ------
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,6 @@ platform :ios do
     for project in projects
       swiftlint(
         mode: :fix,
-        path: project,
         strict: true,
         raise_if_swiftlint_error: true,
         config_file: ".swiftlint.yml"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,6 +26,7 @@ platform :ios do
     for project in projects
       swiftlint(
         mode: :fix,
+        path: project,
         strict: true,
         raise_if_swiftlint_error: true,
         config_file: ".swiftlint.yml"

--- a/samples/tacos/src/test/kotlin/com/slack/circuit/tacos/OrderTacosPresenterTest.kt
+++ b/samples/tacos/src/test/kotlin/com/slack/circuit/tacos/OrderTacosPresenterTest.kt
@@ -14,6 +14,7 @@ import com.slack.circuit.tacos.step.SummaryOrderStep
 import com.slack.circuit.tacos.step.ToppingsOrderStep
 import com.slack.circuit.test.test
 import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -125,7 +126,7 @@ class OrderTacosPresenterTest {
       val filling = Ingredient("apple")
       sink(OrderStep.UpdateOrder.SetFilling(filling))
 
-      awaitItem()
+      advanceUntilIdle()
       assertThat(details).isEqualTo(OrderDetails(filling = filling))
     }
   }


### PR DESCRIPTION
Still discussing separately if this is the right move. Alternative could be an `awaitItem(predicate: (T) -> Boolean)` extension