### PR TITLE
Better `BackHandler` guarding of root pops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ would only retain if the Activity was in a configuration change.
 - Update to Kotlin `2.1.21`.
 - Build against KSP `2.1.21-2.0.1`.
 - Fix not being able to provide a custom ViewModel to `continuityRetainedStateRegistry()`
+- Fix `rememberCircuitNavigator` and `rememberInterceptingNavigator` replaying a root pop at the same screen
 
 0.28.0
 ------

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -66,10 +66,8 @@ public fun rememberCircuitNavigator(
       val screen = navigator.peek()
       if (screen != null && screen != lastScreen) {
         lastScreen = screen
-        true
-      } else {
-        false
       }
+      lastScreen
     }
   }
   var hasPendingRootPop by remember(hasScreenChanged) { mutableStateOf(false) }

--- a/circuitx/navigation/build.gradle.kts
+++ b/circuitx/navigation/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
     }
     commonTest {
       dependencies {
+        implementation(libs.androidx.lifecycle.runtime.compose.jb)
         implementation(libs.coroutines.test)
         implementation(libs.kotlin.test)
         implementation(libs.molecule.runtime)

--- a/circuitx/navigation/src/commonMain/kotlin/com/slack/circuitx/navigation/intercepting/InterceptingNavigator.kt
+++ b/circuitx/navigation/src/commonMain/kotlin/com/slack/circuitx/navigation/intercepting/InterceptingNavigator.kt
@@ -61,10 +61,8 @@ public fun rememberInterceptingNavigator(
         val screen = navigator.peek()
         if (screen != null && screen != lastScreen) {
           lastScreen = screen
-          true
-        } else {
-          false
         }
+        lastScreen
       }
     }
     var hasPendingRootPop by remember(hasScreenChanged) { mutableStateOf(false) }

--- a/circuitx/navigation/src/commonMain/kotlin/com/slack/circuitx/navigation/intercepting/InterceptingNavigator.kt
+++ b/circuitx/navigation/src/commonMain/kotlin/com/slack/circuitx/navigation/intercepting/InterceptingNavigator.kt
@@ -52,8 +52,9 @@ public fun rememberInterceptingNavigator(
     }
   // Handle the back button here to get pop events from it.
   if (enableBackHandler) {
-    var trigger by remember { mutableStateOf(false) }
-    BackHandler(!trigger) {
+    var hasPendingRootPop by remember(navigator.peek()) { mutableStateOf(false) }
+    var enableRootBackHandler by remember(navigator.peek()) { mutableStateOf(true) }
+    BackHandler(enableRootBackHandler) {
       // Root pop check to prevent an infinite loop if this is used with the Android variant of
       // rememberCircuitNavigator as that calls `OnBackPressedDispatcher.onBackPressed`. We need to
       // unload this BackHandler from the composition before the root pop is triggered, so delay
@@ -61,13 +62,14 @@ public fun rememberInterceptingNavigator(
       if (navigator.peekBackStack().size > 1) {
         interceptingNavigator.pop()
       } else {
-        trigger = true
+        hasPendingRootPop = true
+        enableRootBackHandler = false
       }
     }
-    if (trigger) {
+    if (hasPendingRootPop) {
       SideEffect {
         interceptingNavigator.pop()
-        trigger = false
+        hasPendingRootPop = false
       }
     }
   }

--- a/circuitx/navigation/src/jvmTest/kotlin/com/slack/circuitx/navigation/intercepting/NavigatorBackHandlerTest.kt
+++ b/circuitx/navigation/src/jvmTest/kotlin/com/slack/circuitx/navigation/intercepting/NavigatorBackHandlerTest.kt
@@ -1,0 +1,139 @@
+// Copyright (C) 2025 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuitx.navigation.intercepting
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.backhandler.BackGestureDispatcher
+import androidx.compose.ui.backhandler.BackHandler
+import androidx.compose.ui.backhandler.LocalBackGestureDispatcher
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.CircuitCompositionLocals
+import com.slack.circuit.foundation.NavigableCircuitContent
+import com.slack.circuit.foundation.rememberCircuitNavigator
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestCountPresenter
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.createTestCircuit
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.popRoot
+import kotlin.test.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class NavigatorBackHandlerTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @OptIn(ExperimentalComposeUiApi::class)
+  @Test
+  fun nestedNavigatorRootPopBackHandler() {
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.Standard)
+    var outerBackCount = 0
+    lateinit var navigator: Navigator
+    composeTestRule.setContent {
+      @Suppress("DEPRECATION")
+      CompositionLocalProvider(
+        LocalBackGestureDispatcher provides BackDispatcher,
+        LocalLifecycleOwner provides StartedLifecycleOwner,
+      ) {
+        CircuitCompositionLocals(circuit) {
+          BackHandler(enabled = true) { outerBackCount++ }
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+          val circuitNavigator =
+            rememberCircuitNavigator(
+              backStack = backStack,
+              onRootPop = { BackDispatcher.onBack() },
+              enableBackHandler = true,
+            )
+          navigator = rememberInterceptingNavigator(circuitNavigator)
+          NavigableCircuitContent(navigator = navigator, backStack = backStack)
+        }
+      }
+    }
+    composeTestRule.run {
+      // Navigate to Screen B
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      // Navigate to Screen C
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      // Pop through the onRootPop into the back handler
+      navigator.popRoot()
+      waitForIdle()
+      assertEquals(1, outerBackCount)
+    }
+  }
+
+  @OptIn(ExperimentalComposeUiApi::class)
+  @Test
+  fun nestedNavigatorRootDispatchedBackHandler() {
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.Standard)
+    var outerBackCount = 0
+    lateinit var navigator: Navigator
+    composeTestRule.setContent {
+      CompositionLocalProvider(
+        LocalBackGestureDispatcher provides BackDispatcher,
+        LocalLifecycleOwner provides StartedLifecycleOwner,
+      ) {
+        CircuitCompositionLocals(circuit) {
+          BackHandler(enabled = true) { outerBackCount++ }
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+          val circuitNavigator =
+            rememberCircuitNavigator(
+              backStack = backStack,
+              onRootPop = { BackDispatcher.onBack() },
+              enableBackHandler = true,
+            )
+          navigator = rememberInterceptingNavigator(circuitNavigator)
+          NavigableCircuitContent(navigator = navigator, backStack = backStack)
+        }
+      }
+    }
+    composeTestRule.run {
+      // Navigate to Screen B
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      // Navigate to Screen C
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      // Back through the onRootPop into the back handler
+      BackDispatcher.onBack()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      BackDispatcher.onBack()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      BackDispatcher.onBack()
+      waitForIdle()
+      assertEquals(1, outerBackCount)
+    }
+  }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private val BackDispatcher =
+  object : BackGestureDispatcher() {
+
+    fun onBack() {
+      activeListener?.onStarted()
+      activeListener?.onCompleted()
+    }
+  }
+
+private val StartedLifecycleOwner =
+  object : Lifecycle(), LifecycleOwner {
+    override val lifecycle: Lifecycle = this
+    override val currentState: State = State.STARTED
+
+    override fun addObserver(observer: LifecycleObserver) = Unit
+
+    override fun removeObserver(observer: LifecycleObserver) = Unit
+  }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ androidx-annotation = "1.9.1"
 androidx-appcompat = "1.7.1"
 androidx-browser = "1.8.0"
 androidx-lifecycle = "2.9.1"
+androidx-lifecycle-jb = "2.9.0"
 agp = "8.10.1"
 anvil = "0.4.1"
 atomicfu = "0.27.0"
@@ -126,6 +127,7 @@ androidx-core = "androidx.core:core-ktx:1.16.0"
 
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
+androidx-lifecycle-runtime-compose-jb = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle-jb" }
 androidx-lifecycle-viewModel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewModel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 # Force a newer version of androidx.loader because Espresso depends on an old and wrong version of it


### PR DESCRIPTION
- Only fire the root pop in the navigators `BackHandler` once, and then reset the trigger if the root screen changes