### PR TITLE
Remove out of date testing info

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,12 +18,6 @@ Test helpers are available via the `circuit-test` artifact.
 testImplementation("com.slack.circuit:circuit-test:<version>")
 ```
 
-For Gradle JVM projects, you can use Gradle test fixtures syntax on the core circuit artifact.
-
-```kotlin
-testImplementation(testFixtures("com.slack.circuit:circuit:<version>"))
-```
-
 For unit tests on the JVM in an Android module, please set below in your project's AGP config.
 
 ```gradle


### PR DESCRIPTION
I _believe_  this info is out of date? 

Getting this in a hobby project trying use the `testFixtures("com.slack.circuit:circuit:<version>")`

```
:auth:core:test: Could not find com.slack.circuit:circuit:0.33.1.
Searched in the following locations:
  - https://repo.maven.apache.org/maven2/com/slack/circuit/circuit/0.33.1/circuit-0.33.1.pom
Required by:
    project ':auth:core'
```