### PR TITLE
Fix value restoration after `removeState` call in `RetainedStateHolder`

### DIFF
--- a/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedStateHolderTest.kt
+++ b/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedStateHolderTest.kt
@@ -33,6 +33,7 @@ import com.slack.circuit.retained.RetainedStateHolder
 import com.slack.circuit.retained.RetainedStateRegistry
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.retained.rememberRetainedStateHolder
+import kotlin.random.Random
 import leakcanary.DetectLeaksAfterTestSuccess.Companion.detectLeaksAfterTestSuccessWrapping
 import org.junit.Rule
 import org.junit.Test
@@ -305,7 +306,7 @@ class RetainedStateHolderTest {
       }
     }
 
-    composeTestRule.runOnIdle { showFirstPage = false }
+    showFirstPage = false
 
     composeTestRule.runOnIdle {
       val savedData = registry.saveAll()
@@ -315,6 +316,35 @@ class RetainedStateHolderTest {
 
   @Test
   fun saveNothingWhenCanRetainCheckerReturnsFalse() {
+    var showFirstPage by mutableStateOf(true)
+    val registry = RetainedStateRegistry(emptyMap())
+    val canRetainChecker = CanRetainChecker { false }
+    composeTestRule.setContent {
+      CompositionLocalProvider(LocalRetainedStateRegistry provides registry) {
+        val holder = rememberRetainedStateHolder()
+        CompositionLocalProvider(LocalCanRetainChecker provides canRetainChecker) {
+          holder.RetainedStateProvider(showFirstPage.toString()) {
+            rememberRetained { Random.nextInt() }
+          }
+        }
+      }
+    }
+
+    composeTestRule.runOnIdle {
+      val savedData = registry.saveAll()
+      assertThat(savedData).isEqualTo(emptyMap<String, List<Any?>>())
+    }
+
+    showFirstPage = false
+
+    composeTestRule.runOnIdle {
+      val savedData = registry.saveAll()
+      assertThat(savedData).isEqualTo(emptyMap<String, List<Any?>>())
+    }
+  }
+
+  @Test
+  fun alwaysReinitializeWhenCanRetainCheckerReturnsFalse() {
     var increment = 0
     var restorableNumber = -1
     val registry = RetainedStateRegistry(emptyMap())
@@ -351,7 +381,12 @@ class RetainedStateHolderTest {
     composeTestRule.waitForIdle()
     screen = Screens.Screen1
 
-    composeTestRule.runOnIdle { assertThat(restorableNumber).isEqualTo(2) }
+    composeTestRule.runOnIdle {
+      assertThat(restorableNumber).isEqualTo(2)
+
+      val savedData = registry.saveAll()
+      assertThat(savedData).isEqualTo(emptyMap<String, List<Any?>>())
+    }
   }
 
   @Test
@@ -396,6 +431,13 @@ class RetainedStateHolderTest {
     screen = Screens.Screen1
 
     composeTestRule.runOnIdle { assertThat(restorableNumber).isEqualTo(1) }
+
+    canRetainChecker = CanRetainChecker { false }
+
+    composeTestRule.runOnIdle {
+      val savedData = registry.saveAll()
+      assertThat(savedData).isEqualTo(emptyMap<String, List<Any?>>())
+    }
   }
 
   class Activity : ComponentActivity() {

--- a/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedStateHolderTest.kt
+++ b/circuit-retained/src/androidInstrumentedTest/kotlin/com/slack/circuit/retained/android/RetainedStateHolderTest.kt
@@ -440,6 +440,31 @@ class RetainedStateHolderTest {
     }
   }
 
+  @Test
+  fun removedStateShouldNotBeRestored() {
+    var increment = 0
+    val screen = Screens.Screen1
+    var restorableStateHolder: RetainedStateHolder? = null
+    var restorableNumberOnScreen1 = -1
+    restorationTester.setContent {
+      val holder = rememberRetainedStateHolder()
+      restorableStateHolder = holder
+      holder.RetainedStateProvider(screen.name) {
+        restorableNumberOnScreen1 = rememberRetained { increment++ }
+      }
+    }
+
+    composeTestRule.runOnIdle {
+      assertThat(restorableNumberOnScreen1).isEqualTo(0)
+      restorableNumberOnScreen1 = -1
+      restorableStateHolder!!.removeState(screen.name)
+    }
+
+    restorationTester.emulateRetainedInstanceStateRestore()
+
+    composeTestRule.runOnIdle { assertThat(restorableNumberOnScreen1).isEqualTo(1) }
+  }
+
   class Activity : ComponentActivity() {
     fun doFakeSave() {
       onSaveInstanceState(Bundle())


### PR DESCRIPTION
I discovered an issue while running additional tests with `RetainedStateHolder` where the handling was incorrect.

```kotlin
@Test
fun removedStateShouldNotBeRestored() {
  var increment = 0
  val screen = Screens.Screen1
  var restorableStateHolder: RetainedStateHolder? = null
  var restorableNumberOnScreen1 = -1
  restorationTester.setContent {
    val holder = rememberRetainedStateHolder()
    restorableStateHolder = holder
    holder.RetainedStateProvider(screen.name) {
      restorableNumberOnScreen1 = rememberRetained { increment++ }
    }
  }

  composeTestRule.runOnIdle {
    assertThat(restorableNumberOnScreen1).isEqualTo(0)
    restorableNumberOnScreen1 = -1
    restorableStateHolder!!.removeState(screen.name)
  }

  restorationTester.emulateRetainedInstanceStateRestore()

  composeTestRule.runOnIdle { assertThat(restorableNumberOnScreen1).isEqualTo(1) }
}
```

In this test scenario, the `RetainedStateHolder` holds a child `RetainedStateRegistry` for Screen1. Since `removeState` is called, the corresponding `Entry.shouldSave` is set to false, preventing a call to `saveValue` in the subsequent `DisposableEffect`.

#### RetainedStateHolder.kt (before fix)
```kotlin
@Composable
override fun RetainedStateProvider(key: String, content: @Composable (() -> Unit)) {
  CompositionLocalProvider(LocalRetainedStateRegistry provides registry) {
    ReusableContent(key) {
      val entry = remember { Entry() }
      val childRegistry = rememberRetained(key = key) { RetainedStateRegistry() }
      CompositionLocalProvider(
        LocalRetainedStateRegistry provides childRegistry,
        LocalCanRetainChecker provides CanRetainChecker.Always,
        content = content,
      )
      DisposableEffect(Unit) {
        entries[key] = entry
        onDispose {
          if (entry.shouldSave) {
            registry.saveValue(key)
          }
          entries -= key
        }
      }
    }
  }
}
```

However, when the parent’s overall `RetainedStateRegistry.saveAll()` is invoked, the childRegistry—lacking a specifically set `LocalCanRetainChecker`—does not consider the `Entry.shouldSave` flag and ends up saving the value.

To fix this, I modified the code to provide a `LocalCanRetainChecker` for the childRegistry. Additionally, I have added few test logics for `RetainedStateHolder`.

I wish this had been handled better in #1794; sorry for the hassle, and please take a look when you have time!