### PR TITLE
Handle duplicate IDs in animal bios

### DIFF
--- a/samples/star/src/commonMain/sqldelight/com/slack/circuit/star/db/star.sq
+++ b/samples/star/src/commonMain/sqldelight/com/slack/circuit/star/db/star.sq
@@ -52,7 +52,7 @@ deleteAllBios:
 DELETE FROM animalBio;
 
 putAnimalBio:
-INSERT INTO animalBio
+INSERT OR REPLACE INTO animalBio
 VALUES ?;
 
 deleteAllAnimals:


### PR DESCRIPTION
Looks like the petfinder API reuses these quickly