### PR TITLE
Always name parameters in code gen

### DIFF
--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -303,13 +303,7 @@ private class CircuitSymbolProcessor(
             FactoryType.UI
           }
         val assistedParams =
-          fd.assistedParameters(
-            symbols,
-            logger,
-            screenKSType,
-            factoryType == FactoryType.PRESENTER,
-            includeParameterNames = codegenMode != KOTLIN_INJECT_ANVIL,
-          )
+          fd.assistedParameters(symbols, logger, screenKSType, factoryType == FactoryType.PRESENTER)
         codeBlock =
           when (factoryType) {
             FactoryType.PRESENTER ->
@@ -476,7 +470,6 @@ private class CircuitSymbolProcessor(
               logger,
               screenKSType,
               allowNavigator = factoryType == FactoryType.PRESENTER,
-              includeParameterNames = codegenMode != KOTLIN_INJECT_ANVIL,
             )
           }
         codeBlock =
@@ -548,7 +541,6 @@ private fun KSFunctionDeclaration.assistedParameters(
   logger: KSPLogger,
   screenType: KSType,
   allowNavigator: Boolean,
-  includeParameterNames: Boolean,
 ): CodeBlock {
   return buildSet {
       for (param in parameters) {
@@ -583,15 +575,7 @@ private fun KSFunctionDeclaration.assistedParameters(
       }
     }
     .toList()
-    .map {
-      val prefix =
-        if (includeParameterNames) {
-          "${it.name} = "
-        } else {
-          ""
-        }
-      CodeBlock.of("$prefix${it.factoryName}")
-    }
+    .map { CodeBlock.of("${it.name} = ${it.factoryName}") }
     .joinToCode(",·")
 }
 

--- a/circuit-codegen/src/test/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorTest.kt
+++ b/circuit-codegen/src/test/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorTest.kt
@@ -1344,10 +1344,10 @@ class CircuitSymbolProcessorTest {
           import androidx.compose.ui.Modifier
 
           data object Static : StaticScreen
-          
+
           @CircuitInject(Static::class, AppScope::class)
           @Composable
-          fun StaticUi(screen: Static, modifier: Modifier) {} 
+          fun StaticUi(screen: Static, modifier: Modifier) {}
         """
             .trimIndent(),
         ),
@@ -1355,7 +1355,7 @@ class CircuitSymbolProcessorTest {
       expectedContent =
         """
         package test
-        
+
         import com.slack.circuit.runtime.CircuitContext
         import com.slack.circuit.runtime.CircuitUiState
         import com.slack.circuit.runtime.screen.Screen
@@ -1363,7 +1363,7 @@ class CircuitSymbolProcessorTest {
         import com.slack.circuit.runtime.ui.ui
         import com.squareup.anvil.annotations.ContributesMultibinding
         import javax.inject.Inject
-        
+
         @ContributesMultibinding(AppScope::class)
         public class StaticUiFactory @Inject constructor() : Ui.Factory {
           override fun create(screen: Screen, context: CircuitContext): Ui<*>? = when (screen) {


### PR DESCRIPTION
Avoids any potential issues. Resolves #1704