### PR TITLE
Fix formatting in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,5 +20,6 @@ formatter, use the `spotlessApply` command.
 ### iOS
 
 To build any of the iOS checks, you must do the following:
+
 1. Run `bundle install` to set up fastlane.
 2. Have `swiftformat` installed. You can install it via `brew install swiftformat`.


### PR DESCRIPTION
Minor fix that I noticed.


Before:
<img width="787" height="187" alt="Screenshot 2025-11-14 at 2 44 48 PM" src="https://github.com/user-attachments/assets/72ad1483-6606-4333-b06d-454f5ac24317" />

After:

<img width="770" height="189" alt="Screenshot 2025-11-14 at 3 39 31 PM" src="https://github.com/user-attachments/assets/8d78fc84-5cf2-4912-bdcb-7c2486d6d732" />
