### PR TITLE
Fix crash on right side back gesture

### DIFF
--- a/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
+++ b/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
@@ -47,6 +47,7 @@ import com.slack.circuit.foundation.NavigatorDefaults
 import com.slack.circuit.runtime.InternalCircuitApi
 import com.slack.circuit.runtime.internal.rememberStableCoroutineScope
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
+import kotlin.math.abs
 import kotlin.math.absoluteValue
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
@@ -117,7 +118,7 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(
         snapshotFlow { swipeProgress }
           .collect { progress ->
             if (progress != 0f) {
-              seekableTransitionState.seekTo(fraction = progress, targetState = previous)
+              seekableTransitionState.seekTo(fraction = abs(progress), targetState = previous)
             }
           }
       }


### PR DESCRIPTION
- Fixes #1927
- Missed that the `BackHandler` in `AndroidPredictiveBackNavigationDecoration` indicates the swipe edge with a positive/negative value 


https://github.com/user-attachments/assets/41e5ada1-9f5d-44be-8d96-113cb4ec74e2

