### PR TITLE
Fix CI connected check task wiring

### DIFF
--- a/build-logic/src/main/kotlin/circuit.base.gradle.kts
+++ b/build-logic/src/main/kotlin/circuit.base.gradle.kts
@@ -163,11 +163,10 @@ if (project.rootProject != project) {
         token.set(emulatorWtfToken)
       }
     }
-    // We don't always run emulator.wtf on CI (forks can't access it), so we add this helper
-    // lifecycle task that depends on connectedCheck as an alternative. We do this only on projects
-    // that apply emulator.wtf though as we don't want to run _all_ connected checks on CI since
-    // that would include benchmarks.
-    tasks.register("ciConnectedCheck") { dependsOn("connectedCheck") }
+    // Fork PRs cannot use emulator.wtf secrets, so CI runs this helper against a local emulator
+    // instead. Keep it scoped to projects that opted into emulator.wtf so we do not pick up every
+    // connected test in the repo, including benchmark modules.
+    tasks.register("ciConnectedCheck") { dependsOn("androidConnectedCheck") }
   }
 
   pluginManager.withPlugin("dev.zacsweers.anvil") {

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -151,7 +151,6 @@ tasks
       )
 
       if (name == "compileAndroidHostTest" || name == "compileAndroidDeviceTest") {
-        logger.lifecycle("Configuring parcelize for $name")
         freeCompilerArgs.addAll(
           "-P",
           "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=com.slack.circuit.internal.runtime.Parcelize",


### PR DESCRIPTION
This changed in AGP 9. Fixes https://github.com/slackhq/circuit/actions/runs/26523755523/job/78413184294