### PR TITLE
Extract subcircuit codegen scaffold from the monolith

### DIFF
--- a/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/FactoryType.kt
+++ b/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/FactoryType.kt
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.subcircuit.codegen
+
+internal enum class FactoryType {
+  PRESENTER,
+  UI,
+}

--- a/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/InstantiationType.kt
+++ b/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/InstantiationType.kt
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.subcircuit.codegen
+
+internal enum class InstantiationType {
+  FUNCTION,
+  CLASS,
+}

--- a/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitCodegenMode.kt
+++ b/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitCodegenMode.kt
@@ -1,0 +1,361 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.subcircuit.codegen
+
+import com.google.devtools.ksp.processing.JvmPlatformInfo
+import com.google.devtools.ksp.processing.PlatformInfo
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.slack.circuit.subcircuit.codegen.FactoryType.UI
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.ABSTRACT
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+
+internal enum class SubCircuitCodegenMode {
+  UNKNOWN {
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
+      return false
+    }
+
+    override fun addInjectAnnotation(
+      classBuilder: TypeSpec.Builder,
+      constructorBuilder: FunSpec.Builder,
+      options: SubCircuitOptions,
+    ) {
+      error("Unknown codegen mode, should not be called")
+    }
+  },
+  /**
+   * The Anvil Codegen mode
+   *
+   * This mode annotates generated factory types with `ContributesMultibinding`, allowing for Anvil
+   * to automatically wire the generated class up to Dagger's multibinding system within a given
+   * scope (e.g. AppScope).
+   *
+   * ```kotlin
+   * @ContributesMultibinding(AppScope::class)
+   * public class MyPresenter_Factory_SubPresenterFactory @Inject constructor(
+   *   private val factory: MyPresenter.Factory,
+   * ) : SubPresenterFactory { ... }
+   * ```
+   */
+  ANVIL {
+    private val contributesMultibindingCN =
+      ClassName("com.squareup.anvil.annotations", "ContributesMultibinding")
+
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
+      // Anvil only supports JVM & Android
+      return platforms.all { it is JvmPlatformInfo }
+    }
+
+    override fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {
+      builder.addAnnotation(
+        AnnotationSpec.builder(contributesMultibindingCN).addMember("%T::class", scope).build()
+      )
+    }
+
+    override fun addInjectAnnotation(
+      classBuilder: TypeSpec.Builder,
+      constructorBuilder: FunSpec.Builder,
+      options: SubCircuitOptions,
+    ) {
+      constructorBuilder.addAnnotation(runtime.inject(options))
+    }
+  },
+
+  /**
+   * The Hilt Codegen mode
+   *
+   * This mode provides an additional type, a Hilt module, which binds the generated factory, wiring
+   * up multibinding in the Hilt DI framework. The scope provided via `SubCircuitInject` is used to
+   * define the dagger component the factory provider is installed in.
+   *
+   * ```kotlin
+   * @Module
+   * @InstallIn(SingletonComponent::class)
+   * @OriginatingElement(topLevelClass = MyPresenter::class)
+   * public abstract class MyPresenter_Factory_SubPresenterFactoryModule {
+   *   @Binds
+   *   @IntoSet
+   *   public abstract
+   *       fun bindMyPresenter_Factory_SubPresenterFactory(
+   *           myPresenter_Factory_SubPresenterFactory: MyPresenter_Factory_SubPresenterFactory):
+   *       SubPresenterFactory
+   * }
+   * ```
+   */
+  HILT {
+    override val originAnnotation: OriginAnnotation = SubCircuitNames.DAGGER_ORIGIN
+
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
+      // Hilt only supports JVM & Android
+      return platforms.all { it is JvmPlatformInfo }
+    }
+
+    override fun produceAdditionalTypeSpec(
+      factory: ClassName,
+      factoryType: FactoryType,
+      scope: TypeName,
+      topLevelClass: ClassName?,
+    ): TypeSpec {
+      val moduleAnnotations =
+        listOfNotNull(
+          AnnotationSpec.builder(SubCircuitNames.DAGGER_MODULE).build(),
+          AnnotationSpec.builder(SubCircuitNames.DAGGER_INSTALL_IN)
+            .addMember("%T::class", scope)
+            .build(),
+          // Required to generate this here too since this is a separate class from the generated
+          // factory
+          topLevelClass?.let {
+            AnnotationSpec.builder(SubCircuitNames.DAGGER_ORIGINATING_ELEMENT)
+              .addMember("%L = %T::class", "topLevelClass", topLevelClass)
+              .build()
+          },
+        )
+
+      val providerAnnotations =
+        listOf(
+          AnnotationSpec.builder(SubCircuitNames.DAGGER_BINDS).build(),
+          AnnotationSpec.builder(SubCircuitNames.DAGGER_INTO_SET).build(),
+        )
+
+      val providerReturns =
+        if (factoryType == UI) {
+          SubCircuitNames.SUB_UI_FACTORY
+        } else {
+          SubCircuitNames.SUB_PRESENTER_FACTORY
+        }
+
+      val factoryName = factory.simpleName
+
+      val providerSpec =
+        FunSpec.builder("bind${factoryName}")
+          .addModifiers(ABSTRACT)
+          .addAnnotations(providerAnnotations)
+          .addParameter(name = factoryName.replaceFirstChar { it.lowercase() }, type = factory)
+          .returns(providerReturns)
+          .build()
+
+      return TypeSpec.classBuilder(factory.peerClass(factoryName + SubCircuitNames.MODULE))
+        .addModifiers(ABSTRACT)
+        .addAnnotations(moduleAnnotations)
+        .addFunction(providerSpec)
+        .build()
+    }
+
+    override fun addInjectAnnotation(
+      classBuilder: TypeSpec.Builder,
+      constructorBuilder: FunSpec.Builder,
+      options: SubCircuitOptions,
+    ) {
+      constructorBuilder.addAnnotation(runtime.inject(options))
+    }
+  },
+
+  /**
+   * The `kotlin-inject` Anvil Codegen mode
+   *
+   * This mode annotates generated factory types with `ContributesBinding`, allowing for KI-Anvil to
+   * automatically wire the generated class up to KI's multibinding system within a given scope
+   * (e.g. AppScope).
+   *
+   * ```kotlin
+   * @Inject
+   * @ContributesBinding(AppScope::class, multibinding = true)
+   * public class MyPresenter_SubPresenterFactory(
+   *   private val provider: () -> MyPresenter,
+   * ) : SubPresenterFactory { ... }
+   * ```
+   */
+  KOTLIN_INJECT_ANVIL {
+    override val runtime: InjectionRuntime = InjectionRuntime.KotlinInject
+    override val originAnnotation: OriginAnnotation = SubCircuitNames.KotlinInject.Anvil.ORIGIN
+
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
+      // KI-Anvil supports all
+      return true
+    }
+
+    override fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {
+      builder.addAnnotation(
+        AnnotationSpec.builder(SubCircuitNames.KotlinInject.Anvil.CONTRIBUTES_BINDING)
+          .addMember("%T::class", scope)
+          .addMember("multibinding = true")
+          .build()
+      )
+    }
+
+    override fun addInjectAnnotation(
+      classBuilder: TypeSpec.Builder,
+      constructorBuilder: FunSpec.Builder,
+      options: SubCircuitOptions,
+    ) {
+      classBuilder.addAnnotation(runtime.inject(options))
+    }
+
+    override fun filterValidInjectionSites(
+      candidates: Collection<KSDeclaration>
+    ): Collection<KSDeclaration> {
+      return candidates.filter { it is KSFunctionDeclaration || it is KSClassDeclaration }
+    }
+  },
+
+  /**
+   * The `metro` code gen mode
+   *
+   * This mode annotates generated factory types with `ContributesIntoSet`, allowing for Metro to
+   * automatically wire the generated class up to its multibinding system within a given scope (e.g.
+   * AppScope).
+   *
+   * ```kotlin
+   * @Inject
+   * @ContributesIntoSet(AppScope::class)
+   * public class MyPresenter_SubPresenterFactory(
+   *   private val provider: Provider<MyPresenter>
+   * ) : SubPresenterFactory { ... }
+   * ```
+   */
+  METRO {
+    override val runtime: InjectionRuntime = InjectionRuntime.Metro
+    override val originAnnotation: OriginAnnotation = SubCircuitNames.Metro.ORIGIN
+
+    override fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean {
+      // Metro supports all
+      return true
+    }
+
+    override fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {
+      builder.addAnnotation(
+        AnnotationSpec.builder(SubCircuitNames.Metro.CONTRIBUTES_INTO_SET)
+          .addMember("%T::class", scope)
+          .build()
+      )
+    }
+
+    override fun addInjectAnnotation(
+      classBuilder: TypeSpec.Builder,
+      constructorBuilder: FunSpec.Builder,
+      options: SubCircuitOptions,
+    ) {
+      classBuilder.addAnnotation(runtime.inject(options))
+    }
+
+    override fun filterValidInjectionSites(
+      candidates: Collection<KSDeclaration>
+    ): Collection<KSDeclaration> {
+      return candidates.filter { it is KSFunctionDeclaration || it is KSClassDeclaration }
+    }
+  };
+
+  open val runtime: InjectionRuntime = InjectionRuntime.Jakarta
+  open val originAnnotation: OriginAnnotation? = null
+
+  open fun annotateFactory(builder: TypeSpec.Builder, scope: TypeName) {}
+
+  open fun produceAdditionalTypeSpec(
+    factory: ClassName,
+    factoryType: FactoryType,
+    scope: TypeName,
+    topLevelClass: ClassName?,
+  ): TypeSpec? {
+    return null
+  }
+
+  abstract fun supportsPlatforms(platforms: List<PlatformInfo>): Boolean
+
+  abstract fun addInjectAnnotation(
+    classBuilder: TypeSpec.Builder,
+    constructorBuilder: FunSpec.Builder,
+    options: SubCircuitOptions,
+  )
+
+  /** Filters the candidates for @Inject annotation placement. */
+  open fun filterValidInjectionSites(
+    candidates: Collection<KSDeclaration>
+  ): Collection<KSDeclaration> = candidates.filterIsInstance<KSFunctionDeclaration>()
+
+  sealed interface InjectionRuntime {
+
+    fun inject(options: SubCircuitOptions): ClassName
+
+    fun declarationInjects(options: SubCircuitOptions): Collection<ClassName> =
+      listOf(inject(options))
+
+    val assisted: ClassName
+    val assistedInject: ClassName?
+    val assistedFactory: ClassName?
+
+    fun asProvider(providedType: TypeName, options: SubCircuitOptions): TypeName
+
+    fun getProviderBlock(provider: CodeBlock): CodeBlock
+
+    data object Jakarta : InjectionRuntime {
+      override fun inject(options: SubCircuitOptions): ClassName =
+        if (options.useJavaxOnly) SubCircuitNames.INJECT_JAVAX else SubCircuitNames.INJECT
+
+      override fun declarationInjects(options: SubCircuitOptions): Collection<ClassName> {
+        // If explicitly using javax only look for javax, otherwise look for both.
+        return if (options.useJavaxOnly) {
+          listOf(SubCircuitNames.INJECT_JAVAX)
+        } else {
+          listOf(SubCircuitNames.INJECT, SubCircuitNames.INJECT_JAVAX)
+        }
+      }
+
+      override val assisted: ClassName = SubCircuitNames.ASSISTED
+      override val assistedInject: ClassName = SubCircuitNames.ASSISTED_INJECT
+      override val assistedFactory: ClassName = SubCircuitNames.ASSISTED_FACTORY
+
+      override fun asProvider(providedType: TypeName, options: SubCircuitOptions): TypeName {
+        val className =
+          if (options.useJavaxOnly) SubCircuitNames.PROVIDER_JAVAX else SubCircuitNames.PROVIDER
+        return className.parameterizedBy(providedType)
+      }
+
+      override fun getProviderBlock(provider: CodeBlock): CodeBlock {
+        return CodeBlock.of("%L.get()", provider)
+      }
+    }
+
+    data object KotlinInject : InjectionRuntime {
+      override fun inject(options: SubCircuitOptions) = SubCircuitNames.KotlinInject.INJECT
+
+      override val assisted: ClassName = SubCircuitNames.KotlinInject.ASSISTED
+      override val assistedInject: ClassName? = null
+      override val assistedFactory: ClassName? = null // It has no annotation
+
+      override fun asProvider(providedType: TypeName, options: SubCircuitOptions): TypeName {
+        return LambdaTypeName.get(returnType = providedType)
+      }
+
+      override fun getProviderBlock(provider: CodeBlock): CodeBlock {
+        return CodeBlock.of("%L()", provider)
+      }
+    }
+
+    data object Metro : InjectionRuntime {
+      override fun inject(options: SubCircuitOptions) = SubCircuitNames.Metro.INJECT
+
+      override val assisted: ClassName = SubCircuitNames.Metro.ASSISTED
+      override val assistedInject: ClassName? = null
+      override val assistedFactory: ClassName = SubCircuitNames.Metro.ASSISTED_FACTORY
+
+      override fun asProvider(providedType: TypeName, options: SubCircuitOptions): TypeName {
+        return LambdaTypeName.get(returnType = providedType)
+      }
+
+      override fun getProviderBlock(provider: CodeBlock): CodeBlock {
+        return CodeBlock.of("%L()", provider)
+      }
+    }
+  }
+}
+
+internal class OriginAnnotation(val className: ClassName, val parameterName: String? = null)

--- a/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitNames.kt
+++ b/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitNames.kt
@@ -1,0 +1,88 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.subcircuit.codegen
+
+import com.squareup.kotlinpoet.ClassName
+
+internal object SubCircuitNames {
+  val ASSISTED = ClassName("dagger.assisted", "Assisted")
+  val ASSISTED_FACTORY = ClassName("dagger.assisted", "AssistedFactory")
+  val ASSISTED_INJECT = ClassName("dagger.assisted", "AssistedInject")
+  val INJECT = ClassName("jakarta.inject", "Inject")
+  val INJECT_JAVAX = ClassName("javax.inject", "Inject")
+  val PROVIDER = ClassName("jakarta.inject", "Provider")
+  val PROVIDER_JAVAX = ClassName("javax.inject", "Provider")
+  const val DAGGER_PACKAGE = "dagger"
+  const val DAGGER_HILT_PACKAGE = "$DAGGER_PACKAGE.hilt"
+  const val DAGGER_HILT_CODEGEN_PACKAGE = "$DAGGER_HILT_PACKAGE.codegen"
+  const val DAGGER_MULTIBINDINGS_PACKAGE = "$DAGGER_PACKAGE.multibindings"
+  const val SUB_CIRCUIT_PACKAGE = "com.slack.circuit.subcircuit"
+  val MODIFIER = ClassName("androidx.compose.ui", "Modifier")
+  val SUB_CIRCUIT_INJECT_ANNOTATION = ClassName(SUB_CIRCUIT_PACKAGE, "SubCircuitInject")
+  val SUB_PRESENTER = ClassName(SUB_CIRCUIT_PACKAGE, "SubPresenter")
+  val SUB_PRESENTER_FACTORY = ClassName(SUB_CIRCUIT_PACKAGE, "SubPresenterFactory")
+  val SUB_UI = ClassName(SUB_CIRCUIT_PACKAGE, "SubUi")
+  val SUB_UI_FACTORY = ClassName(SUB_CIRCUIT_PACKAGE, "SubUiFactory")
+  val SUB_CIRCUIT_UI_STATE = ClassName(SUB_CIRCUIT_PACKAGE, "SubCircuitUiState")
+  val SUB_SCREEN = ClassName(SUB_CIRCUIT_PACKAGE, "SubScreen")
+  val DAGGER_MODULE = ClassName(DAGGER_PACKAGE, "Module")
+  val DAGGER_BINDS = ClassName(DAGGER_PACKAGE, "Binds")
+  val DAGGER_INSTALL_IN = ClassName(DAGGER_HILT_PACKAGE, "InstallIn")
+  val DAGGER_ORIGINATING_ELEMENT = ClassName(DAGGER_HILT_CODEGEN_PACKAGE, "OriginatingElement")
+  val DAGGER_ORIGIN = OriginAnnotation(DAGGER_ORIGINATING_ELEMENT, "topLevelClass")
+  val DAGGER_INTO_SET = ClassName(DAGGER_MULTIBINDINGS_PACKAGE, "IntoSet")
+  const val MODULE = "Module"
+  const val SUB_PRESENTER_FACTORY_SUFFIX = "_SubPresenterFactory"
+  const val SUB_UI_FACTORY_SUFFIX = "_SubUiFactory"
+
+  /**
+   * Qualified names of annotations that mark an annotation as a qualifier. Any annotation
+   * meta-annotated with one of these is propagated from the annotated declaration to the generated
+   * factory class.
+   */
+  val QUALIFIER_ANNOTATION_NAMES =
+    setOf(
+      "javax.inject.Qualifier",
+      "jakarta.inject.Qualifier",
+      "dev.zacsweers.metro.Qualifier",
+      "me.tatarka.inject.annotations.Qualifier",
+    )
+
+  /**
+   * FQCNs of provider/lazy types that are already deferrable references to a dependency. When a
+   * function parameter already has one of these types (or is a Kotlin function type), the codegen
+   * passes it through to the factory constructor as-is instead of re-wrapping it in a provider.
+   */
+  val PASS_THROUGH_PROVIDER_NAMES =
+    setOf(
+      "javax.inject.Provider",
+      "jakarta.inject.Provider",
+      "dev.zacsweers.metro.Provider",
+      "kotlin.Function0",
+      "dagger.Lazy",
+      "kotlin.Lazy",
+    )
+
+  object KotlinInject {
+    private const val ANNOTATIONS_PACKAGE = "me.tatarka.inject.annotations"
+    val INJECT = ClassName(ANNOTATIONS_PACKAGE, "Inject")
+    val ASSISTED = ClassName(ANNOTATIONS_PACKAGE, "Assisted")
+
+    object Anvil {
+      private const val RUNTIME_PACKAGE = "software.amazon.lastmile.kotlin.inject.anvil"
+      private const val RUNTIME_INTERNAL_PACKAGE =
+        "software.amazon.lastmile.kotlin.inject.anvil.internal"
+      internal val CONTRIBUTES_BINDING = ClassName(RUNTIME_PACKAGE, "ContributesBinding")
+      val ORIGIN = OriginAnnotation(ClassName(RUNTIME_INTERNAL_PACKAGE, "Origin"))
+    }
+  }
+
+  object Metro {
+    private const val RUNTIME_PACKAGE = "dev.zacsweers.metro"
+    val INJECT = ClassName(RUNTIME_PACKAGE, "Inject")
+    val ASSISTED = ClassName(RUNTIME_PACKAGE, "Assisted")
+    val ASSISTED_FACTORY = ClassName(RUNTIME_PACKAGE, "AssistedFactory")
+    val ORIGIN = OriginAnnotation(ClassName(RUNTIME_PACKAGE, "Origin"))
+    internal val CONTRIBUTES_INTO_SET = ClassName(RUNTIME_PACKAGE, "ContributesIntoSet")
+  }
+}

--- a/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitOptions.kt
+++ b/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitOptions.kt
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.subcircuit.codegen
+
+import com.google.devtools.ksp.processing.KSPLogger
+
+internal data class SubCircuitOptions(
+  val mode: SubCircuitCodegenMode,
+  val lenient: Boolean,
+  val useJavaxOnly: Boolean,
+) {
+  companion object {
+    const val MODE = "subcircuit.codegen.mode"
+    const val LENIENT = "subcircuit.codegen.lenient"
+    const val USE_JAVAX_ONLY = "subcircuit.codegen.useJavaxOnly"
+
+    internal val UNKNOWN =
+      SubCircuitOptions(SubCircuitCodegenMode.UNKNOWN, lenient = false, useJavaxOnly = false)
+
+    fun load(options: Map<String, String>, logger: KSPLogger): SubCircuitOptions {
+      val mode =
+        options[MODE].let { mode ->
+          if (mode == null) {
+            SubCircuitCodegenMode.ANVIL
+          } else {
+            SubCircuitCodegenMode.entries.find { it.name.equals(mode, ignoreCase = true) }
+              ?: run {
+                logger.error("Unrecognised option for codegen mode \"$mode\".")
+                return UNKNOWN
+              }
+          }
+        }
+
+      if (mode == SubCircuitCodegenMode.UNKNOWN) {
+        logger.error("Specifying \"$mode\" as a SubCircuit code gen mode is prohibited.")
+        return UNKNOWN
+      }
+
+      val lenient = options[LENIENT]?.toBoolean() ?: false
+      val useJavaxOnly = options[USE_JAVAX_ONLY]?.toBoolean() ?: false
+      return SubCircuitOptions(mode = mode, lenient = lenient, useJavaxOnly = useJavaxOnly)
+    }
+  }
+}

--- a/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitSymbols.kt
+++ b/circuitx/subcircuit-codegen/src/main/kotlin/com/slack/circuit/subcircuit/codegen/SubCircuitSymbols.kt
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.subcircuit.codegen
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSType
+
+internal class SubCircuitSymbols private constructor(resolver: Resolver) {
+  val modifier = resolver.loadKSType(SubCircuitNames.MODIFIER.canonicalName)
+  val subCircuitUiState = resolver.loadKSType(SubCircuitNames.SUB_CIRCUIT_UI_STATE.canonicalName)
+
+  private fun Resolver.loadKSType(name: String): KSType =
+    loadOptionalKSType(name) ?: error("Could not find $name in classpath")
+
+  private fun Resolver.loadOptionalKSType(name: String?): KSType? {
+    if (name == null) return null
+    return getClassDeclarationByName(getKSNameFromString(name))?.asType(emptyList())
+  }
+
+  companion object {
+    fun create(resolver: Resolver): SubCircuitSymbols? {
+      @Suppress("SwallowedException")
+      return try {
+        SubCircuitSymbols(resolver)
+      } catch (e: IllegalStateException) {
+        null
+      }
+    }
+  }
+}

--- a/kotlin-js-store/package-lock.json
+++ b/kotlin-js-store/package-lock.json
@@ -4515,18 +4515,7 @@
     },
     "packages/circuitx-subcircuit-test": {
       "version": "0.0.0-unspecified",
-      "devDependencies": {
-        "karma": "github:Kotlin/karma#6.4.5",
-        "karma-chrome-launcher": "3.2.0",
-        "karma-mocha": "2.0.1",
-        "karma-sourcemap-loader": "0.4.0",
-        "karma-webpack": "5.0.1",
-        "kotlin-web-helpers": "3.0.0",
-        "mocha": "11.7.5",
-        "source-map-loader": "5.0.0",
-        "webpack": "5.101.3",
-        "webpack-cli": "6.0.1"
-      }
+      "devDependencies": {}
     },
     "packages/circuitx-subcircuit-test-test": {
       "version": "0.0.0-unspecified",

--- a/kotlin-js-store/package-lock.json
+++ b/kotlin-js-store/package-lock.json
@@ -4515,7 +4515,18 @@
     },
     "packages/circuitx-subcircuit-test": {
       "version": "0.0.0-unspecified",
-      "devDependencies": {}
+      "devDependencies": {
+        "karma": "github:Kotlin/karma#6.4.5",
+        "karma-chrome-launcher": "3.2.0",
+        "karma-mocha": "2.0.1",
+        "karma-sourcemap-loader": "0.4.0",
+        "karma-webpack": "5.0.1",
+        "kotlin-web-helpers": "3.0.0",
+        "mocha": "11.7.5",
+        "source-map-loader": "5.0.0",
+        "webpack": "5.101.3",
+        "webpack-cli": "6.0.1"
+      }
     },
     "packages/circuitx-subcircuit-test-test": {
       "version": "0.0.0-unspecified",


### PR DESCRIPTION
# Change

First of three stacked PRs splitting the [subcircuit-codegen rework](https://github.com/slackhq/circuit/pull/2775) so it's more reviewable. This one just adds the shared scaffolding, ported file-for-file from `circuit-codegen`, without wiring any of it up yet.

- `SubCircuitNames`, `SubCircuitOptions`, `SubCircuitSymbols`
- `FactoryType`, `InstantiationType`
- `SubCircuitCodegenMode` (ANVIL, HILT, KOTLIN_INJECT_ANVIL, METRO) as strategy objects

Mostly a mechanical port of the `circuit-codegen` scaffold, adapted to SubCircuit's naming. The provider swap that actually uses these files is the next PR in the stack.

## Stack
1. **this PR** — scaffold
2. Swap the processor to the new provider
3. New-mode test coverage + docs


🤖 Generated with [Claude Code](https://claude.com/claude-code)