### PR TITLE
Fix minor typo in setup doc

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,7 +46,7 @@ Circuit is split into a few different artifacts to allow for more granular contr
 | `circuit-runtime`           | Common runtime components like `Screen`, `Navigator`, etc.                                       |
 | `circuit-runtime-presenter` | The `Presenter` API, depends on `circuit-runtime`.                                               |
 | `circuit-runtime-ui`        | The `Ui` API, depends on `circuit-runtime`.                                                      |
-| `circuit-foundation`        | The Circuit foundational APIs like `Circuit`, `CircuitContent`, etc. Depends on the first three. |
+| `circuit-foundation`        | The Circuit foundational APIs like `Circuit`, `CircuitContent`, etc. Depends on the first four. |
 | `circuit-test`              | First-party test APIs for testing navigation, state emissions, and event sinks.                  |
 | `circuit-overlay`           | Optional `Overlay` APIs.                                                                         |
 | `circuit-retained`          | Optional `rememberRetained()` APIs.                                                              |


### PR DESCRIPTION
There are 4 now.

<img width="625" height="348" alt="image" src="https://github.com/user-attachments/assets/b4c70854-6cd7-4143-bef4-fd3c45a99c95" />
