### PR TITLE
[FIXED] 404 errors for video demo and css files

### DIFF
--- a/docs/shared-elements-tutorial.md
+++ b/docs/shared-elements-tutorial.md
@@ -176,7 +176,7 @@ The call to `requireAnimatedScope` is accessing a `AnimatedVisibilityScope` that
 
 === "Android"
     <div markdown>
-    <video style="float: left; margin-right: 0.8em;" width="400" controls="true" autoplay="true" loop="true" src="/videos/shared-elements-tutorial-step-4.mp4" ></video>
+    <video style="float: left; margin-right: 0.8em;" width="400" controls="true" autoplay="true" loop="true" src="../videos/shared-elements-tutorial-step-4.mp4" ></video>
 
     With that we now have a shared element transition where the sender image transitions across the two screens!
     </div>
@@ -244,7 +244,7 @@ Text(
 === "Android"
     <div markdown>
 
-    <video style="float: left; margin-right: 0.8em;" width="400" controls="true" autoplay="true" loop="true" src="/videos/shared-elements-tutorial-step-5.mp4" ></video>
+    <video style="float: left; margin-right: 0.8em;" width="400" controls="true" autoplay="true" loop="true" src="../videos/shared-elements-tutorial-step-5.mp4" ></video>
 
     After the `Modifier.sharedBounds()` is added to each of the three `Text` in the `EmailItem` composable and the `EmailDetailContent` composable you should now see the majority of the email tranistioning across the two `Screens`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,6 @@ theme:
     - content.code.copy
     - content.code.select
 
-extra_css:
-  - 'css/app.css'
-
 markdown_extensions:
   - smarty
   - codehilite:


### PR DESCRIPTION
## Summary
Some video URLs were broken because of how GitHub pages base URL uses the project name `circuit`.

* Currently used: https://slackhq.github.io/videos/shared-elements-tutorial-step-5.mp4
* Correct Path: https://slackhq.github.io/circuit/videos/shared-elements-tutorial-step-5.mp4

I used relative path instead to keep it simple and align with other usages.

📖 Affected page: https://slackhq.github.io/circuit/shared-elements-tutorial/


## Fixes

<img width="1495" alt="Screenshot 2025-02-14 at 9 02 26 AM" src="https://github.com/user-attachments/assets/0f2364df-99e3-44a7-a96d-99ab4ecb0403" />
