### PR TITLE
Add missing Linux targets to circuit-foundation

### DIFF
--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -20,6 +20,8 @@ kotlin {
   iosX64()
   iosArm64()
   iosSimulatorArm64()
+  linuxArm64()
+  linuxX64()
   macosX64()
   macosArm64()
   js(IR) {


### PR DESCRIPTION
I noticed these were omitted when I tried to use circuit for a Linux CLI with Mosaic! 