### PR TITLE
Change SaveableStateHolder to remove saved states of removed records

### DIFF
--- a/circuit-foundation/src/androidUnitTest/AndroidManifest.xml
+++ b/circuit-foundation/src/androidUnitTest/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <activity android:name="com.slack.circuit.foundation.NavigableCircuitRetainedStateTestActivity"/>
+        <activity android:name="com.slack.circuit.foundation.NavigableCircuitSaveableStateTestActivity"/>
         <activity android:name="com.slack.circuit.foundation.NavigableCircuitViewModelStateTestActivity"/>
     </application>
 </manifest>

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateAndroidTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateAndroidTest.kt
@@ -1,0 +1,109 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import com.slack.circuit.internal.test.TestContentTags.TAG_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_INCREASE_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(ComposeUiTestRunner::class)
+class NavigableCircuitSaveableStateAndroidTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<NavigableCircuitSaveableStateTestActivity>()
+
+  private val scenario: ActivityScenario<NavigableCircuitSaveableStateTestActivity>
+    get() = composeTestRule.activityRule.scenario
+
+  @Test
+  fun saveableStateScopedToBackstackWithRecreations() {
+    composeTestRule.run {
+      // Current: Screen A. Increase count to 1
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen C. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Pop to Screen B. Increase count from 1 to 2.
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Navigate to Screen C. Assert that it's state was not retained
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Pop to Screen B. Assert that it's state was retained
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Pop to Screen A. Assert that it's state was retained
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Assert that it's state was not retained
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+}

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateAndroidTest.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateAndroidTest.kt
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Slack Technologies, LLC
+// Copyright (C) 2025 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.foundation
 

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTestActivity.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTestActivity.kt
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.internal.test.TestCountPresenter
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.createTestCircuit
+
+class NavigableCircuitSaveableStateTestActivity : ComponentActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.Saveable)
+
+    setContent {
+      CircuitCompositionLocals(circuit) {
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+        val navigator =
+          rememberCircuitNavigator(
+            backStack = backStack,
+            onRootPop = {}, // no-op for tests
+          )
+        NavigableCircuitContent(navigator = navigator, backStack = backStack)
+      }
+    }
+  }
+}

--- a/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTestActivity.kt
+++ b/circuit-foundation/src/androidUnitTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTestActivity.kt
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Slack Technologies, LLC
+// Copyright (C) 2025 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.foundation
 

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.foundation
 
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -17,6 +20,7 @@ import com.slack.circuit.internal.test.TestContentTags.TAG_RESET_ROOT_BETA
 import com.slack.circuit.internal.test.TestCountPresenter
 import com.slack.circuit.internal.test.TestScreen
 import com.slack.circuit.internal.test.createTestCircuit
+import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,17 +30,17 @@ class NavigableCircuitSaveableStateTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  @Test fun saveableStateScopedToBackstackWithKeys() = saveableStateScopedToBackstack(true)
-
-  @Test fun saveableStateScopedToBackstackWithoutKeys() = saveableStateScopedToBackstack(false)
-
-  @Test
-  fun saveableStateScopedToBackstackResetRootsWithKeys() =
-    saveableStateScopedToBackstackResetRoots(true)
-
-  @Test
-  fun saveableStateScopedToBackstackResetRootsWithoutKeys() =
-    saveableStateScopedToBackstackResetRoots(false)
+  //  @Test fun saveableStateScopedToBackstackWithKeys() = saveableStateScopedToBackstack(true)
+  //
+  //  @Test fun saveableStateScopedToBackstackWithoutKeys() = saveableStateScopedToBackstack(false)
+  //
+  //  @Test
+  //  fun saveableStateScopedToBackstackResetRootsWithKeys() =
+  //    saveableStateScopedToBackstackResetRoots(true)
+  //
+  //  @Test
+  //  fun saveableStateScopedToBackstackResetRootsWithoutKeys() =
+  //    saveableStateScopedToBackstackResetRoots(false)
 
   private fun saveableStateScopedToBackstack(useKeys: Boolean) {
     composeTestRule.run {
@@ -206,6 +210,61 @@ class NavigableCircuitSaveableStateTest {
       // Root Beta should now be active. The top record for Root Beta  is Screen A: (count: 2)
       onNodeWithTag(TAG_LABEL).assertTextEquals("A")
       onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+    }
+  }
+
+  @Test
+  fun saveableStateClearRemovedRecordStates() {
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.Saveable)
+    val saveableStateRegistry = SaveableStateRegistry(emptyMap(), { true })
+    composeTestRule.setContent {
+      CircuitCompositionLocals(circuit) {
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+        val navigator = rememberCircuitNavigator(backStack = backStack)
+        CompositionLocalProvider(LocalSaveableStateRegistry provides saveableStateRegistry) {
+          NavigableCircuitContent(navigator = navigator, backStack = backStack)
+        }
+      }
+    }
+
+    fun areStructuresEqual(obj1: Any?, obj2: Any?): Boolean =
+      when {
+        obj1 == null && obj2 == null -> true
+        obj1 == null || obj2 == null -> false
+        obj1 is Map<*, *> && obj2 is Map<*, *> ->
+          obj1.keys.size == obj2.keys.size &&
+            obj1.entries.indices.all { i ->
+              val value1 = obj1.entries.elementAt(i).value
+              val value2 = obj2.entries.elementAt(i).value
+              areStructuresEqual(value1, value2)
+            }
+
+        obj1 is List<*> && obj2 is List<*> ->
+          obj1.size == obj2.size && obj1.indices.all { i -> areStructuresEqual(obj1[i], obj2[i]) }
+
+        obj1::class != obj2::class -> false
+        else -> true
+      }
+
+    composeTestRule.run {
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+
+      // Navigate to Screen B
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      // Pop to Screen A
+      onNodeWithTag(TAG_POP).performClick()
+
+      val savedStates1 = saveableStateRegistry.performSave()
+
+      // Navigate to Screen B
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      // Pop to Screen A
+      onNodeWithTag(TAG_POP).performClick()
+
+      val savedStates2 = saveableStateRegistry.performSave()
+      assertTrue(areStructuresEqual(savedStates1, savedStates2))
     }
   }
 }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/NavigableCircuitSaveableStateTest.kt
@@ -30,17 +30,17 @@ class NavigableCircuitSaveableStateTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  //  @Test fun saveableStateScopedToBackstackWithKeys() = saveableStateScopedToBackstack(true)
-  //
-  //  @Test fun saveableStateScopedToBackstackWithoutKeys() = saveableStateScopedToBackstack(false)
-  //
-  //  @Test
-  //  fun saveableStateScopedToBackstackResetRootsWithKeys() =
-  //    saveableStateScopedToBackstackResetRoots(true)
-  //
-  //  @Test
-  //  fun saveableStateScopedToBackstackResetRootsWithoutKeys() =
-  //    saveableStateScopedToBackstackResetRoots(false)
+  @Test fun saveableStateScopedToBackstackWithKeys() = saveableStateScopedToBackstack(true)
+
+  @Test fun saveableStateScopedToBackstackWithoutKeys() = saveableStateScopedToBackstack(false)
+
+  @Test
+  fun saveableStateScopedToBackstackResetRootsWithKeys() =
+    saveableStateScopedToBackstackResetRoots(true)
+
+  @Test
+  fun saveableStateScopedToBackstackResetRootsWithoutKeys() =
+    saveableStateScopedToBackstackResetRoots(false)
 
   private fun saveableStateScopedToBackstack(useKeys: Boolean) {
     composeTestRule.run {
@@ -220,7 +220,11 @@ class NavigableCircuitSaveableStateTest {
     composeTestRule.setContent {
       CircuitCompositionLocals(circuit) {
         val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
-        val navigator = rememberCircuitNavigator(backStack = backStack)
+        val navigator =
+          rememberCircuitNavigator(
+            backStack = backStack,
+            onRootPop = {}, // no-op for tests
+          )
         CompositionLocalProvider(LocalSaveableStateRegistry provides saveableStateRegistry) {
           NavigableCircuitContent(navigator = navigator, backStack = backStack)
         }


### PR DESCRIPTION
As described in #1895, `NavigableCircuitContent` internally uses `SaveableStateHolder` to store and restore saveableState when a record changes. However, there is an unintended issue where the state persists even for popped records.

In this change, a `DisposableEffect` has been added after rendering the contents of `SaveableStateHolder`. This ensures that when a specific record is removed, removeState is called before the values are saved within `SaveableStateHolder`, preventing unintended state retention.

Fixes #1895

