### PR TITLE
Fix `onNavEvent` not passing along all arguments to reset root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This new decorator uses the Compose multiplatform `PredictiveBackHandler` to dri
 
 - Switched Compose uses to depend on Compose Multiplatform over Jetpack Compose
 - Android minimum SDK is now `minSdk` 23
+- Fixed `Navigator.onNavEvent()` not passing all arguments to `resetRoot()`
 - Update Compose Multiplatform to `1.9.0`.
 - Update to Kotlin `2.2.20`.
 - Update to Molecule `2.2.0`.

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavEvent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavEvent.kt
@@ -16,7 +16,12 @@ public fun Navigator.onNavEvent(event: NavEvent) {
   when (event) {
     is NavEvent.Pop -> pop(event.result)
     is NavEvent.GoTo -> goTo(event.screen)
-    is NavEvent.ResetRoot -> resetRoot(event.newRoot)
+    is NavEvent.ResetRoot ->
+      resetRoot(
+        newRoot = event.newRoot,
+        saveState = event.saveState,
+        restoreState = event.restoreState,
+      )
   }
 }
 

--- a/circuit-foundation/src/commonTest/kotlin/com/slack/circuit/foundation/NavEventTest.kt
+++ b/circuit-foundation/src/commonTest/kotlin/com/slack/circuit/foundation/NavEventTest.kt
@@ -1,0 +1,65 @@
+package com.slack.circuit.foundation
+
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.screen.PopResult
+import com.slack.circuit.runtime.screen.Screen
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NavEventTest {
+
+  @Test
+  fun onNavEvent_pop_callsNavigatorPop() {
+    val navigator = FakeNavigator()
+    navigator.onNavEvent(NavEvent.Pop(TestPopResult))
+    assertEquals(TestPopResult, navigator.lastPopResult)
+  }
+
+  @Test
+  fun onNavEvent_goTo_callsNavigatorGoTo() {
+    val navigator = FakeNavigator()
+    navigator.onNavEvent(NavEvent.GoTo(TestScreen))
+    assertEquals(TestScreen, navigator.lastGoToScreen)
+  }
+
+  @Test
+  fun onNavEvent_resetRoot_callsNavigatorResetRoot() {
+    val navigator = FakeNavigator()
+    navigator.onNavEvent(
+      NavEvent.ResetRoot(newRoot = TestScreen, saveState = true, restoreState = false)
+    )
+    assertEquals(TestScreen, navigator.lastResetRootScreen)
+    assertTrue(navigator.lastResetRootSaveState)
+    assertTrue(!navigator.lastResetRootRestoreState)
+  }
+}
+
+private class FakeNavigator : Navigator {
+  var lastGoToScreen: Screen? = null
+  var lastPopResult: PopResult? = null
+  var lastResetRootScreen: Screen? = null
+  var lastResetRootSaveState: Boolean = false
+  var lastResetRootRestoreState: Boolean = false
+
+  override fun goTo(screen: Screen): Boolean {
+    lastGoToScreen = screen
+    return true
+  }
+
+  override fun pop(result: PopResult?): Screen? {
+    lastPopResult = result
+    return null
+  }
+
+  override fun resetRoot(newRoot: Screen, saveState: Boolean, restoreState: Boolean): List<Screen> {
+    lastResetRootScreen = newRoot
+    lastResetRootSaveState = saveState
+    lastResetRootRestoreState = restoreState
+    return emptyList()
+  }
+
+  override fun peek() = TODO("Not implemented")
+
+  override fun peekBackStack() = TODO("Not implemented")
+}


### PR DESCRIPTION
Easy fix, easy to miss too so added a test to cover it