### PR TITLE
Add passing tonal elevation to M3 Bottom Sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 **Unreleased**
 --------------
+- **New**: Pass `tonalElevation` to `BottomSheetOverlay` so that is reflected in `ModalBottomSheet`.
 
 0.24.0
 ------

--- a/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/BottomSheetOverlay.kt
+++ b/circuitx/overlays/src/commonMain/kotlin/com/slack/circuitx/overlays/BottomSheetOverlay.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.foundation.internal.BackHandler
 import com.slack.circuit.overlay.Overlay
@@ -49,6 +50,7 @@ private constructor(
   private val onDismiss: (() -> Result)?,
   private val sheetShape: Shape?,
   private val sheetContainerColor: Color?,
+  private val tonalElevation: Dp?,
   private val dragHandle: (@Composable () -> Unit)?,
   private val skipPartiallyExpandedState: Boolean,
   private val properties: ModalBottomSheetProperties,
@@ -70,6 +72,7 @@ private constructor(
   public constructor(
     model: Model,
     sheetContainerColor: Color? = null,
+    tonalElevation: Dp? = null,
     sheetShape: Shape? = null,
     dragHandle: @Composable (() -> Unit)? = null,
     skipPartiallyExpandedState: Boolean = false,
@@ -82,6 +85,7 @@ private constructor(
     dragHandle = dragHandle,
     sheetShape = sheetShape,
     sheetContainerColor = sheetContainerColor,
+    tonalElevation = tonalElevation,
     skipPartiallyExpandedState = skipPartiallyExpandedState,
     properties =
       createBottomSheetProperties(isFocusable = isFocusable, shouldDismissOnBackPress = false),
@@ -104,6 +108,7 @@ private constructor(
     model: Model,
     onDismiss: (() -> Result),
     sheetContainerColor: Color? = null,
+    tonalElevation: Dp? = null,
     sheetShape: Shape? = null,
     dragHandle: @Composable (() -> Unit)? = null,
     skipPartiallyExpandedState: Boolean = false,
@@ -116,6 +121,7 @@ private constructor(
     dragHandle = dragHandle,
     sheetShape = sheetShape,
     sheetContainerColor = sheetContainerColor,
+    tonalElevation = tonalElevation,
     skipPartiallyExpandedState = skipPartiallyExpandedState,
     properties = properties,
     content = content,
@@ -161,6 +167,7 @@ private constructor(
       sheetState = sheetState,
       shape = sheetShape ?: RoundedCornerShape(32.dp),
       containerColor = sheetContainerColor ?: BottomSheetDefaults.ContainerColor,
+      tonalElevation = tonalElevation ?: 0.dp,
       dragHandle = dragHandle ?: { BottomSheetDefaults.DragHandle() },
       // Go edge-to-edge
       windowInsets = WindowInsets(0, 0, 0, 0),


### PR DESCRIPTION
Material 3 has the concept of a tonal elevation that can be used to introduce a tonal shift to the bottom sheet container when containerColor is ColorScheme.surface.