### PR TITLE
Add support for CircuitContext in CodeGen

### DIFF
--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -589,6 +589,9 @@ private fun KSFunctionDeclaration.assistedParameters(
               )
             }
           }
+          type.isInstanceOf(symbols.circuitContext) -> {
+            addOrError(AssistedType("context", type.toTypeName(), param.name!!.getShortName()))
+          }
         }
       }
     }

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbols.kt
@@ -10,6 +10,7 @@ internal class CircuitSymbols private constructor(resolver: Resolver) {
   val circuitUiState = resolver.loadKSType(CircuitNames.CIRCUIT_UI_STATE.canonicalName)
   val screen = resolver.loadKSType(CircuitNames.SCREEN.canonicalName)
   val navigator = resolver.loadKSType(CircuitNames.NAVIGATOR.canonicalName)
+  val circuitContext = resolver.loadKSType(CircuitNames.CIRCUIT_CONTEXT.canonicalName)
 
   private fun Resolver.loadKSType(name: String): KSType =
     loadOptionalKSType(name) ?: error("Could not find $name in classpath")


### PR DESCRIPTION
Codegen was missing the necessary support for generating the factory code for CircuitContext.

- This PR adds CircuitContext as a circuit Symbol
- Adds support for the symbol processor to add circuit context as a parameter to the autogenerated code.