### PR TITLE
Update `AndroidPredictiveBackNavDecorator` to handle its back animation

### DIFF
--- a/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
+++ b/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
@@ -117,7 +117,7 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
         .graphicsLayer { alpha = fade }
         .predictiveBackMotion(
           enabled = { showPrevious },
-          isSeeking = { isSeeking },
+          isSeeking = { isSwipeInProgress },
           shape = MaterialTheme.shapes.extraLarge,
           elevation = if (SharedElementTransitionScope.isTransitionActive) 0.dp else 6.dp,
           transition = transition,
@@ -148,7 +148,7 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
         }
       }
     ) { targetState ->
-      if (isSeeking) {
+      if (isSwipeInProgress) {
         1f
       } else {
         when (targetState) {
@@ -174,7 +174,7 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
     ) { targetState ->
       val preEnter = fullWidth() / -10
       val postExit = fullWidth() / 10
-      if (isSeeking) {
+      if (isSwipeInProgress) {
         IntOffset.Zero
       } else {
         when (targetState) {

--- a/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
+++ b/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
@@ -10,21 +10,34 @@ import androidx.compose.animation.EnterExitState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateIntOffset
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.GraphicsLayerScope
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.constrain
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.slack.circuit.foundation.NavigatorDefaults
@@ -35,6 +48,14 @@ import com.slack.circuit.runtime.InternalCircuitApi
 import com.slack.circuit.runtime.navigation.NavArgument
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
 import kotlin.math.absoluteValue
+
+private val FastOutExtraSlowInEasing = CubicBezierEasing(0.208333f, 0.82f, 0.25f, 1f)
+private val AccelerateEasing = CubicBezierEasing(0.3f, 0f, 1f, 1f)
+private val DecelerateEasing = CubicBezierEasing(0f, 0f, 0f, 1f)
+
+private const val DEBUG_MULTIPLIER = 1
+private const val SHORT_DURATION = 83 * DEBUG_MULTIPLIER
+private const val NORMAL_DURATION = 450 * DEBUG_MULTIPLIER
 
 public actual fun GestureNavigationDecorationFactory(
   fallback: AnimatedNavDecorator.Factory,
@@ -65,13 +86,10 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
       // come back from back stack
       AnimatedNavEvent.Backward,
       AnimatedNavEvent.Pop -> {
-        if (showPrevious) {
-            // Handle all the animation in predictiveBackMotion
-            EnterTransition.None togetherWith ExitTransition.None
-          } else {
-            NavigatorDefaults.backward
-          }
-          .apply { targetContentZIndex = --zIndexDepth }
+        // Handle all the animation in predictiveBackMotion
+        (EnterTransition.None togetherWith ExitTransition.None).apply {
+          targetContentZIndex = --zIndexDepth
+        }
       }
       // Root reset. Crossfade
       AnimatedNavEvent.RootReset -> {
@@ -86,18 +104,85 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
     targetState: GestureNavTransitionHolder<T>,
     innerContent: @Composable (T) -> Unit,
   ) {
+    var fullWidth by remember { mutableIntStateOf(0) }
+    val fade by transition.fade()
+    val offset by transition.offset { fullWidth }
     Box(
-      Modifier.predictiveBackMotion(
-        enabled = { showPrevious },
-        isSeeking = { isSeeking },
-        shape = MaterialTheme.shapes.extraLarge,
-        elevation = if (SharedElementTransitionScope.isTransitionActive) 0.dp else 6.dp,
-        transition = transition,
-        offset = { swipeOffset },
-        progress = { seekableTransitionState.fraction },
-      )
+      Modifier.layout { measurable, constraints ->
+          val placeable = measurable.measure(constraints)
+          val size = constraints.constrain(IntSize(placeable.width, placeable.height))
+          fullWidth = size.width
+          layout(size.width, size.height) { placeable.place(offset.x, offset.y) }
+        }
+        .graphicsLayer { alpha = fade }
+        .predictiveBackMotion(
+          enabled = { showPrevious },
+          isSeeking = { isSeeking },
+          shape = MaterialTheme.shapes.extraLarge,
+          elevation = if (SharedElementTransitionScope.isTransitionActive) 0.dp else 6.dp,
+          transition = transition,
+          offset = { swipeOffset },
+          progress = { seekableTransitionState.fraction },
+        )
     ) {
       innerContent(targetState.navStack.active)
+    }
+  }
+
+  /**
+   * Fade the same as [androidx.compose.animation.fadeIn] + [androidx.compose.animation.fadeOut]
+   * from [NavigatorDefaults.backward].
+   */
+  @Composable
+  private fun Transition<EnterExitState>.fade(): State<Float> {
+    return animateFloat(
+      transitionSpec = {
+        when {
+          EnterExitState.PreEnter isTransitioningTo EnterExitState.Visible ->
+            tween(durationMillis = SHORT_DURATION, delayMillis = 0, easing = LinearEasing)
+
+          EnterExitState.Visible isTransitioningTo EnterExitState.PostExit ->
+            tween(durationMillis = SHORT_DURATION, delayMillis = 50, easing = AccelerateEasing)
+
+          else -> spring()
+        }
+      }
+    ) { targetState ->
+      if (isSeeking) {
+        1f
+      } else {
+        when (targetState) {
+          EnterExitState.Visible -> 1f
+          EnterExitState.PreEnter -> 1f
+          EnterExitState.PostExit -> 0f
+        }
+      }
+    }
+  }
+
+  /**
+   * Offset the same as
+   * [androidx.compose.animation.slideInHorizontally] + [androidx.compose.animation.slideOutHorizontally]
+   * from [NavigatorDefaults.backward].
+   */
+  @Composable
+  private fun Transition<EnterExitState>.offset(fullWidth: () -> Int): State<IntOffset> {
+    return animateIntOffset(
+      transitionSpec = {
+        tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing)
+      }
+    ) { targetState ->
+      val preEnter = fullWidth() / -10
+      val postExit = fullWidth() / 10
+      if (isSeeking) {
+        IntOffset.Zero
+      } else {
+        when (targetState) {
+          EnterExitState.Visible -> IntOffset.Zero
+          EnterExitState.PreEnter -> IntOffset(preEnter, 0)
+          EnterExitState.PostExit -> IntOffset(postExit, 0)
+        }
+      }
     }
   }
 
@@ -108,8 +193,6 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
   }
 }
 
-private val DecelerateEasing = CubicBezierEasing(0f, 0f, 0f, 1f)
-
 /**
  * Implements most of the treatment specified at
  * https://developer.android.com/design/ui/mobile/guides/patterns/predictive-back
@@ -117,7 +200,7 @@ private val DecelerateEasing = CubicBezierEasing(0f, 0f, 0f, 1f)
 private fun Modifier.predictiveBackMotion(
   enabled: () -> Boolean,
   isSeeking: () -> Boolean,
-  shape: Shape,
+  shape: CornerBasedShape,
   elevation: Dp,
   transition: Transition<EnterExitState>,
   progress: () -> Float,
@@ -134,7 +217,7 @@ private fun Modifier.predictiveBackMotion(
 // https://developer.android.com/design/ui/mobile/guides/patterns/predictive-back#shared-element-transition
 private fun GraphicsLayerScope.sharedElementTransition(
   isSeeking: () -> Boolean,
-  shape: Shape,
+  shape: CornerBasedShape,
   elevation: Dp,
   transition: Transition<EnterExitState>,
   progress: Float,
@@ -144,12 +227,21 @@ private fun GraphicsLayerScope.sharedElementTransition(
   when (transition.targetState) {
     EnterExitState.PreEnter,
     EnterExitState.Visible -> return
+
     EnterExitState.PostExit -> Unit
   }
 
   clip = true
-  this.shape = shape
-  shadowElevation = elevation.toPx()
+
+  val shapeElevationFraction = (progress.absoluteValue * 5f).coerceAtMost(1f)
+  this.shape =
+    RoundedCornerShape(
+      topStart = (shape.topStart.toPx(size, this) * shapeElevationFraction).toDp(),
+      topEnd = (shape.topEnd.toPx(size, this) * shapeElevationFraction).toDp(),
+      bottomEnd = (shape.bottomEnd.toPx(size, this) * shapeElevationFraction).toDp(),
+      bottomStart = (shape.bottomStart.toPx(size, this) * shapeElevationFraction).toDp(),
+    )
+  shadowElevation = lerp(0f, elevation.toPx(), shapeElevationFraction)
 
   val scale = lerp(1f, 0.9f, progress.absoluteValue)
   scaleX = scale
@@ -159,7 +251,7 @@ private fun GraphicsLayerScope.sharedElementTransition(
   val marginX = ((size.width * (1 - scale)) / 2).coerceAtMost(8.dp.toPx())
   val marginY = ((size.height * (1 - scale)) / 2).coerceAtMost(8.dp.toPx())
   val maxTranslationX = (progress.absoluteValue * (size.width / 20))
-  // Determine a y axis easing to match the x progress
+  // Determine a y-axis easing to match the x progress
   val progressY = (offset.y.absoluteValue / size.height).coerceIn(0f, 1f)
   val transformY = DecelerateEasing.transform(progressY)
   val maxTranslationY = (transformY * (size.height / 20))

--- a/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
+++ b/circuitx/gesture-navigation/src/androidMain/kotlin/com/slack/circuitx/gesturenavigation/AndroidPredictiveBackNavigationDecoration.kt
@@ -10,12 +10,7 @@ import androidx.compose.animation.EnterExitState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Transition
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.animateIntOffset
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
@@ -24,20 +19,13 @@ import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.GraphicsLayerScope
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.constrain
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.slack.circuit.foundation.NavigatorDefaults
@@ -49,13 +37,7 @@ import com.slack.circuit.runtime.navigation.NavArgument
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
 import kotlin.math.absoluteValue
 
-private val FastOutExtraSlowInEasing = CubicBezierEasing(0.208333f, 0.82f, 0.25f, 1f)
-private val AccelerateEasing = CubicBezierEasing(0.3f, 0f, 1f, 1f)
 private val DecelerateEasing = CubicBezierEasing(0f, 0f, 0f, 1f)
-
-private const val DEBUG_MULTIPLIER = 1
-private const val SHORT_DURATION = 83 * DEBUG_MULTIPLIER
-private const val NORMAL_DURATION = 450 * DEBUG_MULTIPLIER
 
 public actual fun GestureNavigationDecorationFactory(
   fallback: AnimatedNavDecorator.Factory,
@@ -86,10 +68,13 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
       // come back from back stack
       AnimatedNavEvent.Backward,
       AnimatedNavEvent.Pop -> {
-        // Handle all the animation in predictiveBackMotion
-        (EnterTransition.None togetherWith ExitTransition.None).apply {
-          targetContentZIndex = --zIndexDepth
-        }
+        if (showPrevious) {
+            // Handle all the animation in predictiveBackMotion
+            EnterTransition.None togetherWith ExitTransition.None
+          } else {
+            NavigatorDefaults.backward
+          }
+          .apply { targetContentZIndex = --zIndexDepth }
       }
       // Root reset. Crossfade
       AnimatedNavEvent.RootReset -> {
@@ -104,85 +89,18 @@ internal class AndroidPredictiveBackNavDecorator<T : NavArgument>(onBackInvoked:
     targetState: GestureNavTransitionHolder<T>,
     innerContent: @Composable (T) -> Unit,
   ) {
-    var fullWidth by remember { mutableIntStateOf(0) }
-    val fade by transition.fade()
-    val offset by transition.offset { fullWidth }
     Box(
-      Modifier.layout { measurable, constraints ->
-          val placeable = measurable.measure(constraints)
-          val size = constraints.constrain(IntSize(placeable.width, placeable.height))
-          fullWidth = size.width
-          layout(size.width, size.height) { placeable.place(offset.x, offset.y) }
-        }
-        .graphicsLayer { alpha = fade }
-        .predictiveBackMotion(
-          enabled = { showPrevious },
-          isSeeking = { isSwipeInProgress },
-          shape = MaterialTheme.shapes.extraLarge,
-          elevation = if (SharedElementTransitionScope.isTransitionActive) 0.dp else 6.dp,
-          transition = transition,
-          offset = { swipeOffset },
-          progress = { seekableTransitionState.fraction },
-        )
+      Modifier.predictiveBackMotion(
+        enabled = { showPrevious },
+        isSeeking = { isSwipeInProgress },
+        shape = MaterialTheme.shapes.extraLarge,
+        elevation = if (SharedElementTransitionScope.isTransitionActive) 0.dp else 6.dp,
+        transition = transition,
+        offset = { swipeOffset },
+        progress = { seekableTransitionState.fraction },
+      )
     ) {
       innerContent(targetState.navStack.active)
-    }
-  }
-
-  /**
-   * Fade the same as [androidx.compose.animation.fadeIn] + [androidx.compose.animation.fadeOut]
-   * from [NavigatorDefaults.backward].
-   */
-  @Composable
-  private fun Transition<EnterExitState>.fade(): State<Float> {
-    return animateFloat(
-      transitionSpec = {
-        when {
-          EnterExitState.PreEnter isTransitioningTo EnterExitState.Visible ->
-            tween(durationMillis = SHORT_DURATION, delayMillis = 0, easing = LinearEasing)
-
-          EnterExitState.Visible isTransitioningTo EnterExitState.PostExit ->
-            tween(durationMillis = SHORT_DURATION, delayMillis = 50, easing = AccelerateEasing)
-
-          else -> spring()
-        }
-      }
-    ) { targetState ->
-      if (isSwipeInProgress) {
-        1f
-      } else {
-        when (targetState) {
-          EnterExitState.Visible -> 1f
-          EnterExitState.PreEnter -> 1f
-          EnterExitState.PostExit -> 0f
-        }
-      }
-    }
-  }
-
-  /**
-   * Offset the same as
-   * [androidx.compose.animation.slideInHorizontally] + [androidx.compose.animation.slideOutHorizontally]
-   * from [NavigatorDefaults.backward].
-   */
-  @Composable
-  private fun Transition<EnterExitState>.offset(fullWidth: () -> Int): State<IntOffset> {
-    return animateIntOffset(
-      transitionSpec = {
-        tween(durationMillis = NORMAL_DURATION, easing = FastOutExtraSlowInEasing)
-      }
-    ) { targetState ->
-      val preEnter = fullWidth() / -10
-      val postExit = fullWidth() / 10
-      if (isSwipeInProgress) {
-        IntOffset.Zero
-      } else {
-        when (targetState) {
-          EnterExitState.Visible -> IntOffset.Zero
-          EnterExitState.PreEnter -> IntOffset(preEnter, 0)
-          EnterExitState.PostExit -> IntOffset(postExit, 0)
-        }
-      }
     }
   }
 

--- a/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/PredictiveBackNavigationDecorator.kt
+++ b/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/PredictiveBackNavigationDecorator.kt
@@ -21,6 +21,7 @@ import com.slack.circuit.runtime.navigation.NavArgument
 import com.slack.circuit.runtime.navigation.NavStackList
 import com.slack.circuit.runtime.navigation.navStackListOf
 import kotlin.math.abs
+import kotlinx.coroutines.CancellationException
 
 internal abstract class PredictiveBackNavigationDecorator<T : NavArgument>(
   private val onBackInvoked: () -> Unit
@@ -64,15 +65,7 @@ internal abstract class PredictiveBackNavigationDecorator<T : NavArgument>(
 
     seekableTransitionState = remember { SeekableTransitionState(current) }
 
-    LaunchedEffect(current) {
-      swipeProgress = 0f
-      isSeeking = false
-      seekableTransitionState.animateTo(current)
-      // After the current state has changed (i.e. any transition has completed),
-      // clear out any transient state
-      showPrevious = false
-      swipeOffset = Offset.Zero
-    }
+    LaunchedEffect(current) { resetTo(current) }
 
     LaunchedEffect(previous, current) {
       if (previous != null) {
@@ -80,7 +73,11 @@ internal abstract class PredictiveBackNavigationDecorator<T : NavArgument>(
           .collect { progress ->
             if (progress != 0f) {
               isSeeking = true
-              seekableTransitionState.seekTo(fraction = abs(progress), targetState = previous)
+              try {
+                seekableTransitionState.seekTo(fraction = abs(progress), targetState = previous)
+              } catch (_: CancellationException) {
+                // If seekTo is interrupted we want to keep observing the swipeProgress
+              }
             }
           }
       }
@@ -92,12 +89,19 @@ internal abstract class PredictiveBackNavigationDecorator<T : NavArgument>(
         swipeProgress = progress
         swipeOffset = offset
       },
-      onBackCancelled = {
-        isSeeking = false
-        seekableTransitionState.animateTo(current)
-      },
+      onBackCancelled = { resetTo(current) },
       onBackCompleted = { onBackInvoked() },
     )
     return rememberTransition(seekableTransitionState, label = "PredictiveBackNavigationDecorator")
+  }
+
+  suspend fun resetTo(current: GestureNavTransitionHolder<T>) {
+    swipeProgress = 0f
+    isSeeking = false
+    seekableTransitionState.animateTo(current)
+    // After the current state has changed (i.e. any transition has completed),
+    // clear out any transient state
+    showPrevious = false
+    swipeOffset = Offset.Zero
   }
 }

--- a/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/PredictiveBackNavigationDecorator.kt
+++ b/circuitx/gesture-navigation/src/commonMain/kotlin/com/slack/circuitx/gesturenavigation/PredictiveBackNavigationDecorator.kt
@@ -34,7 +34,7 @@ internal abstract class PredictiveBackNavigationDecorator<T : NavArgument>(
   protected var showPrevious: Boolean by mutableStateOf(false)
     private set
 
-  protected var isSeeking: Boolean by mutableStateOf(false)
+  protected var isSwipeInProgress: Boolean by mutableStateOf(false)
     private set
 
   protected var swipeProgress: Float by mutableFloatStateOf(0f)
@@ -72,7 +72,7 @@ internal abstract class PredictiveBackNavigationDecorator<T : NavArgument>(
         snapshotFlow { swipeProgress }
           .collect { progress ->
             if (progress != 0f) {
-              isSeeking = true
+              isSwipeInProgress = true
               try {
                 seekableTransitionState.seekTo(fraction = abs(progress), targetState = previous)
               } catch (_: CancellationException) {
@@ -97,7 +97,7 @@ internal abstract class PredictiveBackNavigationDecorator<T : NavArgument>(
 
   suspend fun resetTo(current: GestureNavTransitionHolder<T>) {
     swipeProgress = 0f
-    isSeeking = false
+    isSwipeInProgress = false
     seekableTransitionState.animateTo(current)
     // After the current state has changed (i.e. any transition has completed),
     // clear out any transient state

--- a/circuitx/gesture-navigation/src/iosMain/kotlin/com/slack/circuitx/gesturenavigation/iOSPredictiveBackNavigationDecoration.kt
+++ b/circuitx/gesture-navigation/src/iosMain/kotlin/com/slack/circuitx/gesturenavigation/iOSPredictiveBackNavigationDecoration.kt
@@ -108,7 +108,7 @@ internal class IOSPredictiveBackNavDecorator<T : NavArgument>(
         Modifier.gestureTranslation(
           targetState = targetState,
           transition = transition,
-          isSeeking = { isSeeking },
+          isSeeking = { isSwipeInProgress },
           showPrevious = { showPrevious },
           swipeOffset = { swipeOffset },
         )


### PR DESCRIPTION
- Use `None` for the backwards `AnimatedContent` transition spec to avoid any collision with the predictive back
    - Reimplementing it on the content directly 
- Added some animation for the elevation and corner radius of the "shared element" style predictive back
- Fully reset the state on back cancel


https://github.com/user-attachments/assets/98023f4d-f52e-4d54-ac9e-a8121eeec282

