### PR TITLE
Fixes for `rememberCircuitNavigator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This new decorator uses the Compose multiplatform `PredictiveBackHandler` to dri
 - Switched Compose uses to depend on Compose Multiplatform over Jetpack Compose
 - Android minimum SDK is now `minSdk` 23
 - Fixed `Navigator.onNavEvent()` not passing all arguments to `resetRoot()`
+- Fixes to `rememberCircuitNavigator()` capturing `onRootPop` and not recreating if a new backstack was provided
 - Update Compose Multiplatform to `1.9.0`.
 - Update to Kotlin `2.2.20`.
 - Update to Molecule `2.2.0`.

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -73,10 +73,11 @@ kotlin {
     androidMain { dependencies { implementation(libs.androidx.activity.compose) } }
     commonTest {
       dependencies {
+        implementation(libs.compose.ui.test)
+        implementation(libs.coroutines.test)
         implementation(libs.kotlin.test)
         implementation(libs.molecule.runtime)
         implementation(libs.turbine)
-        implementation(libs.coroutines.test)
 
         implementation(projects.internalTestUtils)
       }

--- a/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/RememberCircuitNavigatorTest.kt
+++ b/circuit-foundation/src/commonJvmTest/kotlin/com/slack/circuit/foundation/RememberCircuitNavigatorTest.kt
@@ -1,0 +1,129 @@
+// Copyright (C) 2025 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.slack.circuit.backstack.BackStack
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.screen.PopResult
+import com.slack.circuit.runtime.screen.Screen
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(ComposeUiTestRunner::class)
+class RememberCircuitNavigatorTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun `rememberCircuitNavigator creates navigator with correct initial state`() =
+    composeTestRule.run {
+      val backStack = FakeBackStack()
+      backStack.push(TestScreen)
+      setContent {
+        val navigator = rememberCircuitNavigator(backStack = backStack, onRootPop = {})
+        assertNotNull(navigator)
+        assertEquals(TestScreen, navigator.peek())
+        assertEquals(listOf(TestScreen), navigator.peekBackStack())
+      }
+    }
+
+  @Test
+  fun `rememberCircuitNavigator creates new navigator when backstack instance changes`() =
+    composeTestRule.run {
+      val navigators = mutableSetOf<Navigator>()
+      setContent {
+        var backStack by remember { mutableStateOf(FakeBackStack().apply { push(TestScreen) }) }
+        rememberCircuitNavigator(backStack = backStack, onRootPop = {}).also { navigators += it }
+        SideEffect {
+          // Simulate the backstack instance changing
+          if (backStack.rootRecord?.screen != TestScreen2) {
+            backStack = FakeBackStack().apply { push(TestScreen2) }
+          }
+        }
+      }
+      assertEquals(2, navigators.size)
+      navigators.single { it.peek() == TestScreen }
+      navigators.single { it.peek() == TestScreen2 }
+      Unit
+    }
+
+  @Test
+  fun `rememberCircuitNavigator always calls the correct onRootPop lambda`() =
+    composeTestRule.run {
+      val backStack = FakeBackStack()
+      backStack.push(TestScreen)
+      var onRootPopped = 0
+      val onRootPop1 = { _: PopResult? -> onRootPopped = 1 }
+      val onRootPop2 = { _: PopResult? -> onRootPopped = 2 }
+      setContent {
+        var onRootPop by remember { mutableStateOf(onRootPop1) }
+        val navigator = rememberCircuitNavigator(backStack = backStack, onRootPop = onRootPop)
+        SideEffect {
+          // Call pop on the root screen to trigger the onRootPop lambda
+          if (onRootPopped == 0 && onRootPop == onRootPop2) {
+            navigator.pop()
+          }
+          // Simulate the onRootPop changing
+          if (onRootPop == onRootPop1) {
+            onRootPop = onRootPop2
+          }
+        }
+      }
+      assertEquals(2, onRootPopped)
+    }
+}
+
+private class FakeBackStack : BackStack<BackStack.Record> {
+
+  private val stack = ArrayDeque<BackStack.Record>()
+  override val size: Int
+    get() = stack.size
+
+  override val topRecord: BackStack.Record?
+    get() = stack.firstOrNull()
+
+  override val rootRecord: BackStack.Record?
+    get() = stack.lastOrNull()
+
+  override fun push(record: BackStack.Record, resultKey: String?): Boolean {
+    return stack.add(record)
+  }
+
+  override fun push(screen: Screen, resultKey: String?): Boolean {
+    return stack.add(FakeBackStackRecord(screen.toString(), screen))
+  }
+
+  override fun pop(result: PopResult?): BackStack.Record? {
+    return stack.removeFirstOrNull()
+  }
+
+  override fun saveState() = Unit
+
+  override fun restoreState(screen: Screen): Boolean = false
+
+  override fun containsRecord(record: BackStack.Record, includeSaved: Boolean): Boolean =
+    record in stack
+
+  override fun isRecordReachable(key: String, depth: Int, includeSaved: Boolean): Boolean {
+    return stack.firstNotNullOfOrNull { record -> record.key.takeIf { it == key } } != null
+  }
+
+  override fun iterator(): Iterator<BackStack.Record> {
+    return stack.iterator()
+  }
+
+  class FakeBackStackRecord(override val key: String, override val screen: Screen) :
+    BackStack.Record {
+
+    override suspend fun awaitResult(key: String): PopResult? = null
+  }
+}

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigatorImpl.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -23,6 +24,7 @@ import com.slack.circuit.runtime.screen.Screen
 
 /**
  * Creates and remembers a new [Navigator] for navigating within [CircuitContents][CircuitContent].
+ * A new [Navigator] will be created if the [backStack] instance changes.
  *
  * @param backStack The backing [BackStack] to navigate.
  * @param onRootPop Invoked when the backstack is at root (size 1) and the user presses the back
@@ -34,7 +36,8 @@ public fun rememberCircuitNavigator(
   backStack: BackStack<out Record>,
   onRootPop: (result: PopResult?) -> Unit,
 ): Navigator {
-  return remember { Navigator(backStack, onRootPop) }
+  val latestOnRootPop by rememberUpdatedState(onRootPop)
+  return remember(backStack) { Navigator(backStack) { popResult -> latestOnRootPop(popResult) } }
 }
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -124,6 +124,7 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 compose-runtime-saveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "compose-jb" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-jb" }
 compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-jb" }
+compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-jb" }
 compose-ui-testing-junit = { module = "org.jetbrains.compose.ui:ui-test-junit4", version.ref = "compose-jb" }
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-jb" }
 compose-ui-tooling-data = { module = "org.jetbrains.compose.ui:ui-tooling-data", version.ref = "compose-jb" }


### PR DESCRIPTION
- Was not recreating the `Navigator` if a new backstack was provided
- Was capturing the initial `onRootPop`
- From https://github.com/slackhq/circuit/discussions/2327