### PR TITLE
fix(gesture-navigation): hide material dependency as an implementation detail

### DIFF
--- a/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/CupertinoGestureNavigationDecorator.kt
+++ b/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/CupertinoGestureNavigationDecorator.kt
@@ -1,7 +1,6 @@
 // Copyright (C) 2023 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
 @file:Suppress("DEPRECATION") // TODO migrate!
-@file:OptIn(ExperimentalMaterialApi::class)
 
 package com.slack.circuitx.gesturenavigation
 
@@ -69,6 +68,7 @@ import kotlinx.coroutines.flow.filter
  *   navigation. This is useless when you have full width horizontally scrolling layouts. Defaults
  *   to true.
  */
+@ExperimentalMaterialApi
 internal class CupertinoGestureNavigationDecorator<T : NavArgument>(
   private val enterOffsetFraction: Float = 0.25f,
   private val swipeThreshold: ThresholdConfig = FractionalThreshold(0.4f),


### PR DESCRIPTION
See https://github.com/slackhq/circuit/issues/2017