### PR TITLE
Bump local emulator running to match Star min sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
         id: gradle-instrumentation-fork
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          # Use API 28 for star samples
-          api-level: 28
+          # Use API 30 for star samples
+          api-level: 30
           arch: x86_64
           disable-animations: true
           disk-size: 6000M


### PR DESCRIPTION
Looks like this is failing [here](https://github.com/slackhq/circuit/actions/runs/16577776251/job/46903588513?pr=2104) so updating to match the star minSdk
<img width="513" height="340" alt="Screenshot 2025-07-28 at 18 53 23" src="https://github.com/user-attachments/assets/2c449712-ecae-40c3-b61f-868ee6884b30" />
 https://github.com/slackhq/circuit/blob/66677694c8cf4ddc652da42ccde2999c1c924465/samples/star/apk/build.gradle.kts#L11-L13