### PR TITLE
Cache konan deps in actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,24 @@ jobs:
             caches/jars-9
             caches/transforms-3
 
+      - name: Cache konan
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.konan/cache
+            ~/.konan/dependencies
+            ~/.konan/kotlin-native-macos*
+            ~/.konan/kotlin-native-mingw*
+            ~/.konan/kotlin-native-windows*
+            ~/.konan/kotlin-native-linux*
+            ~/.konan/kotlin-native-prebuilt-macos*
+            ~/.konan/kotlin-native-prebuilt-mingw*
+            ~/.konan/kotlin-native-prebuilt-windows*
+            ~/.konan/kotlin-native-prebuilt-linux*
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-
+
       - name: Build and run checks
         id: gradle-build
         run: |


### PR DESCRIPTION
These take a long time to download on CI https://github.com/slackhq/circuit/actions/runs/20533476624/job/58988210211#step:5:23

Ported from Metro's CI