### PR TITLE
Codegen - Ensure parameter name is include on java `OriginatingElement`

### DIFF
--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitNames.kt
@@ -35,6 +35,7 @@ internal object CircuitNames {
   val DAGGER_BINDS = ClassName(DAGGER_PACKAGE, "Binds")
   val DAGGER_INSTALL_IN = ClassName(DAGGER_HILT_PACKAGE, "InstallIn")
   val DAGGER_ORIGINATING_ELEMENT = ClassName(DAGGER_HILT_CODEGEN_PACKAGE, "OriginatingElement")
+  val DAGGER_ORIGIN = OriginAnnotation(DAGGER_ORIGINATING_ELEMENT, "topLevelClass")
   val DAGGER_INTO_SET = ClassName(DAGGER_MULTIBINDINGS_PACKAGE, "IntoSet")
   const val MODULE = "Module"
   const val FACTORY = "Factory"
@@ -49,7 +50,7 @@ internal object CircuitNames {
       private const val RUNTIME_INTERNAL_PACKAGE =
         "software.amazon.lastmile.kotlin.inject.anvil.internal"
       internal val CONTRIBUTES_BINDING = ClassName(RUNTIME_PACKAGE, "ContributesBinding")
-      val ORIGIN = ClassName(RUNTIME_INTERNAL_PACKAGE, "Origin")
+      val ORIGIN = OriginAnnotation(ClassName(RUNTIME_INTERNAL_PACKAGE, "Origin"))
     }
   }
 
@@ -59,7 +60,7 @@ internal object CircuitNames {
     val ASSISTED = ClassName(RUNTIME_PACKAGE, "Assisted")
     val ASSISTED_FACTORY = ClassName(RUNTIME_PACKAGE, "AssistedFactory")
     val PROVIDER = ClassName(RUNTIME_PACKAGE, "Provider")
-    val ORIGIN = ClassName(RUNTIME_PACKAGE, "Origin")
+    val ORIGIN = OriginAnnotation(ClassName(RUNTIME_PACKAGE, "Origin"))
     internal val CONTRIBUTES_INTO_SET = ClassName(RUNTIME_PACKAGE, "ContributesIntoSet")
   }
 }

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorProvider.kt
@@ -166,8 +166,15 @@ private class CircuitSymbolProcessor(
         mode.annotateFactory(builder = this, scope = scope)
         if (topLevelClass != null && mode.originAnnotation != null) {
           addAnnotation(
-            AnnotationSpec.builder(mode.originAnnotation)
-              .addMember("%T::class", topLevelClass)
+            AnnotationSpec.builder(mode.originAnnotation.className)
+              .apply {
+                val parameterName = mode.originAnnotation.parameterName
+                if (parameterName != null) {
+                  addMember("%L = %T::class", parameterName, topLevelClass)
+                } else {
+                  addMember("%T::class", topLevelClass)
+                }
+              }
               .build()
           )
         }

--- a/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
+++ b/circuit-codegen/src/main/kotlin/com/slack/circuit/codegen/CodegenMode.kt
@@ -91,7 +91,7 @@ internal enum class CodegenMode {
    * ```
    */
   HILT {
-    override val originAnnotation: ClassName = CircuitNames.DAGGER_ORIGINATING_ELEMENT
+    override val originAnnotation: OriginAnnotation = CircuitNames.DAGGER_ORIGIN
 
     override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
       // Hilt only supports JVM & Android
@@ -175,7 +175,7 @@ internal enum class CodegenMode {
    */
   KOTLIN_INJECT_ANVIL {
     override val runtime: InjectionRuntime = InjectionRuntime.KotlinInject
-    override val originAnnotation: ClassName = CircuitNames.KotlinInject.Anvil.ORIGIN
+    override val originAnnotation: OriginAnnotation = CircuitNames.KotlinInject.Anvil.ORIGIN
 
     override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
       // KI-Anvil supports all
@@ -223,7 +223,7 @@ internal enum class CodegenMode {
    */
   METRO {
     override val runtime: InjectionRuntime = InjectionRuntime.Metro
-    override val originAnnotation: ClassName = CircuitNames.Metro.ORIGIN
+    override val originAnnotation: OriginAnnotation = CircuitNames.Metro.ORIGIN
 
     override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
       // Metro supports all
@@ -254,7 +254,7 @@ internal enum class CodegenMode {
   };
 
   open val runtime: InjectionRuntime = InjectionRuntime.Jakarta
-  open val originAnnotation: ClassName? = null
+  open val originAnnotation: OriginAnnotation? = null
 
   open fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {}
 
@@ -355,3 +355,8 @@ internal enum class CodegenMode {
     }
   }
 }
+
+public class OriginAnnotation(
+  public val className: ClassName,
+  public val parameterName: String? = null,
+)

--- a/circuit-codegen/src/test/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorTest.kt
+++ b/circuit-codegen/src/test/kotlin/com/slack/circuit/codegen/CircuitSymbolProcessorTest.kt
@@ -1530,7 +1530,7 @@ class CircuitSymbolProcessorTest {
         import dagger.hilt.codegen.OriginatingElement
         import jakarta.inject.Inject
 
-        @OriginatingElement(FavoritesPresenter::class)
+        @OriginatingElement(topLevelClass = FavoritesPresenter::class)
         public class FavoritesPresenterFactory @Inject constructor(
           private val factory: FavoritesPresenter.Factory,
         ) : Presenter.Factory {


### PR DESCRIPTION
Need to ensure that named parameters are used with Java annotations.
> Only named arguments are available for Java annotations.

For Hilt the additional `OriginatingElement` was missing "topLevelClass" in the non anvil case.

