### PR TITLE
Use the old bool naming for the parameter reset roots

### DIFF
--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavEvent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavEvent.kt
@@ -34,9 +34,9 @@ public sealed interface NavEvent : CircuitUiEvent {
     /** Alternate parameter based constructor. */
     public constructor(
       newRoot: Screen,
-      save: Boolean = false,
-      restore: Boolean = false,
-      clear: Boolean = false,
-    ) : this(newRoot, StateOptions(save = save, restore = restore, clear = clear))
+      saveState: Boolean = false,
+      restoreState: Boolean = false,
+      clearState: Boolean = false,
+    ) : this(newRoot, StateOptions(save = saveState, restore = restoreState, clear = clearState))
   }
 }

--- a/circuit-foundation/src/commonTest/kotlin/com/slack/circuit/foundation/NavEventTest.kt
+++ b/circuit-foundation/src/commonTest/kotlin/com/slack/circuit/foundation/NavEventTest.kt
@@ -40,7 +40,9 @@ class NavEventTest {
   @Suppress("DEPRECATION")
   fun onNavEvent_deprecatedResetRoot_callsNavigatorResetRoot() {
     val navigator = FakeNavigator()
-    navigator.onNavEvent(NavEvent.ResetRoot(newRoot = TestScreen, save = true, restore = true))
+    navigator.onNavEvent(
+      NavEvent.ResetRoot(newRoot = TestScreen, saveState = true, restoreState = true)
+    )
     assertEquals(TestScreen, navigator.lastResetRootScreen)
     val options = navigator.lastResetRootOptions!!
     assertTrue(options.save)

--- a/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
+++ b/circuit-runtime/src/commonMain/kotlin/com/slack/circuit/runtime/Navigator.kt
@@ -126,11 +126,11 @@ public fun Navigator.resetRoot(
   newRoot: Screen,
   saveState: Boolean = false,
   restoreState: Boolean = false,
-  clear: Boolean = false,
+  clearState: Boolean = false,
 ): List<Screen> =
   resetRoot(
     newRoot = newRoot,
-    options = Navigator.StateOptions(save = saveState, restore = restoreState, clear = clear),
+    options = Navigator.StateOptions(save = saveState, restore = restoreState, clear = clearState),
   )
 
 /**


### PR DESCRIPTION
Follow up to https://github.com/slackhq/circuit/pull/2344, keeping the previous parameter names.