### PR TITLE
[Docs] Decouple Screen class from State class in the docs example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,9 @@ There’s some glue code missing from this example that's covered in the [Code G
 
 ```kotlin
 @Parcelize
-data object CounterScreen : Screen {
+data object CounterScreen : Screen
+
+data object CounterCircuit {
   data class CounterState(
     val count: Int,
     val eventSink: (CounterEvent) -> Unit,


### PR DESCRIPTION
I'd like to propose decoupling the Screen from State in the
intro docs section to suggest a better pattern.

The Screen is kind of an API that should be exposed, allowing
other code to navigate to it, but the State is internal to the
Presenter and the Ui, so this updates the docs to not nest
the State under the Screen as they are independent.