### PR TITLE
Revert "chore(deps): update dependency ruby to v3.4.6"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: '3.4.6'
+          ruby-version: '3.2.2'
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
Reverts slackhq/circuit#2329

Fastlane doesn't support this yet (yay max versions) and fails the iOS build