### PR TITLE
docs: Add Circuit recipes

### DIFF
--- a/docs/recipes/bottom-sheet-picker.md
+++ b/docs/recipes/bottom-sheet-picker.md
@@ -3,21 +3,19 @@
 **Problem:** the user taps something and a modal bottom sheet of options appears; picking one returns
 that value to the caller.
 
-CircuitX's `BottomSheetOverlay` takes a strongly-typed input model and returns a typed result, and
-`show()` suspends until the sheet finishes. Requires `circuitx-overlays` and a `ContentWithOverlays`
-above this UI.
+CircuitX's `BottomSheetOverlay` takes a strongly typed model and returns a typed result. `show()` suspends
+until the sheet finishes. Requires `circuitx-overlays` and a `ContentWithOverlays` above this UI.
 
 ## One-time setup: `ContentWithOverlays`
 
-Overlays render into an `OverlayHost` exposed by `ContentWithOverlays`. Wrap your navigable content
-in it **once**, at the root — every screen below then has `LocalOverlayHost` available. (If you use
-shared-element transitions, `SharedElementTransitionLayout` goes just outside `ContentWithOverlays` —
-shown here; drop that line if you don't.)
+Wrap your navigable content in `ContentWithOverlays` once at the composition root. Every screen within it can
+show overlays. If you use shared-element transitions, put `SharedElementTransitionLayout` just
+outside `ContentWithOverlays`; otherwise omit it.
 
 ```kotlin
 setContent {
   CircuitCompositionLocals(circuit) {
-    SharedElementTransitionLayout {            // optional — only if you use shared elements
+    SharedElementTransitionLayout {            // Optional: only if you use shared elements.
       ContentWithOverlays {
         NavigableCircuitContent(navigator = navigator, navStack = navStack)
       }
@@ -65,9 +63,8 @@ fun TaskEditor(state: TaskState, modifier: Modifier = Modifier) {
 }
 ```
 
-If the sheet should host a whole reusable component rather than inline content, render it with
-**SubCircuit** inside the sheet body — the component delegates its events (including "dismiss with this
-value") up to the host via its `outerEventSink`, which is exactly the embedded-component pattern. See
+If the sheet hosts a reusable component instead of inline content, render that component with
+**SubCircuit** and pass the selected value back through its `outerEventSink`. See
 [Embed a reusable component](reusable-component-subcircuit.md).
 
 **See also:** [CircuitX overlays](../circuitx/overlays.md) ·

--- a/docs/recipes/bottom-sheet-picker.md
+++ b/docs/recipes/bottom-sheet-picker.md
@@ -1,0 +1,74 @@
+# [Recipe](index.md): Pick a value from a bottom sheet
+
+**Problem:** the user taps something and a modal bottom sheet of options appears; picking one returns
+that value to the caller.
+
+CircuitX's `BottomSheetOverlay` takes a strongly-typed input model and returns a typed result, and
+`show()` suspends until the sheet finishes. Requires `circuitx-overlays` and a `ContentWithOverlays`
+above this UI.
+
+## One-time setup: `ContentWithOverlays`
+
+Overlays render into an `OverlayHost` exposed by `ContentWithOverlays`. Wrap your navigable content
+in it **once**, at the root — every screen below then has `LocalOverlayHost` available. (If you use
+shared-element transitions, `SharedElementTransitionLayout` goes just outside `ContentWithOverlays` —
+shown here; drop that line if you don't.)
+
+```kotlin
+setContent {
+  CircuitCompositionLocals(circuit) {
+    SharedElementTransitionLayout {            // optional — only if you use shared elements
+      ContentWithOverlays {
+        NavigableCircuitContent(navigator = navigator, navStack = navStack)
+      }
+    }
+  }
+}
+```
+
+## Show the sheet
+
+Wrap the sheet in a reusable suspend function on `OverlayHost`:
+
+```kotlin
+suspend fun OverlayHost.pickPriority(current: Priority): Priority =
+  show(
+    BottomSheetOverlay(model = Priority.entries.toList()) { priorities, overlayNavigator ->
+      Column {
+        priorities.forEach { priority ->
+          ListItem(
+            headlineContent = { Text(priority.label) },
+            trailingContent = { if (priority == current) Icon(Icons.Default.Check, null) },
+            modifier = Modifier.clickable { overlayNavigator.finish(priority) },
+          )
+        }
+      }
+    }
+  )
+```
+
+`overlayNavigator.finish(priority)` closes the sheet and resumes `show()` with that value.
+
+Drive it from presenter state so the UI stays declarative — a nullable property says "the picker is
+open", and the result comes back as an event:
+
+```kotlin
+@Composable
+fun TaskEditor(state: TaskState, modifier: Modifier = Modifier) {
+  if (state.isPickingPriority) {
+    OverlayEffect(state.isPickingPriority) {
+      val picked = pickPriority(state.priority)
+      state.eventSink(TaskEvent.PriorityPicked(picked))
+    }
+  }
+  // … editor fields, one of which opens the picker via an event …
+}
+```
+
+If the sheet should host a whole reusable component rather than inline content, render it with
+**SubCircuit** inside the sheet body — the component delegates its events (including "dismiss with this
+value") up to the host via its `outerEventSink`, which is exactly the embedded-component pattern. See
+[Embed a reusable component](reusable-component-subcircuit.md).
+
+**See also:** [CircuitX overlays](../circuitx/overlays.md) ·
+[Ask for confirmation](confirmation-dialog.md) · [Return a result](return-a-result.md)

--- a/docs/recipes/confirmation-dialog.md
+++ b/docs/recipes/confirmation-dialog.md
@@ -1,0 +1,79 @@
+# [Recipe](index.md): Ask for confirmation with a dialog
+
+**Problem:** before a destructive action (delete, discard), you need a yes/no confirmation and the
+answer back in the presenter.
+
+Use an overlay, shown with `OverlayEffect`. The effect suspends on the overlay's result and feeds it
+back as an event, so there's no `showDialog: Boolean` flag and no manual coroutine launching.
+Requires the `circuit-overlay` artifact and a `ContentWithOverlays` somewhere above this UI.
+
+## One-time setup: `ContentWithOverlays`
+
+Overlays render into an `OverlayHost` exposed by `ContentWithOverlays`. Wrap your navigable content
+in it **once**, at the root — every screen below then has `LocalOverlayHost` available, so individual
+recipes never set this up again. (If you use shared-element transitions, `SharedElementTransitionLayout`
+goes just outside `ContentWithOverlays` — shown here; drop that line if you don't.)
+
+```kotlin
+setContent {
+  CircuitCompositionLocals(circuit) {
+    SharedElementTransitionLayout {            // optional — only if you use shared elements
+      ContentWithOverlays {
+        NavigableCircuitContent(navigator = navigator, navStack = navStack)
+      }
+    }
+  }
+}
+```
+
+## Gate the dialog on nullable state, run it with `OverlayEffect`
+
+Model "is the dialog showing?" as a nullable state property — `null` = hidden, non-null carries what
+to confirm. `OverlayEffect` runs whenever that property is non-null, `show()`s the overlay, and the
+result comes back as an ordinary event. `circuitx-overlays` ships `alertDialogOverlay`, a thin
+`Overlay` over Material 3's `AlertDialog`; it resolves to a `DialogResult`
+(`Confirm` / `Cancel` / `Dismiss`).
+
+```kotlin
+// State carries what to confirm, or null.
+data class ItemState(
+  val pendingDelete: ItemId?,
+  val eventSink: (ItemEvent) -> Unit,
+) : CircuitUiState
+```
+
+```kotlin
+@Composable
+fun Item(state: ItemState, modifier: Modifier = Modifier) {
+  if (state.pendingDelete != null) {
+    OverlayEffect(state.pendingDelete) {
+      val result = show(
+        alertDialogOverlay(
+          title = { Text("Delete this item?") },
+          confirmButton = { onClick -> Button(onClick = onClick) { Text("Delete") } },
+          dismissButton = { onClick -> TextButton(onClick = onClick) { Text("Cancel") } },
+        )
+      )
+      val confirmed = result == DialogResult.Confirm
+      state.eventSink(ItemEvent.DeleteAnswered(state.pendingDelete, confirmed))
+    }
+  }
+  // … the rest of the item …
+}
+```
+
+A button in the UI requests the dialog by sending an event; the presenter sets `pendingDelete`, which
+makes `OverlayEffect` fire:
+
+```kotlin
+IconButton(onClick = { state.eventSink(ItemEvent.DeleteClicked(item.id)) }) {
+  Icon(Icons.Default.Delete, contentDescription = "Delete")
+}
+```
+
+This is the "boolean flag → nullable state" pattern: a non-null `pendingDelete` is the single source
+of truth for whether the dialog is up, and `OverlayEffect` — not an imperative `LocalOverlayHost.show`
+in an `onClick` — is what presents it.
+
+**See also:** [Overlays](../overlays.md) · [CircuitX overlays](../circuitx/overlays.md) ·
+[Pick a value from a bottom sheet](bottom-sheet-picker.md)

--- a/docs/recipes/confirmation-dialog.md
+++ b/docs/recipes/confirmation-dialog.md
@@ -3,21 +3,19 @@
 **Problem:** before a destructive action (delete, discard), you need a yes/no confirmation and the
 answer back in the presenter.
 
-Use an overlay, shown with `OverlayEffect`. The effect suspends on the overlay's result and feeds it
-back as an event, so there's no `showDialog: Boolean` flag and no manual coroutine launching.
-Requires the `circuit-overlay` artifact and a `ContentWithOverlays` somewhere above this UI.
+Use an overlay with `OverlayEffect`. The effect suspends on the result and sends it back as an event.
+Requires the `circuit-overlay` artifact and a `ContentWithOverlays` above this UI.
 
 ## One-time setup: `ContentWithOverlays`
 
-Overlays render into an `OverlayHost` exposed by `ContentWithOverlays`. Wrap your navigable content
-in it **once**, at the root — every screen below then has `LocalOverlayHost` available, so individual
-recipes never set this up again. (If you use shared-element transitions, `SharedElementTransitionLayout`
-goes just outside `ContentWithOverlays` — shown here; drop that line if you don't.)
+Wrap your navigable content in `ContentWithOverlays` once at the composition root. Every screen within it can
+show overlays. If you use shared-element transitions, put `SharedElementTransitionLayout` just
+outside `ContentWithOverlays`; otherwise omit it.
 
 ```kotlin
 setContent {
   CircuitCompositionLocals(circuit) {
-    SharedElementTransitionLayout {            // optional — only if you use shared elements
+    SharedElementTransitionLayout {            // Optional: only if you use shared elements.
       ContentWithOverlays {
         NavigableCircuitContent(navigator = navigator, navStack = navStack)
       }
@@ -26,13 +24,11 @@ setContent {
 }
 ```
 
-## Gate the dialog on nullable state, run it with `OverlayEffect`
+## Show the dialog from nullable state
 
-Model "is the dialog showing?" as a nullable state property — `null` = hidden, non-null carries what
-to confirm. `OverlayEffect` runs whenever that property is non-null, `show()`s the overlay, and the
-result comes back as an ordinary event. `circuitx-overlays` ships `alertDialogOverlay`, a thin
-`Overlay` over Material 3's `AlertDialog`; it resolves to a `DialogResult`
-(`Confirm` / `Cancel` / `Dismiss`).
+Use a nullable state property for the pending confirmation. `null` means hidden; a non-null value
+carries what to confirm. `OverlayEffect` shows the overlay when that value is present, and
+`alertDialogOverlay` returns a `DialogResult` (`Confirm`, `Cancel`, or `Dismiss`).
 
 ```kotlin
 // State carries what to confirm, or null.
@@ -71,9 +67,8 @@ IconButton(onClick = { state.eventSink(ItemEvent.DeleteClicked(item.id)) }) {
 }
 ```
 
-This is the "boolean flag → nullable state" pattern: a non-null `pendingDelete` is the single source
-of truth for whether the dialog is up, and `OverlayEffect` — not an imperative `LocalOverlayHost.show`
-in an `onClick` — is what presents it.
+Keep the pending value in state. The presenter sets `pendingDelete`, the UI shows the dialog, and the
+answer returns through `DeleteAnswered`.
 
 **See also:** [Overlays](../overlays.md) · [CircuitX overlays](../circuitx/overlays.md) ·
 [Pick a value from a bottom sheet](bottom-sheet-picker.md)

--- a/docs/recipes/debounce-search.md
+++ b/docs/recipes/debounce-search.md
@@ -1,0 +1,47 @@
+# [Recipe](index.md): Debounce a search field
+
+**Problem:** a search box should query as the user types, but not fire a request on every keystroke.
+
+Hold the query as state, expose a `QueryChanged` event, and debounce the query inside a
+`produceRetainedState` block using a snapshot `Flow`. The debounce and the search live in the
+producer, so they're cancelled and restarted cleanly as the query changes.
+
+```kotlin
+@Composable
+override fun present(): SearchState {
+  var query by rememberRetained { mutableStateOf("") }
+
+  val results by produceRetainedState<List<Hit>>(emptyList()) {
+    snapshotFlow { query }
+      .debounce(300.milliseconds)
+      .distinctUntilChanged()
+      .mapLatest { text -> if (text.isBlank()) emptyList() else searchRepository.search(text) }
+      .collect { hits -> value = hits }
+  }
+
+  return SearchState(query = query, results = results) { event ->
+    when (event) {
+      is SearchEvent.QueryChanged -> query = event.text
+    }
+  }
+}
+```
+
+Key points:
+
+- **`snapshotFlow { query }`** turns the Compose state into a Flow, so `debounce` / `distinctUntilChanged`
+  operate on it without manual plumbing.
+- **`mapLatest`** cancels an in-flight search when a newer query arrives — you never show stale results.
+- The whole pipeline is built **inside** `produceRetainedState`, so it isn't reallocated on
+  recomposition (see [observing a Flow](observe-a-flow.md)).
+
+The UI just reports text changes:
+
+```kotlin
+TextField(
+  value = state.query,
+  onValueChange = { text -> state.eventSink(SearchEvent.QueryChanged(text)) },
+)
+```
+
+**See also:** [Observe a Flow](observe-a-flow.md) · [Show loading states](loading-states.md)

--- a/docs/recipes/debounce-search.md
+++ b/docs/recipes/debounce-search.md
@@ -29,9 +29,9 @@ override fun present(): SearchState {
 
 Key points:
 
-- **`snapshotFlow { query }`** turns the Compose state into a Flow, so `debounce` / `distinctUntilChanged`
-  operate on it without manual plumbing.
-- **`mapLatest`** cancels an in-flight search when a newer query arrives — you never show stale results.
+- **`snapshotFlow { query }`** turns the Compose state into a Flow, so `debounce` and
+  `distinctUntilChanged` can operate on it.
+- **`mapLatest`** cancels an in-flight search when a newer query arrives.
 - The whole pipeline is built **inside** `produceRetainedState`, so it isn't reallocated on
   recomposition (see [observing a Flow](observe-a-flow.md)).
 

--- a/docs/recipes/form-with-validation.md
+++ b/docs/recipes/form-with-validation.md
@@ -1,0 +1,131 @@
+# [Recipe](index.md): A form with validation and submit
+
+**Problem:** a form has fields, per-field validation, a submit button that's only enabled when the
+form is valid, and a submitting state.
+
+Lift each field's value + error + validation into a small **presentation state holder** (the same idea
+as `EmailFieldState` in [Scaling Presenters](../presenter-patterns.md#use-cases-separating-business-logic)).
+The holder owns the Compose state with private setters and validates on every change; the presenter
+just creates one per field with `rememberRetained` and reads from them.
+
+## The field holder
+
+A reusable `@Stable` holder: a value, a derived error, and validity. `onValueChange` re-validates.
+
+```kotlin
+@Stable
+class FieldState(private val validate: (String) -> String?) {
+  var value by mutableStateOf("")
+    private set
+  var error by mutableStateOf<String?>(null)
+    private set
+
+  val isValid: Boolean get() = value.isNotEmpty() && error == null
+
+  fun onValueChange(newValue: String) {
+    value = newValue
+    error = validate(newValue)
+  }
+}
+```
+
+`validate` returns an error message or `null` — so a field is plug-and-play with any rule.
+
+## The state and events
+
+State exposes each field's value/error plus the derived `canSubmit` and `isSubmitting`. Events are
+just "this field changed" and "submit".
+
+```kotlin
+@Stable
+data class SignUpState(
+  val email: String,
+  val emailError: String?,
+  val password: String,
+  val passwordError: String?,
+  val canSubmit: Boolean,
+  val isSubmitting: Boolean,
+  val eventSink: (SignUpEvent) -> Unit,
+) : CircuitUiState
+
+@Immutable
+sealed interface SignUpEvent : CircuitUiEvent {
+  data class EmailChanged(val value: String) : SignUpEvent
+  data class PasswordChanged(val value: String) : SignUpEvent
+  data object Submit : SignUpEvent
+}
+```
+
+## The presenter
+
+Create a `FieldState` per field with `rememberRetained` (so in-progress input survives rotation and
+the back stack). `canSubmit` is **derived** from the holders, never stored.
+
+Submission itself is **not** run from a `rememberCoroutineScope()` — account creation must finish even
+if the user rotates or navigates away, so it lives in the data layer (scoped to outlive the screen).
+The presenter just *triggers* it and *observes* its in-flight state, the same way it observes any
+other repository state.
+
+```kotlin
+@Composable
+override fun present(): SignUpState {
+  val email = rememberRetained { FieldState(::validateEmail) }
+  val password = rememberRetained { FieldState(::validatePassword) }
+
+  // accountRepository owns the submission + its scope; we observe whether it's in flight.
+  val submitting by produceRetainedState(initialValue = false) {
+    accountRepository.signUpInFlight.collect { inFlight -> value = inFlight }
+  }
+
+  val canSubmit = email.isValid && password.isValid && !submitting
+
+  return SignUpState(
+    email = email.value,
+    emailError = email.error,
+    password = password.value,
+    passwordError = password.error,
+    canSubmit = canSubmit,
+    isSubmitting = submitting,
+  ) { event ->
+    when (event) {
+      is SignUpEvent.EmailChanged -> email.onValueChange(event.value)
+      is SignUpEvent.PasswordChanged -> password.onValueChange(event.value)
+      // Fire-and-trigger: the repository launches the work on its own scope and flips
+      // signUpInFlight; no coroutine is launched from the presenter.
+      SignUpEvent.Submit -> if (canSubmit) accountRepository.signUp(email.value, password.value)
+    }
+  }
+}
+
+private fun validateEmail(value: String): String? =
+  if (value.isNotEmpty() && !value.isValidEmail()) "Enter a valid email" else null
+
+private fun validatePassword(value: String): String? =
+  if (value.isNotEmpty() && value.length < 16) "At least 16 characters" else null
+```
+
+## The UI
+
+Binds values, surfaces errors, gates the button on `canSubmit`:
+
+```kotlin
+OutlinedTextField(
+  value = state.email,
+  onValueChange = { value -> state.eventSink(SignUpEvent.EmailChanged(value)) },
+  isError = state.emailError != null,
+  supportingText = { state.emailError?.let { error -> Text(error) } },
+)
+Button(onClick = { state.eventSink(SignUpEvent.Submit) }, enabled = state.canSubmit) {
+  if (state.isSubmitting) CircularProgressIndicator() else Text("Sign up")
+}
+```
+
+The validation logic lives in the holder, `canSubmit` is computed from the holders — there's no way
+for them to drift out of sync with the field values, and adding a third field is one more
+`rememberRetained { FieldState(...) }`. Submission runs in the data layer rather than from a
+presenter coroutine scope, so it survives the user rotating or navigating away mid-request — see
+[run a suspend action from an event](run-suspend-from-event.md) for why.
+
+**See also:** [Scaling Presenters: state holders](../presenter-patterns.md#use-cases-separating-business-logic) ·
+[States and Events](../states-and-events.md) ·
+[Run a suspend action from an event](run-suspend-from-event.md)

--- a/docs/recipes/form-with-validation.md
+++ b/docs/recipes/form-with-validation.md
@@ -3,14 +3,15 @@
 **Problem:** a form has fields, per-field validation, a submit button that's only enabled when the
 form is valid, and a submitting state.
 
-Lift each field's value + error + validation into a small **presentation state holder** (the same idea
+Put each field's value, error, and validation into a small **presentation state holder** (the same idea
 as `EmailFieldState` in [Scaling Presenters](../presenter-patterns.md#use-cases-separating-business-logic)).
-The holder owns the Compose state with private setters and validates on every change; the presenter
-just creates one per field with `rememberRetained` and reads from them.
+The holder owns the Compose state and validates on every change; the presenter creates one per field
+with `rememberRetained` and reads from them.
 
 ## The field holder
 
-A reusable `@Stable` holder: a value, a derived error, and validity. `onValueChange` re-validates.
+A reusable `@Stable` holder keeps the value/error/validity together. `onValueChange()`
+re-validates.
 
 ```kotlin
 @Stable
@@ -26,15 +27,17 @@ class FieldState(private val validate: (String) -> String?) {
     value = newValue
     error = validate(newValue)
   }
+  
+  private fun validate(newValue: String): String? {
+    // returns an error message or null, so each field can use its own rule
+  }
 }
 ```
 
-`validate` returns an error message or `null` — so a field is plug-and-play with any rule.
-
 ## The state and events
 
-State exposes each field's value/error plus the derived `canSubmit` and `isSubmitting`. Events are
-just "this field changed" and "submit".
+State exposes each field's value and error, plus `canSubmit` and `isSubmitting`. Events are "this
+field changed" and "submit".
 
 ```kotlin
 @Stable
@@ -58,13 +61,11 @@ sealed interface SignUpEvent : CircuitUiEvent {
 
 ## The presenter
 
-Create a `FieldState` per field with `rememberRetained` (so in-progress input survives rotation and
-the back stack). `canSubmit` is **derived** from the holders, never stored.
+Create a `FieldState` per field with `rememberRetained` so in-progress input survives rotation and
+the back stack. Derive `canSubmit` from the holders instead of storing it separately.
 
-Submission itself is **not** run from a `rememberCoroutineScope()` — account creation must finish even
-if the user rotates or navigates away, so it lives in the data layer (scoped to outlive the screen).
-The presenter just *triggers* it and *observes* its in-flight state, the same way it observes any
-other repository state.
+Keep account creation in the data layer if it must persist through config changes or navigation.
+The presenter triggers the request and observes its in-flight state like any other repository state.
 
 ```kotlin
 @Composable
@@ -72,7 +73,7 @@ override fun present(): SignUpState {
   val email = rememberRetained { FieldState(::validateEmail) }
   val password = rememberRetained { FieldState(::validatePassword) }
 
-  // accountRepository owns the submission + its scope; we observe whether it's in flight.
+  // accountRepository owns the submission; the presenter observes whether it is in flight.
   val submitting by produceRetainedState(initialValue = false) {
     accountRepository.signUpInFlight.collect { inFlight -> value = inFlight }
   }
@@ -90,8 +91,7 @@ override fun present(): SignUpState {
     when (event) {
       is SignUpEvent.EmailChanged -> email.onValueChange(event.value)
       is SignUpEvent.PasswordChanged -> password.onValueChange(event.value)
-      // Fire-and-trigger: the repository launches the work on its own scope and flips
-      // signUpInFlight; no coroutine is launched from the presenter.
+      // The repository launches the work on its own scope and updates signUpInFlight.
       SignUpEvent.Submit -> if (canSubmit) accountRepository.signUp(email.value, password.value)
     }
   }
@@ -120,11 +120,9 @@ Button(onClick = { state.eventSink(SignUpEvent.Submit) }, enabled = state.canSub
 }
 ```
 
-The validation logic lives in the holder, `canSubmit` is computed from the holders — there's no way
-for them to drift out of sync with the field values, and adding a third field is one more
-`rememberRetained { FieldState(...) }`. Submission runs in the data layer rather than from a
-presenter coroutine scope, so it survives the user rotating or navigating away mid-request — see
-[run a suspend action from an event](run-suspend-from-event.md) for why.
+The holder keeps validation close to the field value, and `canSubmit` is computed from the holders.
+Adding another field is one more `rememberRetained { FieldState(...) }`. For more on where to launch
+suspend work, see [run a suspend action from an event](run-suspend-from-event.md).
 
 **See also:** [Scaling Presenters: state holders](../presenter-patterns.md#use-cases-separating-business-logic) ·
 [States and Events](../states-and-events.md) ·

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -1,0 +1,47 @@
+Recipes
+=======
+
+Task-focused, copy-pasteable solutions to common problems with Circuit. Each recipe states a problem,
+gives a complete snippet, and links to the reference docs for depth. Browse to the problem you have —
+there's no required reading order.
+
+New to Circuit? Start with the [Tutorial](../tutorial.md) and [States and Events](../states-and-events.md)
+first; these recipes assume you know what a `Screen`, `Presenter`, and `Ui` are.
+
+## Loading data
+
+- [Show loading, loaded, and error states](loading-states.md)
+- [Observe a Flow or repository without leaking it](observe-a-flow.md)
+- [Retry a failed load](retry-a-failed-load.md)
+- [Pull to refresh](pull-to-refresh.md)
+- [Paginate a list (load more on scroll)](paginate-a-list.md)
+- [Debounce a search field](debounce-search.md)
+
+## Navigation & results
+
+- [Return a result to the previous screen](return-a-result.md)
+- [Ask for confirmation with a dialog](confirmation-dialog.md)
+- [Pick a value from a bottom sheet](bottom-sheet-picker.md)
+- [Tabs with independent back stacks](tabs-with-back-stacks.md)
+- [Navigate to an Android Activity or URL](navigate-to-android.md)
+- [Intercept, block, or rewrite navigation](intercept-navigation.md)
+
+## Composing & reusing UI
+
+- [Embed a reusable component that delegates navigation](reusable-component-subcircuit.md)
+- [Share selection state across list items](shared-selection-state.md)
+- [Keep UI state across rotation and the back stack](keep-state-across-config-change.md)
+
+## Effects & lifecycle
+
+- [Log an impression once when a screen opens](log-an-impression.md)
+- [Run a one-shot suspend action from an event](run-suspend-from-event.md)
+
+## Forms
+
+- [A form with validation and submit](form-with-validation.md)
+
+## Testing
+
+- [Test a presenter that navigates](test-a-presenter.md)
+- [Test a presenter that shows an overlay](test-an-overlay.md)

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -1,9 +1,8 @@
 Recipes
 =======
 
-Task-focused, copy-pasteable solutions to common problems with Circuit. Each recipe states a problem,
-gives a complete snippet, and links to the reference docs for depth. Browse to the problem you have —
-there's no required reading order.
+Task-focused, copy-pasteable solutions to common Circuit patterns. Start with the problem you have;
+there is no required reading order.
 
 New to Circuit? Start with the [Tutorial](../tutorial.md) and [States and Events](../states-and-events.md)
 first; these recipes assume you know what a `Screen`, `Presenter`, and `Ui` are.

--- a/docs/recipes/intercept-navigation.md
+++ b/docs/recipes/intercept-navigation.md
@@ -1,0 +1,139 @@
+# [Recipe](index.md): Intercept, block, or rewrite navigation
+
+**Problem:** before a `goTo` / `pop` / `resetRoot` actually happens, you want to inspect it and
+either let it through, block it, send it somewhere else, or hand it off to something outside Circuit
+(an Activity, an external URL).
+
+Use `circuitx-navigation`. A `NavigationInterceptor` sits in front of the real `Navigator`; each
+navigation call runs through your interceptors first, and each can **skip**, **consume**, **fail**,
+or **rewrite** the event. Wire them up with `rememberInterceptingNavigator`.
+
+```kotlin
+dependencies {
+  implementation("com.slack.circuit:circuitx-navigation:<version>")
+}
+```
+
+## Wire it up
+
+`rememberInterceptingNavigator` wraps your base navigator. Everything else (`NavigableCircuitContent`)
+takes the intercepting navigator in place of the original.
+
+```kotlin
+@Composable
+fun App(circuit: Circuit) {
+  val navStack = rememberSaveableNavStack(HomeScreen)
+  val baseNavigator = rememberCircuitNavigator(navStack) {
+    // Do something when the root screen is popped, usually exiting the app
+  }
+
+  val navigator = rememberInterceptingNavigator(
+    navigator = baseNavigator,
+    interceptors = listOf(AuthInterceptor(authManager), UrlRewriteInterceptor),
+  )
+
+  CircuitCompositionLocals(circuit) {
+    NavigableCircuitContent(navigator = navigator, navStack = navStack)
+  }
+}
+```
+
+Interceptors run **in order** — the first one to consume or rewrite the event wins.
+
+## The four outcomes
+
+Each `NavigationInterceptor` method returns an `InterceptedResult`. All methods default to `Skipped`,
+so you only override the ones you care about (usually `goTo`).
+
+| Result | Effect |
+|--------|--------|
+| `InterceptedResult.Skipped` | not my event — pass to the next interceptor, then the real navigator |
+| `InterceptedResult.Success(consumed = true)` | handled it; stop here, don't navigate |
+| `InterceptedResult.Failure(consumed, reason)` | tried and failed; `consumed` decides whether to stop |
+| `InterceptedResult.Rewrite(newScreen)` | navigate somewhere else instead — re-runs all interceptors with the new event |
+
+`NavigationInterceptor.Skipped` and `NavigationInterceptor.SuccessConsumed` are shorthands for the
+two most common ones.
+
+## Block navigation (consume it)
+
+Stop navigation to a screen the user isn't allowed to reach — e.g. a feature behind a flag. Returning
+a consumed `Failure` halts it; the optional `reason` flows to a `FailureNotifier` for logging.
+
+```kotlin
+class FeatureFlagInterceptor(private val features: FeatureManager) : NavigationInterceptor {
+  override fun goTo(screen: Screen, navigationContext: NavigationContext): InterceptedResult {
+    val flag = (screen as? Flagged)?.requiredFlag ?: return InterceptedResult.Skipped
+    return if (features.isEnabled(flag)) {
+      InterceptedResult.Skipped                          // allow it through
+    } else {
+      InterceptedResult.Failure(consumed = true, reason = DisabledFeature(flag))
+    }
+  }
+}
+```
+
+## Rewrite navigation (send it elsewhere)
+
+Redirect one screen to another. The classic case: gate a protected screen behind login, carrying the
+original destination so you can resume after auth.
+
+```kotlin
+class AuthInterceptor(private val auth: AuthManager) : NavigationInterceptor {
+  override fun goTo(screen: Screen, navigationContext: NavigationContext): InterceptedResult {
+    return if (screen is ProtectedScreen && !auth.isLoggedIn) {
+      InterceptedResult.Rewrite(LoginScreen(returnTo = screen))   // navigate here instead
+    } else {
+      InterceptedResult.Skipped
+    }
+  }
+}
+```
+
+A `Rewrite` restarts interception with the new event, so every interceptor gets a shot at the
+rewritten screen too.
+
+## Hand off to Android (Activities, URLs)
+
+This is what makes the difference between
+[navigating to an Android target](navigate-to-android.md) the simple way and doing it as an
+interceptor. CircuitX ships `AndroidScreenAwareNavigationInterceptor` — drop it in the list and any
+`AndroidScreen` (like `IntentScreen`) is consumed and started instead of pushed onto the back stack:
+
+```kotlin
+val navigator = rememberInterceptingNavigator(
+  navigator = baseNavigator,
+  interceptors = listOf(
+    AndroidScreenAwareNavigationInterceptor(context),   // consumes AndroidScreens
+    AuthInterceptor(authManager),
+  ),
+)
+```
+
+### Interceptor vs. `rememberAndroidScreenAwareNavigator`
+
+Both route `AndroidScreen`s out to Android. Pick by how much else you're doing:
+
+- **[`rememberAndroidScreenAwareNavigator`](navigate-to-android.md)** — a navigator decorator. Simplest
+  when launching Intents is the *only* special handling you need.
+- **`AndroidScreenAwareNavigationInterceptor`** — the same behavior as one interceptor in a list, so
+  it composes with auth/feature-flag/rewrite/analytics interceptors and gains failure-notifier
+  support. Reach for it once you have more than one cross-cutting navigation concern.
+
+## Observe without changing — event listeners
+
+If you only want to *know* about navigation (analytics, logging) without altering it, pass
+`eventListeners` instead of interceptors — they're notified after navigation the interceptors didn't
+consume.
+
+```kotlin
+rememberInterceptingNavigator(
+  navigator = baseNavigator,
+  interceptors = interceptors,
+  eventListeners = listOf(AnalyticsNavigationEventListener(analytics)),
+  notifier = AnalyticsFailureNotifier(analytics),   // called on Failure results
+)
+```
+
+**See also:** [CircuitX navigation](../circuitx/navigation.md) (full interface + listener/notifier
+reference) · [Navigate to an Android Activity or URL](navigate-to-android.md)

--- a/docs/recipes/intercept-navigation.md
+++ b/docs/recipes/intercept-navigation.md
@@ -4,9 +4,9 @@
 either let it through, block it, send it somewhere else, or hand it off to something outside Circuit
 (an Activity, an external URL).
 
-Use `circuitx-navigation`. A `NavigationInterceptor` sits in front of the real `Navigator`; each
-navigation call runs through your interceptors first, and each can **skip**, **consume**, **fail**,
-or **rewrite** the event. Wire them up with `rememberInterceptingNavigator`.
+Use `circuitx-navigation`. A `NavigationInterceptor` runs before the real `Navigator` and can
+**skip**, **consume**, **fail**, or **rewrite** a navigation event. Wire interceptors up with
+`rememberInterceptingNavigator`.
 
 ```kotlin
 dependencies {
@@ -38,19 +38,19 @@ fun App(circuit: Circuit) {
 }
 ```
 
-Interceptors run **in order** — the first one to consume or rewrite the event wins.
+Interceptors run **in order**. The first one to consume or rewrite the event wins.
 
 ## The four outcomes
 
 Each `NavigationInterceptor` method returns an `InterceptedResult`. All methods default to `Skipped`,
 so you only override the ones you care about (usually `goTo`).
 
-| Result | Effect |
-|--------|--------|
-| `InterceptedResult.Skipped` | not my event — pass to the next interceptor, then the real navigator |
-| `InterceptedResult.Success(consumed = true)` | handled it; stop here, don't navigate |
-| `InterceptedResult.Failure(consumed, reason)` | tried and failed; `consumed` decides whether to stop |
-| `InterceptedResult.Rewrite(newScreen)` | navigate somewhere else instead — re-runs all interceptors with the new event |
+| Result                                        | Effect                                                |
+|-----------------------------------------------|-------------------------------------------------------|
+| `InterceptedResult.Skipped`                   | pass to the next interceptor, then the real navigator |
+| `InterceptedResult.Success(consumed = true)`  | handled it; stop here                                 |
+| `InterceptedResult.Failure(consumed, reason)` | failed; `consumed` decides whether to stop            |
+| `InterceptedResult.Rewrite(newScreen)`        | navigate somewhere else instead                       |
 
 `NavigationInterceptor.Skipped` and `NavigationInterceptor.SuccessConsumed` are shorthands for the
 two most common ones.
@@ -95,10 +95,8 @@ rewritten screen too.
 
 ## Hand off to Android (Activities, URLs)
 
-This is what makes the difference between
-[navigating to an Android target](navigate-to-android.md) the simple way and doing it as an
-interceptor. CircuitX ships `AndroidScreenAwareNavigationInterceptor` — drop it in the list and any
-`AndroidScreen` (like `IntentScreen`) is consumed and started instead of pushed onto the back stack:
+CircuitX ships `AndroidScreenAwareNavigationInterceptor`. Add it to the list and any
+`AndroidScreen`, such as `IntentScreen`, is started instead of pushed onto the back stack:
 
 ```kotlin
 val navigator = rememberInterceptingNavigator(
@@ -112,7 +110,7 @@ val navigator = rememberInterceptingNavigator(
 
 ### Interceptor vs. `rememberAndroidScreenAwareNavigator`
 
-Both route `AndroidScreen`s out to Android. Pick by how much else you're doing:
+Both route `AndroidScreen`s out to Android. Pick based on what else your navigator needs to do:
 
 - **[`rememberAndroidScreenAwareNavigator`](navigate-to-android.md)** — a navigator decorator. Simplest
   when launching Intents is the *only* special handling you need.
@@ -122,9 +120,8 @@ Both route `AndroidScreen`s out to Android. Pick by how much else you're doing:
 
 ## Observe without changing — event listeners
 
-If you only want to *know* about navigation (analytics, logging) without altering it, pass
-`eventListeners` instead of interceptors — they're notified after navigation the interceptors didn't
-consume.
+If you only want to observe navigation for analytics or logging, pass `eventListeners` instead of
+interceptors. They are notified after navigation that interceptors did not consume.
 
 ```kotlin
 rememberInterceptingNavigator(

--- a/docs/recipes/keep-state-across-config-change.md
+++ b/docs/recipes/keep-state-across-config-change.md
@@ -1,0 +1,55 @@
+# [Recipe](index.md): Keep UI state across rotation and the back stack
+
+**Problem:** scroll position, a half-typed field, an expanded/collapsed toggle — you want it to
+survive rotation and back-stack navigation, and sometimes process death too.
+
+Pick the retention tier by how durable the value must be:
+
+| API | Survives rotation + back stack | Survives process death | Needs `Parcelable`/`Saver` |
+|-----|:--:|:--:|:--:|
+| `remember` | ❌ | ❌ | – |
+| `rememberRetained` | ✅\* | ❌ | no |
+| `rememberSaveable` | ✅\* | ✅ | yes |
+| `rememberRetainedSaveable` | ✅\* | ✅ | yes |
+
+\* Back-stack survival requires `NavigableCircuitContent` — it gives each record its own state
+registry. Under a lone `CircuitContent` there's no back stack to survive (rotation and process death
+still work as normal).
+
+```kotlin
+@Composable
+override fun present(): EditorState {
+  // Transient — fine to lose on rotation.
+  var focusedField by remember { mutableStateOf<Field?>(null) }
+
+  // Survives rotation + back stack, no serialization. Good default for most UI state.
+  var expanded by rememberRetained { mutableStateOf(false) }
+
+  // Also survives process death; needs a Saveable type (String is fine).
+  var draft by rememberRetainedSaveable { mutableStateOf("") }
+
+  // …
+}
+```
+
+How to choose:
+
+- **`remember`** — cheap, transient state you don't mind recomputing (focus, a transient highlight).
+- **`rememberRetained`** — the workhorse. Survives rotation and back-stack navigation by keeping the
+  value in memory; no `Parcelable` needed. Use for scroll-restorable selections, expanded states,
+  computed values you don't want to recompute.
+- **`rememberSaveable`** — survives process death by serializing to instance state. Needs a
+  `Parcelable` or custom `Saver`.
+- **`rememberRetainedSaveable`** — the union: in-memory like `rememberRetained` (fast, no
+  serialize-on-every-config-change) **and** opportunistically saved so it survives process death. The
+  in-memory value is the source of truth; the saved copy is the fallback when the process is recreated.
+
+For primitives, use the boxing-free holders: `rememberRetained { mutableIntStateOf(0) }`,
+`mutableLongStateOf`, etc.
+
+!!! warning
+    Retain *values*, never a `Flow`, `Navigator`, or `Context` — retaining those leaks everything
+    they reference across the back stack. To get data from a Flow into retained state safely, see
+    [observing a Flow](observe-a-flow.md).
+
+**See also:** [Retention reference](../presenter.md#retention) · [Observe a Flow](observe-a-flow.md)

--- a/docs/recipes/keep-state-across-config-change.md
+++ b/docs/recipes/keep-state-across-config-change.md
@@ -3,18 +3,17 @@
 **Problem:** scroll position, a half-typed field, an expanded/collapsed toggle — you want it to
 survive rotation and back-stack navigation, and sometimes process death too.
 
-Pick the retention tier by how durable the value must be:
+Pick the API based on how durable the value must be:
 
-| API | Survives rotation + back stack | Survives process death | Needs `Parcelable`/`Saver` |
-|-----|:--:|:--:|:--:|
-| `remember` | ❌ | ❌ | – |
-| `rememberRetained` | ✅\* | ❌ | no |
-| `rememberSaveable` | ✅\* | ✅ | yes |
-| `rememberRetainedSaveable` | ✅\* | ✅ | yes |
+| API                        | Survives rotation + back stack | Survives process death | Needs `Parcelable`/`Saver` |
+|----------------------------|:------------------------------:|:----------------------:|:--------------------------:|
+| `remember`                 |               ❌                |           ❌            |             –              |
+| `rememberRetained`         |              ✅\*               |           ❌            |             no             |
+| `rememberSaveable`         |              ✅\*               |           ✅            |            yes             |
+| `rememberRetainedSaveable` |              ✅\*               |           ✅            |            yes             |
 
-\* Back-stack survival requires `NavigableCircuitContent` — it gives each record its own state
-registry. Under a lone `CircuitContent` there's no back stack to survive (rotation and process death
-still work as normal).
+\* Back stack survival requires `NavigableCircuitContent`, which gives each record its own state
+registry. `CircuitContent` alone does not offer a back stack to survive.
 
 ```kotlin
 @Composable
@@ -35,21 +34,20 @@ override fun present(): EditorState {
 How to choose:
 
 - **`remember`** — cheap, transient state you don't mind recomputing (focus, a transient highlight).
-- **`rememberRetained`** — the workhorse. Survives rotation and back-stack navigation by keeping the
-  value in memory; no `Parcelable` needed. Use for scroll-restorable selections, expanded states,
-  computed values you don't want to recompute.
+- **`rememberRetained`** — survives rotation and back-stack navigation by keeping the value in
+  memory; no `Parcelable` needed. Use for selections, expanded states, and computed values you don't
+  want to recompute.
 - **`rememberSaveable`** — survives process death by serializing to instance state. Needs a
   `Parcelable` or custom `Saver`.
-- **`rememberRetainedSaveable`** — the union: in-memory like `rememberRetained` (fast, no
-  serialize-on-every-config-change) **and** opportunistically saved so it survives process death. The
-  in-memory value is the source of truth; the saved copy is the fallback when the process is recreated.
+- **`rememberRetainedSaveable`** — keeps the value in memory like `rememberRetained`, and also saves
+  it so the value can be restored after process death.
 
 For primitives, use the boxing-free holders: `rememberRetained { mutableIntStateOf(0) }`,
 `mutableLongStateOf`, etc.
 
 !!! warning
-    Retain *values*, never a `Flow`, `Navigator`, or `Context` — retaining those leaks everything
-    they reference across the back stack. To get data from a Flow into retained state safely, see
-    [observing a Flow](observe-a-flow.md).
+    Retain *values*, not lifecycle-beholden objects like `Flow`, `Navigator`, or `Context`; those 
+    can keep too much or leak across the back stack. To get data from a Flow into retained state 
+    safely, see [observing a Flow](observe-a-flow.md).
 
 **See also:** [Retention reference](../presenter.md#retention) · [Observe a Flow](observe-a-flow.md)

--- a/docs/recipes/loading-states.md
+++ b/docs/recipes/loading-states.md
@@ -1,0 +1,79 @@
+# [Recipe](index.md): Show loading, loaded, and error states
+
+**Problem:** a screen loads data asynchronously and needs to render distinct loading, success, and
+error UI.
+
+Model the three outcomes as a sealed `State`, and give each variant only the events that make sense
+for it — `Loading` has no events, `Error` only retries. The presenter maps the repository's result
+into the right variant.
+
+```kotlin
+sealed interface ProfileState : CircuitUiState {
+  data object Loading : ProfileState
+
+  data class Loaded(
+    val name: String,
+    val eventSink: (LoadedEvent) -> Unit,
+  ) : ProfileState
+
+  data class Error(
+    val message: String,
+    val eventSink: (ErrorEvent) -> Unit,
+  ) : ProfileState
+}
+
+sealed interface LoadedEvent : CircuitUiEvent {
+  data object Refresh : LoadedEvent
+}
+
+sealed interface ErrorEvent : CircuitUiEvent {
+  data object Retry : ErrorEvent
+}
+```
+
+The presenter collects the repository (which exposes its own loading/success/error result type) and
+translates each case. See [observing a Flow](observe-a-flow.md) for why the Flow is built inside
+`produceRetainedState`.
+
+```kotlin
+@Composable
+override fun present(): ProfileState {
+  val result by produceRetainedState<ProfileResult>(ProfileResult.Loading, screen.userId) {
+    profileRepository.profile(screen.userId).collect { fetched -> value = fetched }
+  }
+
+  return when (val current = result) {
+    ProfileResult.Loading -> ProfileState.Loading
+    is ProfileResult.Success ->
+      ProfileState.Loaded(name = current.name) { event ->
+        when (event) {
+          LoadedEvent.Refresh -> profileRepository.refresh(screen.userId)
+        }
+      }
+    is ProfileResult.Failure ->
+      ProfileState.Error(message = current.message) { event ->
+        when (event) {
+          ErrorEvent.Retry -> profileRepository.refresh(screen.userId)
+        }
+      }
+  }
+}
+```
+
+The UI dispatches on the sealed state — each branch only sees the events it's allowed to send:
+
+```kotlin
+@Composable
+fun Profile(state: ProfileState, modifier: Modifier = Modifier) {
+  when (state) {
+    ProfileState.Loading -> CircularProgressIndicator(modifier)
+    is ProfileState.Loaded ->
+      ProfileBody(state.name, onRefresh = { state.eventSink(LoadedEvent.Refresh) }, modifier)
+    is ProfileState.Error ->
+      ErrorView(state.message, onRetry = { state.eventSink(ErrorEvent.Retry) }, modifier)
+  }
+}
+```
+
+**See also:** [States and Events](../states-and-events.md) ·
+[Retry a failed load](retry-a-failed-load.md) · [Pull to refresh](pull-to-refresh.md)

--- a/docs/recipes/log-an-impression.md
+++ b/docs/recipes/log-an-impression.md
@@ -1,0 +1,49 @@
+# [Recipe](index.md): Log an impression once when a screen opens
+
+**Problem:** fire an analytics impression exactly once when a screen (or item) is shown — not on
+every recomposition, and not again after a configuration change.
+
+Use CircuitX's impression effects (`circuitx-effects`). They run once and won't run again until
+forgotten under the current retained-state registry — so they survive recomposition and rotation.
+
+```kotlin
+@Composable
+override fun present(): ArticleState {
+  // Synchronous, fire-once:
+  ImpressionEffect { analytics.logArticleView(screen.articleId) }
+  // …
+}
+```
+
+For suspending work (a network beacon, a suspend logging call), use `LaunchedImpressionEffect`, and
+pass a key so it re-fires when the thing you're tracking changes — and *only* then:
+
+```kotlin
+// Fires once per distinct article id.
+LaunchedImpressionEffect(screen.articleId) {
+  analytics.logArticleViewAsync(screen.articleId)
+}
+```
+
+Use a constant key (`LaunchedImpressionEffect(Unit) { … }`) for "once for the lifetime of this
+composition, regardless of inputs".
+
+## Re-fire when the user navigates back to the screen
+
+A plain impression effect stays "already fired" when the user pops back to a screen still on the back
+stack. If you want to log a fresh impression on re-entry, wrap the navigator with
+`rememberImpressionNavigator` and use *that* for navigation:
+
+```kotlin
+val navigator = rememberImpressionNavigator(navigator = navigator) {
+  analytics.logScreenReentered(screen.articleId)
+}
+```
+
+| Need | Use |
+|------|-----|
+| sync, once per composition/key | `ImpressionEffect` |
+| suspend, once per composition/key | `LaunchedImpressionEffect(key)` |
+| re-fire when navigated back to | `rememberImpressionNavigator` |
+
+**See also:** [CircuitX effects](../circuitx/effects.md)

--- a/docs/recipes/log-an-impression.md
+++ b/docs/recipes/log-an-impression.md
@@ -3,8 +3,8 @@
 **Problem:** fire an analytics impression exactly once when a screen (or item) is shown — not on
 every recomposition, and not again after a configuration change.
 
-Use CircuitX's impression effects (`circuitx-effects`). They run once and won't run again until
-forgotten under the current retained-state registry — so they survive recomposition and rotation.
+Use CircuitX's impression effects (`circuitx-effects`). They run once for the current retained-state
+registry, so they survive recomposition and rotation.
 
 ```kotlin
 @Composable
@@ -15,8 +15,8 @@ override fun present(): ArticleState {
 }
 ```
 
-For suspending work (a network beacon, a suspend logging call), use `LaunchedImpressionEffect`, and
-pass a key so it re-fires when the thing you're tracking changes — and *only* then:
+For suspending work (a network beacon, a suspend logging call), use `LaunchedImpressionEffect`. Pass
+a key when the impression should run again for a different item:
 
 ```kotlin
 // Fires once per distinct article id.
@@ -40,10 +40,10 @@ val navigator = rememberImpressionNavigator(navigator = navigator) {
 }
 ```
 
-| Need | Use |
-|------|-----|
-| sync, once per composition/key | `ImpressionEffect` |
+| Need                              | Use                             |
+|-----------------------------------|---------------------------------|
+| sync, once per composition/key    | `ImpressionEffect`              |
 | suspend, once per composition/key | `LaunchedImpressionEffect(key)` |
-| re-fire when navigated back to | `rememberImpressionNavigator` |
+| re-fire when navigated back to    | `rememberImpressionNavigator`   |
 
 **See also:** [CircuitX effects](../circuitx/effects.md)

--- a/docs/recipes/navigate-to-android.md
+++ b/docs/recipes/navigate-to-android.md
@@ -1,0 +1,71 @@
+# [Recipe](index.md): Navigate to an Android Activity or URL
+
+**Problem:** a presenter needs to launch something outside Circuit — another `Activity`, a browser,
+the share sheet, a custom tab.
+
+Use `circuitx-android`. Decorate your navigator once with `rememberAndroidScreenAwareNavigator`, then
+`goTo` an `AndroidScreen` from any presenter just like a normal screen.
+
+## Set up the decorated navigator
+
+```kotlin
+class MainActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      val navStack = rememberSaveableNavStack(HomeScreen)
+      val navigator = rememberAndroidScreenAwareNavigator(
+        rememberCircuitNavigator(navStack),   // the Circuit navigator it wraps
+        this@MainActivity,                     // Context used to start activities
+      )
+      CircuitCompositionLocals(circuit) {
+        NavigableCircuitContent(navigator, navStack)
+      }
+    }
+  }
+}
+```
+
+## Launch an Intent from a presenter
+
+`IntentScreen` is the built-in `AndroidScreen` — wrap any `Intent` and `goTo` it:
+
+```kotlin
+return DetailState(detail) { event ->
+  when (event) {
+    is DetailEvent.OpenInBrowser ->
+      navigator.goTo(IntentScreen(Intent(Intent.ACTION_VIEW, event.url.toUri())))
+    is DetailEvent.Share ->
+      navigator.goTo(IntentScreen(Intent.createChooser(shareIntent(event.text), null)))
+  }
+}
+```
+
+The decorated navigator intercepts `AndroidScreen`s and calls `startActivity`; everything else flows
+to the normal Circuit back stack.
+
+## Custom Android targets
+
+For non-Intent targets (a custom tab, a third-party SDK launcher), pass your own
+`AndroidScreenStarter` instead of a `Context`:
+
+```kotlin
+val starter = AndroidScreenStarter { screen ->
+  when (screen) {
+    is IntentScreen -> { context.startActivity(screen.intent, screen.options); true }
+    is CustomTabScreen -> { customTabs.launch(screen.url); true }
+    else -> false   // not handled — let Circuit treat it as a normal screen
+  }
+}
+val navigator = rememberAndroidScreenAwareNavigator(rememberCircuitNavigator(navStack), starter)
+```
+
+!!! tip "Doing more than launching Intents?"
+    `rememberAndroidScreenAwareNavigator` is the simple path when Android handoff is your *only*
+    special navigation handling. Once you're also gating navigation behind auth, feature flags, or
+    rewriting destinations, switch to the interceptor form — `AndroidScreenAwareNavigationInterceptor`
+    is the same behavior as one entry in an interceptor list. See
+    [Intercept, block, or rewrite navigation](intercept-navigation.md).
+
+**See also:** [CircuitX Android](../circuitx/android.md) · [Navigation](../navigation.md) ·
+[Intercept navigation](intercept-navigation.md)

--- a/docs/recipes/navigate-to-android.md
+++ b/docs/recipes/navigate-to-android.md
@@ -4,7 +4,7 @@
 the share sheet, a custom tab.
 
 Use `circuitx-android`. Decorate your navigator once with `rememberAndroidScreenAwareNavigator`, then
-`goTo` an `AndroidScreen` from any presenter just like a normal screen.
+`goTo` an `AndroidScreen` from a presenter like any other screen.
 
 ## Set up the decorated navigator
 
@@ -41,8 +41,8 @@ return DetailState(detail) { event ->
 }
 ```
 
-The decorated navigator intercepts `AndroidScreen`s and calls `startActivity`; everything else flows
-to the normal Circuit back stack.
+The decorated navigator starts `AndroidScreen`s with Android. Other screens still go to the normal
+Circuit back stack.
 
 ## Custom Android targets
 
@@ -54,17 +54,16 @@ val starter = AndroidScreenStarter { screen ->
   when (screen) {
     is IntentScreen -> { context.startActivity(screen.intent, screen.options); true }
     is CustomTabScreen -> { customTabs.launch(screen.url); true }
-    else -> false   // not handled — let Circuit treat it as a normal screen
+    else -> false   // Not handled; let Circuit treat it as a normal screen.
   }
 }
 val navigator = rememberAndroidScreenAwareNavigator(rememberCircuitNavigator(navStack), starter)
 ```
 
 !!! tip "Doing more than launching Intents?"
-    `rememberAndroidScreenAwareNavigator` is the simple path when Android handoff is your *only*
-    special navigation handling. Once you're also gating navigation behind auth, feature flags, or
-    rewriting destinations, switch to the interceptor form — `AndroidScreenAwareNavigationInterceptor`
-    is the same behavior as one entry in an interceptor list. See
+    `rememberAndroidScreenAwareNavigator` is the simple path when Android handoff is your only
+    special navigation handling. Once you also gate navigation behind auth, feature flags, or
+    destination rewrites, use `AndroidScreenAwareNavigationInterceptor` instead. See
     [Intercept, block, or rewrite navigation](intercept-navigation.md).
 
 **See also:** [CircuitX Android](../circuitx/android.md) · [Navigation](../navigation.md) ·

--- a/docs/recipes/observe-a-flow.md
+++ b/docs/recipes/observe-a-flow.md
@@ -1,0 +1,58 @@
+# [Recipe](index.md): Observe a Flow or repository without leaking it
+
+**Problem:** your presenter needs to turn a `Flow` (from a repository, database, or use-case) into
+Circuit state — without leaking the Flow or rebuilding it on every recomposition.
+
+Use `produceRetainedState` and **build the Flow inside the block**. The result is retained across
+recomposition, configuration changes, and the back stack; the Flow itself is scoped to the block and
+torn down correctly.
+
+```kotlin
+@Composable
+override fun present(): ChannelState {
+  val messages by produceRetainedState<List<Message>>(emptyList(), screen.channelId) {
+    messageRepository.messages(screen.channelId).collect { latest -> value = latest }
+  }
+  return ChannelState(messages)
+}
+```
+
+Pass any keys that should restart collection (here, `screen.channelId`) as arguments — the block
+re-runs when a key changes.
+
+## Don't pass the Flow as an argument
+
+`collectAsRetainedState` works, but it takes the Flow as a parameter — so an inline
+`repository.messages()` expression (and its whole operator chain) gets rebuilt in composition on every
+recomposition:
+
+```kotlin
+// ⚠️ Rebuilds the chain in composition every recomposition.
+val messages by messageRepository.messages(screen.channelId)
+  .map { messages -> messages.sortedByDescending(Message::timestamp) }
+  .collectAsRetainedState(initial = emptyList())
+
+// ✅ Built once, inside the block, keyed on channelId.
+val messages by produceRetainedState<List<Message>>(emptyList(), screen.channelId) {
+  messageRepository.messages(screen.channelId)
+    .map { messages -> messages.sortedByDescending(Message::timestamp) }
+    .collect { sorted -> value = sorted }
+}
+```
+
+`collectAsRetainedState` is fine when the Flow is already a stable reference; `produceRetainedState`
+is the safer default because it makes it hard to allocate the chain in composition by accident.
+
+## Never `rememberRetained` a raw Flow instance
+
+```kotlin
+// 🚫 Retains the Flow itself — keeps everything it captures (repos, scopes) alive on the back stack.
+val messages by rememberRetained { messageRepository.messages(id) }.collectAsState(emptyList())
+```
+
+Retain the *result*, not the Flow. (Building a full chain inside a `remember` block is fine — it runs
+once — but don't hold the Flow as retained state, and never `rememberRetained` a `Navigator` or
+`Context`.)
+
+**See also:** [Retention reference](../presenter.md#retention) ·
+[Keep UI state across config change](keep-state-across-config-change.md)

--- a/docs/recipes/observe-a-flow.md
+++ b/docs/recipes/observe-a-flow.md
@@ -4,8 +4,8 @@
 Circuit state — without leaking the Flow or rebuilding it on every recomposition.
 
 Use `produceRetainedState` and **build the Flow inside the block**. The result is retained across
-recomposition, configuration changes, and the back stack; the Flow itself is scoped to the block and
-torn down correctly.
+recomposition, configuration changes, and the back stack. The Flow is collected only while the block
+is active.
 
 ```kotlin
 @Composable
@@ -22,8 +22,8 @@ re-runs when a key changes.
 
 ## Don't pass the Flow as an argument
 
-`collectAsRetainedState` works, but it takes the Flow as a parameter — so an inline
-`repository.messages()` expression (and its whole operator chain) gets rebuilt in composition on every
+`collectAsRetainedState` works, but it takes the Flow as a parameter. An inline
+`repository.messages()` expression and its operator chain are rebuilt in composition on every
 recomposition:
 
 ```kotlin
@@ -40,19 +40,18 @@ val messages by produceRetainedState<List<Message>>(emptyList(), screen.channelI
 }
 ```
 
-`collectAsRetainedState` is fine when the Flow is already a stable reference; `produceRetainedState`
-is the safer default because it makes it hard to allocate the chain in composition by accident.
+`collectAsRetainedState` is fine when the Flow is already a stable reference. `produceRetainedState`
+is the safer default for repository calls and operator chains.
 
 ## Never `rememberRetained` a raw Flow instance
 
 ```kotlin
-// 🚫 Retains the Flow itself — keeps everything it captures (repos, scopes) alive on the back stack.
+// Retains the Flow itself, including anything it captures.
 val messages by rememberRetained { messageRepository.messages(id) }.collectAsState(emptyList())
 ```
 
-Retain the *result*, not the Flow. (Building a full chain inside a `remember` block is fine — it runs
-once — but don't hold the Flow as retained state, and never `rememberRetained` a `Navigator` or
-`Context`.)
+Retain the *result*, not the Flow. Building a chain inside `remember` is fine because it runs once,
+but do not hold the Flow as retained state. The same applies to a `Navigator` or `Context`.
 
 **See also:** [Retention reference](../presenter.md#retention) ·
 [Keep UI state across config change](keep-state-across-config-change.md)

--- a/docs/recipes/paginate-a-list.md
+++ b/docs/recipes/paginate-a-list.md
@@ -3,11 +3,16 @@
 **Problem:** a long list loads a page at a time; reaching the bottom should fetch the next page,
 without firing duplicate requests or losing accumulated items across recomposition.
 
-Pagination has several moving parts — accumulated items, the next cursor, an in-flight flag, an
-end-of-list flag. Rather than scatter four `rememberRetained` vars through `present()`, lift them into
-a small **presentation state holder** (the same idea as `EmailFieldState` in
-[Scaling Presenters](../presenter-patterns.md#use-cases-separating-business-logic)). The holder owns the Compose state; the
-presenter just creates it with `rememberRetained` and drives loading from an effect + events.
+Pagination has several moving parts:
+
+- accumulated items
+- the next cursor
+- an in-flight flag
+- an end-of-list flag
+
+Keep them in a small **presentation state holder** (the same idea as `EmailFieldState` in 
+[Scaling Presenters](../presenter-patterns.md#use-cases-separating-business-logic)). The presenter creates the holder with `rememberRetained` and drives 
+loading from an effect and events.
 
 ## The holder
 
@@ -28,13 +33,12 @@ class PagingState<T> {
   private var nextCursor: String? = null
   private val mutex = Mutex()
 
-  // The fetcher is passed *in* per call, not stored — so the retained holder never captures the
-  // repository. See the note under the presenter.
+  // Pass the fetcher per call so the retained holder only stores paging data.
   suspend fun loadNext(fetchPage: suspend (cursor: String?) -> Page<T>) {
-    // Fast best-effort bail so an overlapping call returns instead of queueing behind the load.
+    // Return early when another load is already running.
     if (endReached || isLoadingMore) return
     mutex.withLock {
-      if (endReached) return                 // re-check inside the lock: a queued caller may be past the end
+      if (endReached) return
       isLoadingMore = true
       try {
         val page = fetchPage(nextCursor)
@@ -49,18 +53,16 @@ class PagingState<T> {
 }
 ```
 
-The holder stores **only data** — items, cursor, flags. The fetcher is a `loadNext()` parameter, not
-a constructor-captured field, so the retained holder can never pull the repository (and whatever it
-references) onto the back stack.
+The holder stores only paging data: items, cursor, and flags. Pass the fetcher to `loadNext()` so the
+retained holder does not keep the repository on the back stack.
 
-The `Mutex.withLock` serializes loads so overlapping `LoadMore` events can't double-fetch; the
-pre-lock `isLoadingMore` check is just a fast bail to avoid queuing. `isLoadingMore` is observable
-state for the UI's loading spinner.
+`Mutex.withLock` serializes loads so overlapping `LoadMore` events cannot double-fetch.
+`isLoadingMore` is observable state for the UI's loading spinner.
 
 ## The presenter
 
 Create the holder with `rememberRetained` so accumulated pages survive rotation and the back stack.
-Load the first page from a `LaunchedImpressionEffect`; handle `LoadMore` events by launching
+Load the first page from `LaunchedImpressionEffect`; handle `LoadMore` events by launching
 `loadNext()`.
 
 ```kotlin
@@ -69,7 +71,7 @@ override fun present(): FeedState {
   val paging = rememberRetained { PagingState<FeedItem>() }
   val scope = rememberCoroutineScope()
 
-  // feedRepository comes from DI and is held by the presenter, not retained. Pass its fetcher in.
+  // feedRepository comes from DI. Pass its fetcher into the retained holder.
   LaunchedImpressionEffect(Unit) { paging.loadNext(feedRepository::page) }   // first page on open
 
   return FeedState(items = paging.items, isLoadingMore = paging.isLoadingMore) { event ->
@@ -90,8 +92,8 @@ override fun present(): FeedState {
 
 ## The UI
 
-The UI owns the `LazyListState`, so the "near the end" detection lives here. Derive the trigger with
-`derivedStateOf` so it only fires when the threshold is crossed, not on every scrolled pixel.
+The UI owns the `LazyListState`, so the "near the end" detection lives here. Use `derivedStateOf` so
+the trigger changes only when the threshold is crossed.
 
 ```kotlin
 @Composable
@@ -119,7 +121,7 @@ fun Feed(state: FeedState, modifier: Modifier = Modifier) {
 private const val PREFETCH_DISTANCE = 5
 ```
 
-**Heavier paging?** If you need cross-page placeholders, retries, and refresh out of the box,
+**Heavier paging?** If you need placeholders, retries, and refresh out of the box,
 [Jetpack Paging](https://developer.android.com/topic/libraries/architecture/paging/v3-overview)'s
 `Pager` exposes a `Flow<PagingData<T>>` you can collect with
 [`produceRetainedState`](observe-a-flow.md) instead of hand-rolling the holder above.

--- a/docs/recipes/paginate-a-list.md
+++ b/docs/recipes/paginate-a-list.md
@@ -1,0 +1,129 @@
+# [Recipe](index.md): Paginate a list (load more on scroll)
+
+**Problem:** a long list loads a page at a time; reaching the bottom should fetch the next page,
+without firing duplicate requests or losing accumulated items across recomposition.
+
+Pagination has several moving parts — accumulated items, the next cursor, an in-flight flag, an
+end-of-list flag. Rather than scatter four `rememberRetained` vars through `present()`, lift them into
+a small **presentation state holder** (the same idea as `EmailFieldState` in
+[Scaling Presenters](../presenter-patterns.md#use-cases-separating-business-logic)). The holder owns the Compose state; the
+presenter just creates it with `rememberRetained` and drives loading from an effect + events.
+
+## The holder
+
+A plain `@Stable` class with private-set state and one suspend `loadNext()`. It's reusable across any
+cursor-paged list.
+
+```kotlin
+@Stable
+class PagingState<T> {
+  private val loaded = mutableStateListOf<T>()
+  val items: List<T> get() = loaded
+
+  var isLoadingMore by mutableStateOf(false)
+    private set
+  var endReached by mutableStateOf(false)
+    private set
+
+  private var nextCursor: String? = null
+  private val mutex = Mutex()
+
+  // The fetcher is passed *in* per call, not stored — so the retained holder never captures the
+  // repository. See the note under the presenter.
+  suspend fun loadNext(fetchPage: suspend (cursor: String?) -> Page<T>) {
+    // Fast best-effort bail so an overlapping call returns instead of queueing behind the load.
+    if (endReached || isLoadingMore) return
+    mutex.withLock {
+      if (endReached) return                 // re-check inside the lock: a queued caller may be past the end
+      isLoadingMore = true
+      try {
+        val page = fetchPage(nextCursor)
+        loaded.addAll(page.items)
+        nextCursor = page.nextCursor
+        endReached = page.nextCursor == null
+      } finally {
+        isLoadingMore = false
+      }
+    }
+  }
+}
+```
+
+The holder stores **only data** — items, cursor, flags. The fetcher is a `loadNext()` parameter, not
+a constructor-captured field, so the retained holder can never pull the repository (and whatever it
+references) onto the back stack.
+
+The `Mutex.withLock` serializes loads so overlapping `LoadMore` events can't double-fetch; the
+pre-lock `isLoadingMore` check is just a fast bail to avoid queuing. `isLoadingMore` is observable
+state for the UI's loading spinner.
+
+## The presenter
+
+Create the holder with `rememberRetained` so accumulated pages survive rotation and the back stack.
+Load the first page from a `LaunchedImpressionEffect`; handle `LoadMore` events by launching
+`loadNext()`.
+
+```kotlin
+@Composable
+override fun present(): FeedState {
+  val paging = rememberRetained { PagingState<FeedItem>() }
+  val scope = rememberCoroutineScope()
+
+  // feedRepository comes from DI and is held by the presenter, not retained. Pass its fetcher in.
+  LaunchedImpressionEffect(Unit) { paging.loadNext(feedRepository::page) }   // first page on open
+
+  return FeedState(items = paging.items, isLoadingMore = paging.isLoadingMore) { event ->
+    when (event) {
+      FeedEvent.LoadMore -> scope.launch { paging.loadNext(feedRepository::page) }
+    }
+  }
+}
+```
+
+!!! warning "Don't capture the repository in the retained holder"
+    `rememberRetained { PagingState<FeedItem>() }` retains **only data** (items, cursor, flags) — never
+    the repository. Constructing it as `rememberRetained { PagingState(feedRepository::page) }` would
+    capture `feedRepository` (and its scopes, `Context`, etc.) in retained state, keeping it alive
+    across rotation and the back stack — the same leak class as
+    [retaining a `Flow`](observe-a-flow.md). The repository lives on the presenter via DI; the holder
+    receives its fetcher per `loadNext()` call.
+
+## The UI
+
+The UI owns the `LazyListState`, so the "near the end" detection lives here. Derive the trigger with
+`derivedStateOf` so it only fires when the threshold is crossed, not on every scrolled pixel.
+
+```kotlin
+@Composable
+fun Feed(state: FeedState, modifier: Modifier = Modifier) {
+  val listState = rememberLazyListState()
+  val shouldLoadMore by remember {
+    derivedStateOf {
+      val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+      lastVisible >= state.items.lastIndex - PREFETCH_DISTANCE
+    }
+  }
+
+  LaunchedEffect(shouldLoadMore) {
+    if (shouldLoadMore) state.eventSink(FeedEvent.LoadMore)
+  }
+
+  LazyColumn(state = listState, modifier = modifier) {
+    items(state.items, key = { item -> item.id }) { item -> FeedRow(item) }
+    if (state.isLoadingMore) {
+      item { CircularProgressIndicator(Modifier.fillMaxWidth().wrapContentWidth()) }
+    }
+  }
+}
+
+private const val PREFETCH_DISTANCE = 5
+```
+
+**Heavier paging?** If you need cross-page placeholders, retries, and refresh out of the box,
+[Jetpack Paging](https://developer.android.com/topic/libraries/architecture/paging/v3-overview)'s
+`Pager` exposes a `Flow<PagingData<T>>` you can collect with
+[`produceRetainedState`](observe-a-flow.md) instead of hand-rolling the holder above.
+
+**See also:** [Observe a Flow](observe-a-flow.md) ·
+[Scaling Presenters: state holders](../presenter-patterns.md#use-cases-separating-business-logic) ·
+[Keep UI state across config change](keep-state-across-config-change.md)

--- a/docs/recipes/pull-to-refresh.md
+++ b/docs/recipes/pull-to-refresh.md
@@ -50,9 +50,9 @@ fun Feed(state: FeedState, modifier: Modifier = Modifier) {
 
 !!! note
     `feedRepository.refresh()` should be a quick trigger that causes the underlying Flow to re-emit.
-    If it kicks off genuinely long-running work, that work belongs in the data layer scoped to
-    something that outlives the screen — not launched from `rememberCoroutineScope()`, which is
-    cancelled when the presenter leaves composition. See
+    If it starts long-running work, that work belongs in the data layer, scoped to something that
+    outlives the screen. `rememberCoroutineScope()` is cancelled when the presenter leaves
+    composition. See
     [run a one-shot suspend action](run-suspend-from-event.md).
 
 **See also:** [Retry a failed load](retry-a-failed-load.md) · [Observe a Flow](observe-a-flow.md) ·

--- a/docs/recipes/pull-to-refresh.md
+++ b/docs/recipes/pull-to-refresh.md
@@ -1,0 +1,59 @@
+# [Recipe](index.md): Pull to refresh
+
+**Problem:** the user pulls down to refresh a list. You need a refreshing flag that's separate from
+the initial load, plus a way to trigger the refresh.
+
+Keep `isRefreshing` as presenter state, set it when the refresh starts, and clear it when the data
+comes back. Trigger the actual work through the repository.
+
+```kotlin
+@Composable
+override fun present(): FeedState {
+  val scope = rememberCoroutineScope()
+  var isRefreshing by rememberRetained { mutableStateOf(false) }
+
+  val items by produceRetainedState<List<FeedItem>>(emptyList()) {
+    feedRepository.items().collect { latest ->
+      value = latest
+      isRefreshing = false   // data arrived → stop the spinner
+    }
+  }
+
+  return FeedState(items = items, isRefreshing = isRefreshing) { event ->
+    when (event) {
+      FeedEvent.Refresh -> {
+        isRefreshing = true
+        scope.launch { feedRepository.refresh() }   // short, UI-tied work — see note below
+      }
+    }
+  }
+}
+```
+
+In the UI, wire `isRefreshing` and the event to Compose's
+[`PullToRefreshBox`](https://developer.android.com/develop/ui/compose/components/pull-to-refresh):
+
+```kotlin
+@Composable
+fun Feed(state: FeedState, modifier: Modifier = Modifier) {
+  PullToRefreshBox(
+    isRefreshing = state.isRefreshing,
+    onRefresh = { state.eventSink(FeedEvent.Refresh) },
+    modifier = modifier,
+  ) {
+    LazyColumn {
+      items(state.items, key = { item -> item.id }) { item -> FeedRow(item) }
+    }
+  }
+}
+```
+
+!!! note
+    `feedRepository.refresh()` should be a quick trigger that causes the underlying Flow to re-emit.
+    If it kicks off genuinely long-running work, that work belongs in the data layer scoped to
+    something that outlives the screen — not launched from `rememberCoroutineScope()`, which is
+    cancelled when the presenter leaves composition. See
+    [run a one-shot suspend action](run-suspend-from-event.md).
+
+**See also:** [Retry a failed load](retry-a-failed-load.md) · [Observe a Flow](observe-a-flow.md) ·
+[Compose pull-to-refresh](https://developer.android.com/develop/ui/compose/components/pull-to-refresh)

--- a/docs/recipes/retry-a-failed-load.md
+++ b/docs/recipes/retry-a-failed-load.md
@@ -1,0 +1,41 @@
+# [Recipe](index.md): Retry a failed load
+
+**Problem:** a load failed and the user taps "Retry". You need to re-run the load and show the
+loading state again.
+
+Drive retries with a counter held in `rememberRetained`. Use it as a key to `produceRetainedState` —
+bumping it re-runs the producer. This keeps the retry trigger in the presenter and avoids exposing
+imperative "reload" methods.
+
+```kotlin
+@Composable
+override fun present(): ArticleState {
+  var retryCount by rememberRetained { mutableIntStateOf(0) }
+
+  val result by produceRetainedState<ArticleResult>(ArticleResult.Loading, screen.id, retryCount) {
+    value = ArticleResult.Loading
+    value = articleRepository.load(screen.id)   // suspend one-shot that returns success/failure
+  }
+
+  return when (val current = result) {
+    ArticleResult.Loading -> ArticleState.Loading
+    is ArticleResult.Success -> ArticleState.Loaded(current.article)
+    is ArticleResult.Failure ->
+      ArticleState.Error(current.message) { event ->
+        when (event) {
+          ErrorEvent.Retry -> retryCount++   // changes the key → producer re-runs
+        }
+      }
+  }
+}
+```
+
+Because `retryCount` is one of the producer's keys, incrementing it cancels any in-flight work,
+resets to `Loading`, and re-runs the load.
+
+If your data source is a `Flow` rather than a one-shot suspend call, expose a `refresh()` on the
+repository instead and call it from the event — the Flow re-emits and your `produceRetainedState`
+collector ([observing a Flow](observe-a-flow.md)) picks it up without a counter.
+
+**See also:** [Show loading, loaded, and error states](loading-states.md) ·
+[Pull to refresh](pull-to-refresh.md)

--- a/docs/recipes/retry-a-failed-load.md
+++ b/docs/recipes/retry-a-failed-load.md
@@ -3,9 +3,8 @@
 **Problem:** a load failed and the user taps "Retry". You need to re-run the load and show the
 loading state again.
 
-Drive retries with a counter held in `rememberRetained`. Use it as a key to `produceRetainedState` —
-bumping it re-runs the producer. This keeps the retry trigger in the presenter and avoids exposing
-imperative "reload" methods.
+Drive retries with a counter held in `rememberRetained`. Use it as a key to `produceRetainedState`;
+incrementing it re-runs the producer.
 
 ```kotlin
 @Composable

--- a/docs/recipes/return-a-result.md
+++ b/docs/recipes/return-a-result.md
@@ -3,8 +3,8 @@
 **Problem:** you navigate to a screen (a picker, an editor) and need the value it produces back on
 the calling screen — surviving process death.
 
-Use the *answering navigator*. The caller wraps its `Navigator` with `rememberAnsweringNavigator<R>`
-and a callback; the target screen pops a `PopResult`, and Circuit delivers it only to the caller that
+Use the **answering navigator**. The caller wraps its `Navigator` with `rememberAnsweringNavigator<R>`
+and a callback. The target screen pops a `PopResult`, and Circuit delivers it only to the caller that
 asked.
 
 ## 1. Define the result
@@ -61,9 +61,9 @@ treat that as "cancelled".
 
 ## Screen result vs. overlay
 
-If the thing you're asking for is an **ephemeral prompt** (confirm, pick from a sheet) rather than a
-full destination, an [overlay](confirmation-dialog.md) is usually a better fit — it's type-safe and
-suspends on the result, though it doesn't survive process death. Full comparison in the
+If the thing you're asking for is a prompt, such as confirm or pick from a sheet, an
+[overlay](confirmation-dialog.md) is usually a better fit. It's type-safe and suspends on the
+result, though it doesn't survive process death. Full comparison in the
 [Overlays doc](../overlays.md#overlay-vs-popresult).
 
 **See also:** [Navigation: results](../navigation.md#results) ·

--- a/docs/recipes/return-a-result.md
+++ b/docs/recipes/return-a-result.md
@@ -1,0 +1,70 @@
+# [Recipe](index.md): Return a result to the previous screen
+
+**Problem:** you navigate to a screen (a picker, an editor) and need the value it produces back on
+the calling screen — surviving process death.
+
+Use the *answering navigator*. The caller wraps its `Navigator` with `rememberAnsweringNavigator<R>`
+and a callback; the target screen pops a `PopResult`, and Circuit delivers it only to the caller that
+asked.
+
+## 1. Define the result
+
+`PopResult` extends `Parcelable`, so results survive process death. `@Parcelize` is the easy way to
+satisfy that.
+
+```kotlin
+@Parcelize
+data object EditNameScreen : Screen
+
+@Parcelize
+data class EditNameResult(val name: String) : PopResult
+```
+
+## 2. Caller: request and receive
+
+```kotlin
+@Composable
+override fun present(): ProfileState {
+  var name by rememberRetained { mutableStateOf("") }
+
+  val editNameNavigator =
+    rememberAnsweringNavigator<EditNameResult>(navigator) { result ->
+      name = result.name        // delivered here when the target pops
+    }
+
+  return ProfileState(name) { event ->
+    when (event) {
+      ProfileEvent.EditName -> editNameNavigator.goTo(EditNameScreen)
+    }
+  }
+}
+```
+
+## 3. Target: pop the result
+
+```kotlin
+@Composable
+override fun present(): EditNameState {
+  var draft by rememberRetained { mutableStateOf("") }
+
+  return EditNameState(draft) { event ->
+    when (event) {
+      is EditNameEvent.TextChanged -> draft = event.text
+      EditNameEvent.Save -> navigator.pop(result = EditNameResult(draft))
+    }
+  }
+}
+```
+
+If the target pops without a result (e.g. the user backs out), the callback simply never fires —
+treat that as "cancelled".
+
+## Screen result vs. overlay
+
+If the thing you're asking for is an **ephemeral prompt** (confirm, pick from a sheet) rather than a
+full destination, an [overlay](confirmation-dialog.md) is usually a better fit — it's type-safe and
+suspends on the result, though it doesn't survive process death. Full comparison in the
+[Overlays doc](../overlays.md#overlay-vs-popresult).
+
+**See also:** [Navigation: results](../navigation.md#results) ·
+[Ask for confirmation with a dialog](confirmation-dialog.md)

--- a/docs/recipes/reusable-component-subcircuit.md
+++ b/docs/recipes/reusable-component-subcircuit.md
@@ -1,0 +1,94 @@
+# [Recipe](index.md): Embed a reusable component that delegates navigation
+
+**Problem:** you have a UI block reused across screens (a profile card, a list row, an embedded
+widget) that emits events — but it shouldn't own navigation. The host screen should decide what a tap
+means.
+
+**Reach for SubCircuit.** It's purpose-built for embedded components: the child gets no `Navigator`
+and delegates everything it can't handle (navigation, dialogs) to its host through an
+`outerEventSink`. That's almost always what you want when one screen's content is composed *inside*
+another.
+
+Pick by how coupled the component is
+([background](https://github.com/slackhq/circuit/pull/2727#issuecomment-4636017793)):
+
+| The component… | Tool |
+|----------------|------|
+| is mostly standalone but defers navigation/dialogs to its host | [`SubCircuit`](#subcircuit-the-default-for-embedding) ← **default** |
+| must share live state with its siblings (selection mode, a shared filter) | hoist into the parent presenter — see [shared selection state](shared-selection-state.md) |
+| is a fully independent destination that just happens to render here, and needs its own `Navigator` | bare [`CircuitContent`](#bare-circuitcontent-the-exception) |
+
+## SubCircuit: the default for embedding
+
+A `SubPresenter` gets no `Navigator` — it receives an `outerEventSink` and pushes anything it can't
+handle up to the parent. The child needs no `Parcelable` screen.
+
+```kotlin
+// 1. Outer events the parent handles, and a SubScreen key (no Parcelable needed).
+sealed interface ProfileCardOuterEvent : SubCircuitOuterEvent {
+  data class OpenProfile(val userId: String) : ProfileCardOuterEvent
+}
+
+data class ProfileCardScreen(val userId: String) : SubScreen<ProfileCardOuterEvent>
+
+// 2. SubPresenter receives outerEventSink instead of a Navigator.
+class ProfileCardPresenter(private val screen: ProfileCardScreen) :
+  SubPresenter<ProfileCardOuterEvent, ProfileCardState> {
+
+  @Composable
+  override fun present(outerEventSink: (ProfileCardOuterEvent) -> Unit): ProfileCardState =
+    ProfileCardState(userId = screen.userId) { event ->
+      when (event) {
+        ProfileCardUiEvent.Clicked ->
+          outerEventSink(ProfileCardOuterEvent.OpenProfile(screen.userId))
+      }
+    }
+}
+```
+
+The host renders it with `SubCircuitContent` and maps the outer events onto its own:
+
+```kotlin
+@Composable
+fun TeamMembers(state: TeamMembersState, modifier: Modifier = Modifier) {
+  LazyColumn(modifier) {
+    items(state.members, key = { member -> member.id }) { member ->
+      SubCircuitContent(
+        screen = ProfileCardScreen(member.id),
+        outerEventSink = { outerEvent ->
+          when (outerEvent) {
+            is ProfileCardOuterEvent.OpenProfile ->
+              state.eventSink(TeamMembersEvent.OpenProfile(outerEvent.userId))
+          }
+        },
+      )
+    }
+  }
+}
+```
+
+This is the same "curry the child's events up to the parent" idea as `CircuitContent`'s `onNavEvent`
+overload — SubCircuit just formalizes it and removes the child's `Navigator` entirely.
+
+## Bare CircuitContent: the exception
+
+Only reach for plain `CircuitContent` when the embedded thing is a **fully independent destination**
+that needs its own `Navigator` — e.g. a self-contained section that navigates on its own and merely
+happens to render inside this screen. It gives the child the ambient `Navigator`, which is exactly
+what you *don't* want for a delegating component.
+
+```kotlin
+@Composable
+fun Dashboard(state: DashboardState, modifier: Modifier = Modifier) {
+  Column(modifier) {
+    CircuitContent(ProfileHeaderScreen(state.userId))   // runs its own presenter + UI, own nav
+    CircuitContent(ActivityFeedScreen(state.userId))
+  }
+}
+```
+
+If you find yourself reaching for `CircuitContent`'s `onNavEvent` overload to curry a child's
+navigation up to the parent, that's the signal you actually wanted SubCircuit.
+
+**See also:** [SubCircuit](../circuitx/subcircuit.md) · [CircuitContent](../circuit-content.md) ·
+[Share selection state across list items](shared-selection-state.md)

--- a/docs/recipes/reusable-component-subcircuit.md
+++ b/docs/recipes/reusable-component-subcircuit.md
@@ -4,27 +4,26 @@
 widget) that emits events — but it shouldn't own navigation. The host screen should decide what a tap
 means.
 
-**Reach for SubCircuit.** It's purpose-built for embedded components: the child gets no `Navigator`
-and delegates everything it can't handle (navigation, dialogs) to its host through an
-`outerEventSink`. That's almost always what you want when one screen's content is composed *inside*
-another.
+Use `SubCircuit` for embedded components. The child gets no `Navigator`; it sends navigation and other
+host-owned events through an `outerEventSink`. That's almost always what you want when one screen's
+content is composed *inside* another.
 
-Pick by how coupled the component is
+Pick based on how independent the component is
 ([background](https://github.com/slackhq/circuit/pull/2727#issuecomment-4636017793)):
 
-| The component… | Tool |
-|----------------|------|
-| is mostly standalone but defers navigation/dialogs to its host | [`SubCircuit`](#subcircuit-the-default-for-embedding) ← **default** |
-| must share live state with its siblings (selection mode, a shared filter) | hoist into the parent presenter — see [shared selection state](shared-selection-state.md) |
-| is a fully independent destination that just happens to render here, and needs its own `Navigator` | bare [`CircuitContent`](#bare-circuitcontent-the-exception) |
+| The component…                                                                                     | Tool                                                                                      |
+|----------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| is mostly standalone but defers navigation/dialogs to its host                                     | [`SubCircuit`](#subcircuit-the-default-for-embedding)                                     |
+| must share live state with its siblings (selection mode, a shared filter)                          | hoist into the parent presenter — see [shared selection state](shared-selection-state.md) |
+| is a fully independent destination that just happens to render here, and needs its own `Navigator` | bare [`CircuitContent`](#bare-circuitcontent-the-exception)                               |
 
 ## SubCircuit: the default for embedding
 
-A `SubPresenter` gets no `Navigator` — it receives an `outerEventSink` and pushes anything it can't
-handle up to the parent. The child needs no `Parcelable` screen.
+A `SubPresenter` receives an `outerEventSink` instead of a `Navigator`. The child needs no
+`Parcelable` screen.
 
 ```kotlin
-// 1. Outer events the parent handles, and a SubScreen key (no Parcelable needed).
+// 1. Outer events the parent handles, plus a SubScreen key.
 sealed interface ProfileCardOuterEvent : SubCircuitOuterEvent {
   data class OpenProfile(val userId: String) : ProfileCardOuterEvent
 }
@@ -46,7 +45,7 @@ class ProfileCardPresenter(private val screen: ProfileCardScreen) :
 }
 ```
 
-The host renders it with `SubCircuitContent` and maps the outer events onto its own:
+The host renders it with `SubCircuitContent` and maps outer events to its own events:
 
 ```kotlin
 @Composable
@@ -67,15 +66,12 @@ fun TeamMembers(state: TeamMembersState, modifier: Modifier = Modifier) {
 }
 ```
 
-This is the same "curry the child's events up to the parent" idea as `CircuitContent`'s `onNavEvent`
-overload — SubCircuit just formalizes it and removes the child's `Navigator` entirely.
+This keeps the child reusable while leaving navigation decisions with the host.
 
 ## Bare CircuitContent: the exception
 
-Only reach for plain `CircuitContent` when the embedded thing is a **fully independent destination**
-that needs its own `Navigator` — e.g. a self-contained section that navigates on its own and merely
-happens to render inside this screen. It gives the child the ambient `Navigator`, which is exactly
-what you *don't* want for a delegating component.
+Use plain `CircuitContent` only when the embedded content is a fully independent destination that
+needs its own `Navigator`, such as a self-contained section that navigates on its own.
 
 ```kotlin
 @Composable
@@ -87,8 +83,8 @@ fun Dashboard(state: DashboardState, modifier: Modifier = Modifier) {
 }
 ```
 
-If you find yourself reaching for `CircuitContent`'s `onNavEvent` overload to curry a child's
-navigation up to the parent, that's the signal you actually wanted SubCircuit.
+If you are reaching for `CircuitContent`'s `onNavEvent` overload to send child navigation up to the
+parent, use `SubCircuit` instead.
 
 **See also:** [SubCircuit](../circuitx/subcircuit.md) · [CircuitContent](../circuit-content.md) ·
 [Share selection state across list items](shared-selection-state.md)

--- a/docs/recipes/run-suspend-from-event.md
+++ b/docs/recipes/run-suspend-from-event.md
@@ -1,7 +1,7 @@
 # [Recipe](index.md): Run a one-shot suspend action from an event
 
-**Problem:** a button tap needs to call a `suspend` function (save, send, toggle) — but a presenter's
-`present()` isn't a coroutine, and you must not block it.
+**Problem:** a button tap needs to call a `suspend` function (save, send, toggle, etc.), but a
+presenter's `present()` isn't a coroutine and you must not block it.
 
 Launch from a `rememberCoroutineScope()` in the event handler:
 
@@ -27,19 +27,18 @@ override fun present(): ComposerState {
 ## The catch: this scope dies with the composition
 
 `rememberCoroutineScope()` is tied to the presenter's place in composition. It's **cancelled** the
-moment the presenter leaves composition — a configuration change, the screen being popped, navigating
-away. That's correct for short, UI-tied work (a quick save where, if the user leaves, abandoning it is
-fine).
+moment the presenter leaves composition: a configuration change, the screen being popped, or
+navigating away. That's fine for short, UI-tied work that can be abandoned if the user leaves.
 
-It is **wrong** for work that must finish regardless of the UI:
+Do not use it for work that must finish regardless of the UI:
 
 ```kotlin
-// 🚫 If the user navigates away mid-upload, this is cancelled and the upload is lost.
+// 🚫 If the user navigates away mid-upload, this is cancelled!
 scope.launch { fileRepository.upload(hugeFile) }
 ```
 
 Push fire-and-forget or must-complete work into the **data layer**, scoped to something that outlives
-the screen (a repository/use-case that owns an application- or user-scoped coroutine scope):
+the screen:
 
 ```kotlin
 // ✅ The repository owns a longer-lived scope; the presenter just triggers it.

--- a/docs/recipes/run-suspend-from-event.md
+++ b/docs/recipes/run-suspend-from-event.md
@@ -1,0 +1,52 @@
+# [Recipe](index.md): Run a one-shot suspend action from an event
+
+**Problem:** a button tap needs to call a `suspend` function (save, send, toggle) — but a presenter's
+`present()` isn't a coroutine, and you must not block it.
+
+Launch from a `rememberCoroutineScope()` in the event handler:
+
+```kotlin
+@Composable
+override fun present(): ComposerState {
+  val scope = rememberCoroutineScope()
+  var sending by rememberRetained { mutableStateOf(false) }
+
+  return ComposerState(isSending = sending) { event ->
+    when (event) {
+      is ComposerEvent.Send ->
+        scope.launch {
+          sending = true
+          messageRepository.send(event.text)
+          sending = false
+        }
+    }
+  }
+}
+```
+
+## The catch: this scope dies with the composition
+
+`rememberCoroutineScope()` is tied to the presenter's place in composition. It's **cancelled** the
+moment the presenter leaves composition — a configuration change, the screen being popped, navigating
+away. That's correct for short, UI-tied work (a quick save where, if the user leaves, abandoning it is
+fine).
+
+It is **wrong** for work that must finish regardless of the UI:
+
+```kotlin
+// 🚫 If the user navigates away mid-upload, this is cancelled and the upload is lost.
+scope.launch { fileRepository.upload(hugeFile) }
+```
+
+Push fire-and-forget or must-complete work into the **data layer**, scoped to something that outlives
+the screen (a repository/use-case that owns an application- or user-scoped coroutine scope):
+
+```kotlin
+// ✅ The repository owns a longer-lived scope; the presenter just triggers it.
+is ComposerEvent.Send -> uploadManager.enqueue(event.file)
+```
+
+Rule of thumb: if the result still matters after the user leaves the screen, it doesn't belong on
+`rememberCoroutineScope()`.
+
+**See also:** [Pull to refresh](pull-to-refresh.md) · [Presenter](../presenter.md)

--- a/docs/recipes/shared-selection-state.md
+++ b/docs/recipes/shared-selection-state.md
@@ -1,0 +1,81 @@
+# [Recipe](index.md): Share selection state across list items
+
+**Problem:** long-pressing a list row enters Gmail-style bulk-selection. Every row must know
+selection mode is active — even though *another* row triggered it — and show a checkbox.
+
+This is the **coordinated** case: the rows aren't independent, they share live state. Don't try to
+sync that between sibling nested Circuits or SubCircuits — that state ping-pongs and never converges.
+Hoist it into **one parent presenter** and render rows as plain composables (or with a
+[StateProducer](../presenter-patterns.md#pattern-3-stateproducer) if the per-row logic is heavy).
+
+```kotlin
+data class InboxState(
+  val rows: List<RowState>,
+  val inSelectionMode: Boolean,
+  val eventSink: (InboxEvent) -> Unit,
+) : CircuitUiState
+
+data class RowState(val id: MessageId, val subject: String, val selected: Boolean)
+
+sealed interface InboxEvent : CircuitUiEvent {
+  data class LongPress(val id: MessageId) : InboxEvent
+  data class Toggle(val id: MessageId) : InboxEvent
+  data object ClearSelection : InboxEvent
+}
+```
+
+The parent presenter owns the selection set; every row's `selected` flag is derived from it, so a
+change made by one row is reflected in all of them on the next state emission:
+
+```kotlin
+@Composable
+override fun present(): InboxState {
+  val messages by produceRetainedState<List<Message>>(emptyList()) {
+    inboxRepository.messages().collect { latest -> value = latest }
+  }
+  val selected = rememberRetained { mutableStateSetOf<MessageId>() }
+
+  // derivedStateOf so the rows list is only rebuilt when `messages` or `selected` actually change,
+  // not on every recomposition.
+  val rows by remember(messages) {
+    derivedStateOf {
+      messages.map { message ->
+        RowState(message.id, message.subject, selected = message.id in selected)
+      }
+    }
+  }
+
+  return InboxState(rows = rows, inSelectionMode = selected.isNotEmpty()) { event ->
+    when (event) {
+      is InboxEvent.LongPress -> selected.add(event.id)
+      is InboxEvent.Toggle ->
+        if (event.id in selected) selected.remove(event.id) else selected.add(event.id)
+      InboxEvent.ClearSelection -> selected.clear()
+    }
+  }
+}
+```
+
+Rows are dumb composables that read their `selected` flag and report events upward — no per-row
+presenter, no cross-row messaging:
+
+```kotlin
+@Composable
+private fun MessageRow(row: RowState, inSelectionMode: Boolean, eventSink: (InboxEvent) -> Unit) {
+  Row(
+    Modifier.combinedClickable(
+      onClick = { if (inSelectionMode) eventSink(InboxEvent.Toggle(row.id)) /* else open */ },
+      onLongClick = { eventSink(InboxEvent.LongPress(row.id)) },
+    )
+  ) {
+    if (inSelectionMode) Checkbox(checked = row.selected, onCheckedChange = null)
+    Text(row.subject)
+  }
+}
+```
+
+**Rule of thumb:** if you find yourself wanting to push shared state *into* each child's `Screen`, the
+children aren't really independent — model the shared state in the parent instead.
+
+**See also:** [Presenter patterns: StateProducer](../presenter-patterns.md#pattern-3-stateproducer) ·
+[Embed a reusable component](reusable-component-subcircuit.md)

--- a/docs/recipes/shared-selection-state.md
+++ b/docs/recipes/shared-selection-state.md
@@ -1,12 +1,11 @@
 # [Recipe](index.md): Share selection state across list items
 
 **Problem:** long-pressing a list row enters Gmail-style bulk-selection. Every row must know
-selection mode is active — even though *another* row triggered it — and show a checkbox.
+selection mode is active (even though *another* row triggered it) and show a checkbox.
 
-This is the **coordinated** case: the rows aren't independent, they share live state. Don't try to
-sync that between sibling nested Circuits or SubCircuits — that state ping-pongs and never converges.
-Hoist it into **one parent presenter** and render rows as plain composables (or with a
-[StateProducer](../presenter-patterns.md#pattern-3-stateproducer) if the per-row logic is heavy).
+Rows in selection mode are not independent; they share live state. Keep that state in **one parent
+presenter** and render rows as plain composables. If per-row logic gets heavy, use a
+[StateProducer](../presenter-patterns.md#pattern-3-stateproducer).
 
 ```kotlin
 data class InboxState(
@@ -35,8 +34,7 @@ override fun present(): InboxState {
   }
   val selected = rememberRetained { mutableStateSetOf<MessageId>() }
 
-  // derivedStateOf so the rows list is only rebuilt when `messages` or `selected` actually change,
-  // not on every recomposition.
+  // Rebuild rows only when messages or selection changes.
   val rows by remember(messages) {
     derivedStateOf {
       messages.map { message ->
@@ -56,8 +54,7 @@ override fun present(): InboxState {
 }
 ```
 
-Rows are dumb composables that read their `selected` flag and report events upward — no per-row
-presenter, no cross-row messaging:
+Rows read their `selected` flag and report events upward:
 
 ```kotlin
 @Composable
@@ -74,8 +71,7 @@ private fun MessageRow(row: RowState, inSelectionMode: Boolean, eventSink: (Inbo
 }
 ```
 
-**Rule of thumb:** if you find yourself wanting to push shared state *into* each child's `Screen`, the
-children aren't really independent — model the shared state in the parent instead.
+**Rule of thumb:** if children need shared state, model that state in the parent.
 
 **See also:** [Presenter patterns: StateProducer](../presenter-patterns.md#pattern-3-stateproducer) ·
 [Embed a reusable component](reusable-component-subcircuit.md)

--- a/docs/recipes/tabs-with-back-stacks.md
+++ b/docs/recipes/tabs-with-back-stacks.md
@@ -1,0 +1,108 @@
+# [Recipe](index.md): Tabs with independent back stacks
+
+**Problem:** a bottom-navigation app where each tab keeps its own navigation history — switching tabs
+and coming back lands you where you left off, not at the tab's root.
+
+Make the tab host its **own Circuit UI** that owns a nested navigable surface: it sets up its own
+`navStack` + `Navigator` internally and renders a `NavigableCircuitContent` for the current tab.
+Switching tabs is a `resetRoot` with `StateOptions.SaveAndRestore`, which snapshots the outgoing
+tab's stack and restores the incoming one.
+
+```kotlin
+@Parcelize
+data object HomeScreen : Screen
+
+// One entry per tab. Each knows its root Screen and how to render in the bottom bar.
+enum class HomeTab(val rootScreen: Screen, val label: String, val icon: ImageVector) {
+  Feed(FeedScreen, "Feed", Icons.Default.Home),
+  Search(SearchScreen, "Search", Icons.Default.Search),
+  Profile(ProfileScreen, "Profile", Icons.Default.Person);
+
+  companion object {
+    fun of(rootScreen: Screen): HomeTab = entries.first { it.rootScreen == rootScreen }
+  }
+}
+```
+
+The UI owns the nested `navStack`/`navigator`, so **tab switching is just a navigator call in the
+`onClick`** — the click is the event. There's no presenter tab state and no
+`LaunchedEffect(currentTab)` bridging state back to the navigator (which would re-run on every
+replay/config change and clobber the restored stack). The selected tab is *derived* from the nav
+stack's current root, so the bar always reflects reality:
+
+```kotlin
+@CircuitInject(HomeScreen::class, AppScope::class)
+@Composable
+fun Home(modifier: Modifier = Modifier) {
+  // This tab host owns its own navigable surface.
+  val navStack = rememberSaveableNavStack(HomeTab.entries.first().rootScreen)
+  val navigator = rememberCircuitNavigator(navStack) {
+    // Do something when the root screen is popped, usually exiting the app
+  }
+
+  // Highlight follows the actual stack *root* — no separate "current tab" state to keep in sync.
+  val currentTab by remember {
+    derivedStateOf { navStack.rootRecord?.screen?.let(HomeTab::of) ?: HomeTab.entries.first() }
+  }
+
+  Scaffold(
+    modifier = modifier,
+    bottomBar = {
+      NavigationBar {
+        HomeTab.entries.forEach { tab ->
+          NavigationBarItem(
+            selected = tab == currentTab,
+            onClick = { navigator.resetRoot(tab.rootScreen, StateOptions.SaveAndRestore) },
+            icon = { Icon(tab.icon, contentDescription = tab.label) },
+            label = { Text(tab.label) },
+          )
+        }
+      }
+    },
+  ) { padding ->
+    NavigableCircuitContent(navigator, navStack, modifier = Modifier.padding(padding))
+  }
+}
+```
+
+`HomeScreen` needs no presenter — it's a [`StaticScreen`](../ui.md#static-ui) whose UI owns all its
+own state. (If you'd rather not make it static, a presenter returning a trivial state works too; the
+point is that none of the tab logic lives there.)
+
+The mechanism:
+
+- The nested `navigator` / `navStack` live **inside** the tab host, so the tabs are a self-contained
+  navigable surface embedded in the screen — not wired up by the caller.
+- Switching is a direct `resetRoot` in the `onClick`, so it fires exactly once per tap — no effect to
+  replay. `SaveAndRestore` snapshots the current tab's stack before swapping roots and restores the
+  target tab's saved stack if it has one. Open **Feed**, drill into `DetailScreen`, switch to
+  **Profile**, switch back — `DetailScreen` is still on top.
+- The first visit to a tab has nothing to restore, so it starts at that tab's `rootScreen`.
+
+Don't track per-tab stacks — or even a "current tab" field — yourself. The nav stack root *is* the
+selected tab, and `SaveAndRestore` is the whole feature.
+
+## The full `StateOptions` API
+
+`resetRoot` takes a [`Navigator.StateOptions`](https://slackhq.github.io/circuit/api/0.x/circuit-runtime/com.slack.circuit.runtime/-navigator/-state-options/),
+a `data class` of three independent flags (all default `false`):
+
+| Flag | Effect |
+|------|--------|
+| `save` | Save the **current** entry list before resetting, keyed by the current root screen. It can be restored later by resetting back to that root with `restore = true`. |
+| `restore` | If the new root has previously-saved state, restore that whole stack instead of starting fresh. If `false` or there's nothing saved, the stack becomes just the new root. |
+| `clear` | Discard any saved state for the new root. Applied *after* a restore, regardless of `restore`. |
+
+Two presets cover the common patterns:
+
+| Preset | Equivalent | Use |
+|--------|------------|-----|
+| `StateOptions.Default` | `StateOptions()` | single back stack — save/restore nothing |
+| `StateOptions.SaveAndRestore` | `StateOptions(save = true, restore = true)` | multiple back stacks (this recipe) |
+
+For anything else, construct one directly — e.g. save the outgoing stack but always start the new
+tab fresh: `StateOptions(save = true, restore = false)`.
+
+**See also:** [Navigation](../navigation.md) ·
+[`StateOptions` API](https://slackhq.github.io/circuit/api/0.x/circuit-runtime/com.slack.circuit.runtime/-navigator/-state-options/) ·
+the [bottom-navigation sample](https://github.com/slackhq/circuit/tree/main/samples/bottom-navigation)

--- a/docs/recipes/tabs-with-back-stacks.md
+++ b/docs/recipes/tabs-with-back-stacks.md
@@ -3,10 +3,9 @@
 **Problem:** a bottom-navigation app where each tab keeps its own navigation history — switching tabs
 and coming back lands you where you left off, not at the tab's root.
 
-Make the tab host its **own Circuit UI** that owns a nested navigable surface: it sets up its own
-`navStack` + `Navigator` internally and renders a `NavigableCircuitContent` for the current tab.
-Switching tabs is a `resetRoot` with `StateOptions.SaveAndRestore`, which snapshots the outgoing
-tab's stack and restores the incoming one.
+Make the tab host a Circuit UI that owns its own `NavStack`, `Navigator`, and
+`NavigableCircuitContent`. Switch tabs with `resetRoot(..., StateOptions.SaveAndRestore)` so each
+tab keeps its stack.
 
 ```kotlin
 @Parcelize
@@ -24,11 +23,8 @@ enum class HomeTab(val rootScreen: Screen, val label: String, val icon: ImageVec
 }
 ```
 
-The UI owns the nested `navStack`/`navigator`, so **tab switching is just a navigator call in the
-`onClick`** — the click is the event. There's no presenter tab state and no
-`LaunchedEffect(currentTab)` bridging state back to the navigator (which would re-run on every
-replay/config change and clobber the restored stack). The selected tab is *derived* from the nav
-stack's current root, so the bar always reflects reality:
+The UI owns the nested `NavStack` and `Navigator`, so tab switching can happen directly from the tab
+click. The selected tab is derived from the nav stack's current root:
 
 ```kotlin
 @CircuitInject(HomeScreen::class, AppScope::class)
@@ -40,7 +36,7 @@ fun Home(modifier: Modifier = Modifier) {
     // Do something when the root screen is popped, usually exiting the app
   }
 
-  // Highlight follows the actual stack *root* — no separate "current tab" state to keep in sync.
+  // Highlight follows the stack root.
   val currentTab by remember {
     derivedStateOf { navStack.rootRecord?.screen?.let(HomeTab::of) ?: HomeTab.entries.first() }
   }
@@ -65,40 +61,37 @@ fun Home(modifier: Modifier = Modifier) {
 }
 ```
 
-`HomeScreen` needs no presenter — it's a [`StaticScreen`](../ui.md#static-ui) whose UI owns all its
-own state. (If you'd rather not make it static, a presenter returning a trivial state works too; the
-point is that none of the tab logic lives there.)
+`HomeScreen` can be a [`StaticScreen`](../ui.md#static-ui) because the UI owns the nested navigation
+state. A presenter returning a trivial state works too; the tab logic still stays in the UI.
 
-The mechanism:
+What this gives you:
 
-- The nested `navigator` / `navStack` live **inside** the tab host, so the tabs are a self-contained
-  navigable surface embedded in the screen — not wired up by the caller.
-- Switching is a direct `resetRoot` in the `onClick`, so it fires exactly once per tap — no effect to
-  replay. `SaveAndRestore` snapshots the current tab's stack before swapping roots and restores the
-  target tab's saved stack if it has one. Open **Feed**, drill into `DetailScreen`, switch to
-  **Profile**, switch back — `DetailScreen` is still on top.
-- The first visit to a tab has nothing to restore, so it starts at that tab's `rootScreen`.
+- The nested `Navigator` and `BavStack` live inside the tab host.
+- `SaveAndRestore` saves the outgoing tab's stack and restores the target tab's saved stack when it
+  has one. Open **Feed**, drill into `DetailScreen`, switch to **Profile**, switch back, and
+  `DetailScreen` is still on top.
+- The first visit to a tab has nothing to restore, so it starts at that tab's root screen.
 
-Don't track per-tab stacks — or even a "current tab" field — yourself. The nav stack root *is* the
-selected tab, and `SaveAndRestore` is the whole feature.
+You do not need to track per-tab stacks or a separate "current tab" field. The nav stack root is the
+selected tab, and `SaveAndRestore` stores the tab stacks.
 
 ## The full `StateOptions` API
 
 `resetRoot` takes a [`Navigator.StateOptions`](https://slackhq.github.io/circuit/api/0.x/circuit-runtime/com.slack.circuit.runtime/-navigator/-state-options/),
 a `data class` of three independent flags (all default `false`):
 
-| Flag | Effect |
-|------|--------|
-| `save` | Save the **current** entry list before resetting, keyed by the current root screen. It can be restored later by resetting back to that root with `restore = true`. |
+| Flag      | Effect                                                                                                                                                                    |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `save`    | Save the **current** entry list before resetting, keyed by the current root screen. It can be restored later by resetting back to that root with `restore = true`.        |
 | `restore` | If the new root has previously-saved state, restore that whole stack instead of starting fresh. If `false` or there's nothing saved, the stack becomes just the new root. |
-| `clear` | Discard any saved state for the new root. Applied *after* a restore, regardless of `restore`. |
+| `clear`   | Discard any saved state for the new root. Applied *after* a restore, regardless of `restore`.                                                                             |
 
-Two presets cover the common patterns:
+Two presets cover the common cases:
 
-| Preset | Equivalent | Use |
-|--------|------------|-----|
-| `StateOptions.Default` | `StateOptions()` | single back stack — save/restore nothing |
-| `StateOptions.SaveAndRestore` | `StateOptions(save = true, restore = true)` | multiple back stacks (this recipe) |
+| Preset                        | Equivalent                                  | Use                                      |
+|-------------------------------|---------------------------------------------|------------------------------------------|
+| `StateOptions.Default`        | `StateOptions()`                            | single back stack — save/restore nothing |
+| `StateOptions.SaveAndRestore` | `StateOptions(save = true, restore = true)` | multiple back stacks (this recipe)       |
 
 For anything else, construct one directly — e.g. save the outgoing stack but always start the new
 tab fresh: `StateOptions(save = true, restore = false)`.

--- a/docs/recipes/test-a-presenter.md
+++ b/docs/recipes/test-a-presenter.md
@@ -1,0 +1,47 @@
+# [Recipe](index.md): Test a presenter that navigates
+
+**Problem:** verify that a presenter emits the right states and navigates where you expect, in
+response to events.
+
+Use `Presenter.test {}` (from `circuit-test`) and a `FakeNavigator`. `test {}` bridges Compose +
+coroutines (Molecule + Turbine) and gives you a turbine whose `awaitItem()` is
+distinct-until-changed. Drive the presenter by invoking the `eventSink` on an emitted state.
+
+```kotlin
+@Test
+fun `clicking an item navigates to its detail`() = runTest {
+  val navigator = FakeNavigator(FeedScreen)
+  val presenter = FeedPresenter(FeedScreen, navigator, FakeFeedRepository(items = listOf(item1)))
+
+  presenter.test {
+    // Consume the initial loading emission before asserting on loaded state.
+    assertEquals(FeedState.Loading, awaitItem())
+
+    val loaded = assertIs<FeedState.Loaded>(awaitItem())
+    loaded.eventSink(FeedEvent.OpenItem(item1.id))     // simulate the tap
+
+    assertEquals(DetailScreen(item1.id), navigator.awaitNextScreen())
+  }
+}
+```
+
+Common `FakeNavigator` assertions:
+
+- `awaitNextScreen()` — the next screen pushed via `goTo`
+- `awaitPop()` — a `pop()` happened
+- `awaitResetRoot()` — a `resetRoot()` happened
+- `assertGoToIsEmpty()` — assert *no* navigation occurred
+
+Two things that trip people up:
+
+- **Consume `Loading` first.** A presenter that starts in `Loading` emits it before the loaded state.
+  `assertIs<FeedState.Loaded>(awaitItem())` on the *first* item will fail — await the loading emission first.
+- **`awaitItem()` is distinct-until-changed.** Identical consecutive states collapse into one, so you
+  assert real transitions, not every recomposition. When you specifically want to assert a
+  recomposition produced *no* change, use the escape hatch `awaitUnchanged()` — it awaits the next
+  emission and fails if it differs from the previous one.
+
+For UI-level event assertions, render the composable with a `TestEventSink` and assert the events it
+emits — see the [testing doc](../testing.md#android-ui-instrumentation-tests).
+
+**See also:** [Testing](../testing.md) · [Test a presenter that shows an overlay](test-an-overlay.md)

--- a/docs/recipes/test-a-presenter.md
+++ b/docs/recipes/test-a-presenter.md
@@ -3,9 +3,8 @@
 **Problem:** verify that a presenter emits the right states and navigates where you expect, in
 response to events.
 
-Use `Presenter.test {}` (from `circuit-test`) and a `FakeNavigator`. `test {}` bridges Compose +
-coroutines (Molecule + Turbine) and gives you a turbine whose `awaitItem()` is
-distinct-until-changed. Drive the presenter by invoking the `eventSink` on an emitted state.
+Use `Presenter.test {}` from `circuit-test` and a `FakeNavigator`. `test {}` gives you a `Turbine` for
+presenter states. Drive the presenter by invoking the `eventSink` on an emitted state.
 
 ```kotlin
 @Test
@@ -32,12 +31,12 @@ Common `FakeNavigator` assertions:
 - `awaitResetRoot()` — a `resetRoot()` happened
 - `assertGoToIsEmpty()` — assert *no* navigation occurred
 
-Two things that trip people up:
+Things to watch for:
 
 - **Consume `Loading` first.** A presenter that starts in `Loading` emits it before the loaded state.
   `assertIs<FeedState.Loaded>(awaitItem())` on the *first* item will fail — await the loading emission first.
 - **`awaitItem()` is distinct-until-changed.** Identical consecutive states collapse into one, so you
-  assert real transitions, not every recomposition. When you specifically want to assert a
+  assert state changes, not every recomposition. When you specifically want to assert a
   recomposition produced *no* change, use the escape hatch `awaitUnchanged()` — it awaits the next
   emission and fails if it differs from the previous one.
 

--- a/docs/recipes/test-an-overlay.md
+++ b/docs/recipes/test-an-overlay.md
@@ -3,10 +3,10 @@
 **Problem:** your presenter shows an overlay (a confirm dialog, a picker) and acts on the result. You
 want to test that logic without standing up real overlay UI.
 
-The trick: don't try to drive a real `OverlayHost` in a unit test. If you model the overlay as
-[nullable state](confirmation-dialog.md#gate-the-dialog-on-nullable-state-run-it-with-overlayeffect) —
-`null` = hidden, non-null = showing — then "is the overlay requested?" and "what happens with each
-result?" are just plain state-and-event assertions, exactly like any other presenter test.
+Do not drive a real `OverlayHost` in a unit test. If you model the overlay as
+[nullable state](confirmation-dialog.md#show-the-dialog-from-nullable-state), then "is the overlay
+requested?" and "what happens with each result?" are just plain state-and-event assertions like any other
+presenter test.
 
 ```kotlin
 @Test
@@ -47,10 +47,9 @@ fun `dismissing the confirmation deletes nothing`() = runTest {
 }
 ```
 
-Because the overlay's result re-enters the presenter as an ordinary event
-(`DeleteAnswered(confirmed = …)`), you cover both the confirm and dismiss paths with no UI and no
-fakes for the overlay machinery. The actual rendering is the `OverlayEffect`'s job and is exercised
-by previews / snapshot tests, not unit tests.
+Because the overlay result re-enters the presenter as an event
+(`DeleteAnswered(confirmed = …)`), you can cover the confirm and dismiss paths without real overlay
+UI. Render the actual overlay in previews or snapshot tests.
 
 **See also:** [Ask for confirmation with a dialog](confirmation-dialog.md) ·
 [Test a presenter that navigates](test-a-presenter.md)

--- a/docs/recipes/test-an-overlay.md
+++ b/docs/recipes/test-an-overlay.md
@@ -1,0 +1,56 @@
+# [Recipe](index.md): Test a presenter that shows an overlay
+
+**Problem:** your presenter shows an overlay (a confirm dialog, a picker) and acts on the result. You
+want to test that logic without standing up real overlay UI.
+
+The trick: don't try to drive a real `OverlayHost` in a unit test. If you model the overlay as
+[nullable state](confirmation-dialog.md#gate-the-dialog-on-nullable-state-run-it-with-overlayeffect) —
+`null` = hidden, non-null = showing — then "is the overlay requested?" and "what happens with each
+result?" are just plain state-and-event assertions, exactly like any other presenter test.
+
+```kotlin
+@Test
+fun `delete asks for confirmation, then deletes on confirm`() = runTest {
+  val repository = FakeItemRepository(items = listOf(item1))
+  val presenter = ItemPresenter(ItemScreen(item1.id), FakeNavigator(ItemScreen(item1.id)), repository)
+
+  presenter.test {
+    val loaded = assertIs<ItemState.Loaded>(awaitItem())
+    assertNull(loaded.pendingDelete)                 // no dialog yet
+
+    loaded.eventSink(ItemEvent.DeleteClicked(item1.id))
+
+    // The presenter now requests the dialog by exposing pendingDelete.
+    val confirming = assertIs<ItemState.Loaded>(awaitItem())
+    assertEquals(item1.id, confirming.pendingDelete)
+
+    // Simulate the user confirming — the same event the OverlayEffect would send.
+    confirming.eventSink(ItemEvent.DeleteAnswered(item1.id, confirmed = true))
+
+    assertTrue(repository.wasDeleted(item1.id))
+  }
+}
+
+@Test
+fun `dismissing the confirmation deletes nothing`() = runTest {
+  val repository = FakeItemRepository(items = listOf(item1))
+  val presenter = ItemPresenter(ItemScreen(item1.id), FakeNavigator(ItemScreen(item1.id)), repository)
+
+  presenter.test {
+    val loaded = assertIs<ItemState.Loaded>(awaitItem())
+    loaded.eventSink(ItemEvent.DeleteClicked(item1.id))
+    awaitItem()   // pendingDelete set
+
+    loaded.eventSink(ItemEvent.DeleteAnswered(item1.id, confirmed = false))
+    assertFalse(repository.wasDeleted(item1.id))
+  }
+}
+```
+
+Because the overlay's result re-enters the presenter as an ordinary event
+(`DeleteAnswered(confirmed = …)`), you cover both the confirm and dismiss paths with no UI and no
+fakes for the overlay machinery. The actual rendering is the `OverlayEffect`'s job and is exercised
+by previews / snapshot tests, not unit tests.
+
+**See also:** [Ask for confirmation with a dialog](confirmation-dialog.md) ·
+[Test a presenter that navigates](test-a-presenter.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       'Overlays': circuitx/overlays.md
       'SubCircuit': circuitx/subcircuit.md
   - 'Deep Linking': deep-linking-android.md
+  - 'Recipes': recipes/index.md
   - 'API': api/0.x/index.html
   - 'Discussions ⏏': https://github.com/slackhq/circuit/discussions
   - 'Change Log': changelog.md


### PR DESCRIPTION
# Change

A set of practical, copy-pasteable recipes for common Circuit patterns - navigation, state, lists, forms, testing, and more. Each one is a focused "how do I do X" with a working snippet, rather than reference docs. Influenced by patterns we've encountered at Slack!

Linked from the nav under `Recipes` (`docs/recipes/index.md` is the landing page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)