### PR TITLE
Retained migration part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@ Also new:
   [retain](https://developer.android.com/develop/ui/compose/state-lifespans#retain) API.
   - Setting `CircuitRetainedSettings.useFirstParty = true` (before the first composition) backs `lifecycleRetainedStateRegistry()` with a root-level `retain` call instead of a Circuit-managed `ViewModel`, delegating configuration-change survival to the `RetainedValuesStore` installed in the composition.
   - All `rememberRetained`/`rememberRetainedSaveable` semantics are unchanged.
-  - First-party `retain {}` calls also compose correctly alongside Circuit's retention.
+  - First-party `retain {}` can be used directly in presenters and UIs alongside `rememberRetained`. In navigated content, retained values follow their record's lifetime.
   - See the [circuit-retained README](https://github.com/slackhq/circuit/tree/main/circuit-retained) for more details.
-  - **NOTE:** This is phase one of a multi-phase migration to the first-party API.
+  - **NOTE:** This is part of a multi-phase migration to the first-party API.
 
 ### Deprecated
 

--- a/circuit-foundation/build.gradle.kts
+++ b/circuit-foundation/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.kotlin.plugin.parcelize)
   alias(libs.plugins.compose)
+  alias(libs.plugins.emulatorWtf)
   id("circuit.base")
   id("circuit.publish")
 }

--- a/circuit-foundation/src/androidDeviceTest/AndroidManifest.xml
+++ b/circuit-foundation/src/androidDeviceTest/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity android:name="androidx.activity.ComponentActivity" />
+    </application>
+</manifest>

--- a/circuit-foundation/src/androidDeviceTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainDeviceTest.kt
+++ b/circuit-foundation/src/androidDeviceTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainDeviceTest.kt
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.internal.test.TestContentTags.TAG_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_INCREASE_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import com.slack.circuit.internal.test.TestCountPresenter
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.createTestCircuit
+import com.slack.circuit.retained.CircuitRetainedSettings
+import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+
+/** Real-device smoke test for first-party retain scoped to navigation records. */
+@OptIn(ExperimentalCircuitRetainedApi::class)
+class NavigableCircuitFirstPartyRetainDeviceTest {
+
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  private val scenario: ActivityScenario<ComponentActivity>
+    get() = composeTestRule.activityRule.scenario
+
+  private val circuit =
+    createTestCircuit(rememberType = TestCountPresenter.RememberType.FirstPartyRetain)
+
+  init {
+    CircuitRetainedSettings.useFirstParty = true
+  }
+
+  @After
+  fun tearDown() {
+    CircuitRetainedSettings.useFirstParty = false
+  }
+
+  @Test
+  fun retainedValuesFollowRecordLifetimeAcrossRecreation() {
+    setActivityContent()
+    composeTestRule.run {
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      scenario.recreate()
+      setActivityContent()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+
+  private fun setActivityContent() {
+    scenario.onActivity { activity ->
+      activity.setContent {
+        CircuitCompositionLocals(circuit) {
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+          val navigator = rememberCircuitNavigator(backStack = backStack, onRootPop = {})
+          NavigableCircuitContent(navigator = navigator, backStack = backStack)
+        }
+      }
+    }
+  }
+}

--- a/circuit-foundation/src/androidHostTest/AndroidManifest.xml
+++ b/circuit-foundation/src/androidHostTest/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
+        <activity android:name="com.slack.circuit.foundation.NavigableCircuitFirstPartyRetainTestActivity"/>
         <activity android:name="com.slack.circuit.foundation.NavigableCircuitRetainedStateTestActivity"/>
         <activity android:name="com.slack.circuit.foundation.NavigableCircuitSaveableStateTestActivity"/>
         <activity android:name="com.slack.circuit.foundation.NavigableCircuitViewModelStateTestActivity"/>

--- a/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/FirstPartyRetainRecordLifecycleTest.kt
+++ b/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/FirstPartyRetainRecordLifecycleTest.kt
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.runtime.retain.RetainObserver
+import androidx.compose.runtime.retain.retain
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import com.slack.circuit.internal.test.TestEvent
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.TestState
+import com.slack.circuit.internal.test.createTestCircuit
+import com.slack.circuit.retained.CircuitRetainedSettings
+import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
+import com.slack.circuit.runtime.presenter.presenterOf
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Pins the per-record retention lifecycle for first-party `retain {}` values in record content,
+ * with both the default animated decoration and EmptyDecoration:
+ * - pushing a screen saves the previous record's values instead of retiring them
+ * - popping back reclaims the same instance (no re-creation)
+ * - the popped record's values are retired
+ */
+@OptIn(ExperimentalCircuitRetainedApi::class)
+@RunWith(ComposeUiTestRunner::class)
+class FirstPartyRetainRecordLifecycleTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val events = mutableListOf<String>()
+
+  private inner class Tracked(val label: String) : RetainObserver {
+    override fun onRetained() {
+      events += "$label:retained"
+    }
+
+    override fun onEnteredComposition() {
+      events += "$label:entered"
+    }
+
+    override fun onExitedComposition() {
+      events += "$label:exited"
+    }
+
+    override fun onRetired() {
+      events += "$label:retired"
+    }
+
+    override fun onUnused() {
+      events += "$label:unused"
+    }
+  }
+
+  @After
+  fun tearDown() {
+    CircuitRetainedSettings.useFirstParty = false
+  }
+
+  @Test
+  fun perRecordRetentionLifecycleWithAnimatedDecoration() {
+    runScenario(useEmptyDecoration = false)
+  }
+
+  @Test
+  fun perRecordRetentionLifecycleWithEmptyDecoration() {
+    runScenario(useEmptyDecoration = true)
+  }
+
+  private fun runScenario(useEmptyDecoration: Boolean) {
+    CircuitRetainedSettings.useFirstParty = true
+    val circuit =
+      createTestCircuit(
+        presenter = { screen, navigator ->
+          val label = (screen as TestScreen).label
+          presenterOf {
+            retain {
+              events += "$label:create"
+              Tracked(label)
+            }
+            TestState(0, label) { event ->
+              when (event) {
+                TestEvent.GoToNextScreen -> navigator.goTo(TestScreen.ScreenB)
+                TestEvent.PopNavigation -> navigator.pop()
+                else -> Unit
+              }
+            }
+          }
+        }
+      )
+
+    composeTestRule.setContent {
+      CircuitCompositionLocals(circuit) {
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+        val navigator = rememberCircuitNavigator(backStack = backStack, onRootPop = {})
+        if (useEmptyDecoration) {
+          NavigableCircuitContent(
+            navigator = navigator,
+            backStack = backStack,
+            decoration = NavigatorDefaults.EmptyDecoration,
+          )
+        } else {
+          NavigableCircuitContent(navigator = navigator, backStack = backStack)
+        }
+      }
+    }
+
+    composeTestRule.onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+    composeTestRule.onNodeWithTag(TAG_GO_NEXT).performClick()
+    composeTestRule.onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+    composeTestRule.waitForIdle()
+
+    // A went to the back stack: its value must be saved, not retired.
+    assertThat(events).contains("A:exited")
+    assertThat(events).doesNotContain("A:retired")
+
+    composeTestRule.onNodeWithTag(TAG_POP).performClick()
+    composeTestRule.onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+    composeTestRule.waitForIdle()
+
+    // A was reclaimed, not recreated, and popped B was retired.
+    assertThat(events.count { it == "A:create" }).isEqualTo(1)
+    assertThat(events).doesNotContain("A:retired")
+    assertThat(events).contains("B:retired")
+  }
+}

--- a/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/FirstPartyRetainRecordLifecycleTest.kt
+++ b/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/FirstPartyRetainRecordLifecycleTest.kt
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.foundation
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.retain.RetainObserver
 import androidx.compose.runtime.retain.retain
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -19,6 +22,8 @@ import com.slack.circuit.internal.test.TestState
 import com.slack.circuit.internal.test.createTestCircuit
 import com.slack.circuit.retained.CircuitRetainedSettings
 import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.Navigator.StateOptions
 import com.slack.circuit.runtime.presenter.presenterOf
 import org.junit.After
 import org.junit.Rule
@@ -75,6 +80,57 @@ class FirstPartyRetainRecordLifecycleTest {
   @Test
   fun perRecordRetentionLifecycleWithEmptyDecoration() {
     runScenario(useEmptyDecoration = true)
+  }
+
+  @Test
+  fun savedRecordsSurviveUntilHostRetires() {
+    CircuitRetainedSettings.useFirstParty = true
+    lateinit var navigator: Navigator
+    val circuit =
+      createTestCircuit(
+        presenter = { screen, _ ->
+          val label = (screen as TestScreen).label
+          presenterOf {
+            retain {
+              events += "$label:create"
+              Tracked(label)
+            }
+            TestState(0, label) {}
+          }
+        }
+      )
+    var showHost by mutableStateOf(true)
+
+    composeTestRule.setContent {
+      if (showHost) {
+        CircuitCompositionLocals(circuit) {
+          val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+          navigator = rememberCircuitNavigator(backStack = backStack, onRootPop = {})
+          NavigableCircuitContent(navigator = navigator, backStack = backStack)
+        }
+      }
+    }
+
+    composeTestRule.onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+    composeTestRule.runOnIdle {
+      navigator.resetRoot(TestScreen.ScreenB, StateOptions.SaveAndRestore)
+    }
+    composeTestRule.onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+    composeTestRule.waitForIdle()
+    assertThat(events).doesNotContain("A:retired")
+
+    composeTestRule.runOnIdle {
+      navigator.resetRoot(TestScreen.ScreenA, StateOptions.SaveAndRestore)
+    }
+    composeTestRule.onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+    composeTestRule.waitForIdle()
+    assertThat(events.count { it == "A:create" }).isEqualTo(1)
+    assertThat(events).doesNotContain("A:retired")
+
+    composeTestRule.runOnIdle { showHost = false }
+    composeTestRule.waitForIdle()
+    assertThat(events.count { it == "A:retired" }).isEqualTo(1)
+    assertThat(events.count { it == "B:retired" }).isEqualTo(1)
   }
 
   private fun runScenario(useEmptyDecoration: Boolean) {

--- a/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainAndroidTest.kt
+++ b/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainAndroidTest.kt
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import com.slack.circuit.internal.test.TestContentTags.TAG_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_INCREASE_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import com.slack.circuit.retained.CircuitRetainedSettings
+import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Mirrors NavigableCircuitRetainedStateAndroidTest with first-party `retain {}` in the presenter
+ * and [CircuitRetainedSettings.useFirstParty] enabled: retained values are scoped per record,
+ * survive recreation while their record is in the nav stack, and are cleared when the record is
+ * popped.
+ */
+@OptIn(ExperimentalCircuitRetainedApi::class)
+@RunWith(ComposeUiTestRunner::class)
+class NavigableCircuitFirstPartyRetainAndroidTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<NavigableCircuitFirstPartyRetainTestActivity>()
+
+  private val scenario: ActivityScenario<NavigableCircuitFirstPartyRetainTestActivity>
+    get() = composeTestRule.activityRule.scenario
+
+  @After
+  fun tearDown() {
+    CircuitRetainedSettings.useFirstParty = false
+  }
+
+  @Test
+  fun retainScopedToBackstackWithRecreations() {
+    composeTestRule.run {
+      // Current: Screen A. Increase count to 1
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen C. Increase count to 1
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Pop to Screen B. Increase count from 1 to 2.
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Navigate to Screen C. Assert that its state was not retained after the pop
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("C")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+
+      // Pop to Screen B. Assert that its state was retained
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("2")
+
+      // Pop to Screen A. Assert that its state was retained
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Now recreate the Activity and assert that the values were retained
+      scenario.recreate()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Navigate to Screen B. Assert that its state was not retained after the pop
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("0")
+    }
+  }
+}

--- a/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainPushPopTest.kt
+++ b/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainPushPopTest.kt
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.slack.circuit.internal.test.TestContentTags.TAG_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_GO_NEXT
+import com.slack.circuit.internal.test.TestContentTags.TAG_INCREASE_COUNT
+import com.slack.circuit.internal.test.TestContentTags.TAG_LABEL
+import com.slack.circuit.internal.test.TestContentTags.TAG_POP
+import com.slack.circuit.retained.CircuitRetainedSettings
+import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Isolates push/pop (no recreation) for first-party retain scoped per record. */
+@OptIn(ExperimentalCircuitRetainedApi::class)
+@RunWith(ComposeUiTestRunner::class)
+class NavigableCircuitFirstPartyRetainPushPopTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<NavigableCircuitFirstPartyRetainTestActivity>()
+
+  @After
+  fun tearDown() {
+    CircuitRetainedSettings.useFirstParty = false
+  }
+
+  @Test
+  fun retainSurvivesPushAndPop() {
+    composeTestRule.run {
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_INCREASE_COUNT).performClick()
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+
+      // Push B, then pop back to A.
+      onNodeWithTag(TAG_GO_NEXT).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("B")
+      onNodeWithTag(TAG_POP).performClick()
+      onNodeWithTag(TAG_LABEL).assertTextEquals("A")
+      onNodeWithTag(TAG_COUNT).assertTextEquals("1")
+    }
+  }
+}

--- a/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainTestActivity.kt
+++ b/circuit-foundation/src/androidHostTest/kotlin/com/slack/circuit/foundation/NavigableCircuitFirstPartyRetainTestActivity.kt
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.internal.test.TestCountPresenter
+import com.slack.circuit.internal.test.TestScreen
+import com.slack.circuit.internal.test.createTestCircuit
+import com.slack.circuit.retained.CircuitRetainedSettings
+import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
+
+@OptIn(ExperimentalCircuitRetainedApi::class)
+class NavigableCircuitFirstPartyRetainTestActivity : ComponentActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    CircuitRetainedSettings.useFirstParty = true
+
+    val circuit = createTestCircuit(rememberType = TestCountPresenter.RememberType.FirstPartyRetain)
+
+    setContent {
+      CircuitCompositionLocals(circuit) {
+        val backStack = rememberSaveableBackStack(TestScreen.ScreenA)
+        val navigator =
+          rememberCircuitNavigator(
+            backStack = backStack,
+            onRootPop = {}, // no-op for tests
+          )
+        NavigableCircuitContent(navigator = navigator, backStack = backStack)
+      }
+    }
+  }
+}

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -49,11 +49,11 @@ import com.slack.circuit.foundation.animation.AnimatedNavDecoration
 import com.slack.circuit.foundation.animation.AnimatedNavDecorator
 import com.slack.circuit.foundation.animation.AnimatedNavEvent
 import com.slack.circuit.foundation.animation.AnimatedNavState
+import com.slack.circuit.foundation.internal.RecordRetainedValuesStores
+import com.slack.circuit.foundation.internal.RecordRetainedValuesStoresHolder
 import com.slack.circuit.foundation.navstack.ProvidedValues
 import com.slack.circuit.foundation.navstack.providedValuesForNavStack
 import com.slack.circuit.foundation.navstack.rememberSaveableNavStack
-import com.slack.circuit.foundation.internal.RecordRetainedValuesStores
-import com.slack.circuit.foundation.internal.RecordRetainedValuesStoresHolder
 import com.slack.circuit.retained.CircuitRetainedSettings
 import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
 import com.slack.circuit.retained.LocalRetainedStateRegistry
@@ -534,44 +534,44 @@ private fun <R : Record> createRecordContent(onActive: () -> Unit, onDispose: ()
 @Composable
 private fun <R : Record> RecordContent(record: R, contentProviderState: ContentProviderState<R>) {
   with(contentProviderState) {
-      saveableStateHolder.SaveableStateProvider(record.registryKey) {
-        // Provides a RetainedStateRegistry that is maintained independently for each record while
-        // the record exists in the back stack.
-        retainedStateHolder.RetainedStateProvider(record.registryKey) {
-          val lifecycle =
-            when (LocalRecordLifecycleState.current) {
-              RecordLifecycleState.Set -> LocalRecordLifecycle.current
-              RecordLifecycleState.Unset -> {
-                val isActive = lastNavigator.navStack.currentRecord == record
-                rememberUpdatedRecordLifecycle(isActive)
-              }
+    saveableStateHolder.SaveableStateProvider(record.registryKey) {
+      // Provides a RetainedStateRegistry that is maintained independently for each record while
+      // the record exists in the back stack.
+      retainedStateHolder.RetainedStateProvider(record.registryKey) {
+        val lifecycle =
+          when (LocalRecordLifecycleState.current) {
+            RecordLifecycleState.Set -> LocalRecordLifecycle.current
+            RecordLifecycleState.Unset -> {
+              val isActive = lastNavigator.navStack.currentRecord == record
+              rememberUpdatedRecordLifecycle(isActive)
             }
-          CompositionLocalProvider(
-            LocalRecordLifecycle provides lifecycle,
-            LocalRecordLifecycleState provides RecordLifecycleState.Set,
-          ) {
-            CircuitContent(
-              screen = record.screen,
-              navigator = lastNavigator,
-              circuit = lastCircuit,
-              unavailableContent = lastUnavailableRoute,
-              key = record.key,
-            )
           }
+        CompositionLocalProvider(
+          LocalRecordLifecycle provides lifecycle,
+          LocalRecordLifecycleState provides RecordLifecycleState.Set,
+        ) {
+          CircuitContent(
+            screen = record.screen,
+            navigator = lastNavigator,
+            circuit = lastCircuit,
+            unavailableContent = lastUnavailableRoute,
+            key = record.key,
+          )
         }
-        // Remove saved states for records that are no longer in the back stack.
-        // Keep this inside SaveableStateProvider so the active registry's state is saved and the
-        // registry is unregistered before this effect calls removeState().
-        // Otherwise a popped record could remain in the saved state map.
-        DisposableEffect(record.registryKey) {
-          onDispose {
-            if (!lastNavigator.navStack.containsRecord(record, includeSaved = true)) {
-              retainedStateHolder.removeState(record.registryKey)
-              saveableStateHolder.removeState(record.registryKey)
-            }
+      }
+      // Remove saved states for records that are no longer in the back stack.
+      // Keep this inside SaveableStateProvider so the active registry's state is saved and the
+      // registry is unregistered before this effect calls removeState().
+      // Otherwise a popped record could remain in the saved state map.
+      DisposableEffect(record.registryKey) {
+        onDispose {
+          if (!lastNavigator.navStack.containsRecord(record, includeSaved = true)) {
+            retainedStateHolder.removeState(record.registryKey)
+            saveableStateHolder.removeState(record.registryKey)
           }
         }
       }
+    }
   }
 }
 

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/NavigableCircuitContent.kt
@@ -34,6 +34,8 @@ import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.retain.LocalRetainedValuesStoreProvider
+import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
@@ -50,6 +52,10 @@ import com.slack.circuit.foundation.animation.AnimatedNavState
 import com.slack.circuit.foundation.navstack.ProvidedValues
 import com.slack.circuit.foundation.navstack.providedValuesForNavStack
 import com.slack.circuit.foundation.navstack.rememberSaveableNavStack
+import com.slack.circuit.foundation.internal.RecordRetainedValuesStores
+import com.slack.circuit.foundation.internal.RecordRetainedValuesStoresHolder
+import com.slack.circuit.retained.CircuitRetainedSettings
+import com.slack.circuit.retained.ExperimentalCircuitRetainedApi
 import com.slack.circuit.retained.LocalRetainedStateRegistry
 import com.slack.circuit.retained.RetainedStateHolder
 import com.slack.circuit.retained.rememberRetained
@@ -258,6 +264,17 @@ public fun <R : Record> NavigableCircuitContent(
   val outerKey = "_navigable_registry_${currentCompositeKeyHashCode.toString(MaxSupportedRadix)}"
   val outerRegistry = rememberRetainedStateRegistry(key = outerKey)
 
+  // When first-party retain is enabled, scope a RetainedValuesStore to each record so that
+  // retain {} calls inside record content get per-record lifetimes. Hosted here, outside any
+  // movableContentOf, so the registry's own retain slot has a stable position.
+  @OptIn(ExperimentalCircuitRetainedApi::class)
+  val recordRetainedValuesStores =
+    if (CircuitRetainedSettings.useFirstParty) {
+      retain { RecordRetainedValuesStoresHolder() }.stores
+    } else {
+      null
+    }
+
   val navDecoration =
     remember(decoration, decoratorFactory) {
       // User specified decorator takes precedence over a default decoration.
@@ -275,7 +292,7 @@ public fun <R : Record> NavigableCircuitContent(
     val saveableStateHolder = rememberSaveableStateHolder()
     val retainedStateHolder = rememberRetainedStateHolder()
     val contentProviderState =
-      remember(saveableStateHolder, retainedStateHolder) {
+      remember(saveableStateHolder, retainedStateHolder, recordRetainedValuesStores) {
           ContentProviderState(
             saveableStateHolder = saveableStateHolder,
             retainedStateHolder = retainedStateHolder,
@@ -288,6 +305,7 @@ public fun <R : Record> NavigableCircuitContent(
           lastNavigator = navigator
           lastCircuit = circuit
           lastUnavailableRoute = unavailableRoute
+          recordRetainedStores = recordRetainedValuesStores
         }
     val activeContentProviders =
       buildCircuitContentProviders(navStack = navigator.navStack) ?: return@CompositionLocalProvider
@@ -461,6 +479,7 @@ public class ContentProviderState<R : Record>(
   internal var lastNavigator by mutableStateOf(navigator)
   internal var lastCircuit by mutableStateOf(circuit)
   internal var lastUnavailableRoute by mutableStateOf(unavailableRoute)
+  internal var recordRetainedStores: RecordRetainedValuesStores? = null
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -483,6 +502,38 @@ public class ContentProviderState<R : Record>(
 private fun <R : Record> createRecordContent(onActive: () -> Unit, onDispose: () -> Unit) =
   movableContentOf<R, ContentProviderState<R>> { record, contentProviderState ->
     with(contentProviderState) {
+      val stores = recordRetainedStores
+      if (stores != null) {
+        // Clear the record's first-party store once the record permanently leaves the nav stack.
+        // Registered before the store provider below so its onDispose runs after the record
+        // content has torn down.
+        DisposableEffect(record.registryKey) {
+          onDispose {
+            if (!lastNavigator.navStack.containsRecord(record, includeSaved = true)) {
+              stores.clear(record.registryKey)
+            }
+          }
+        }
+      }
+      val body: @Composable () -> Unit = { RecordContent(record, contentProviderState) }
+      if (stores != null) {
+        // Scope retain {} calls within the record's content to the record itself.
+        LocalRetainedValuesStoreProvider(stores.storeFor(record.registryKey), body)
+      } else {
+        body()
+      }
+    }
+    // Track if the movableContent is still active to correctly reuse it and not create a new one.
+    DisposableEffect(Unit) {
+      onActive()
+      onDispose { onDispose() }
+    }
+  }
+
+@OptIn(ExperimentalCircuitApi::class)
+@Composable
+private fun <R : Record> RecordContent(record: R, contentProviderState: ContentProviderState<R>) {
+  with(contentProviderState) {
       saveableStateHolder.SaveableStateProvider(record.registryKey) {
         // Provides a RetainedStateRegistry that is maintained independently for each record while
         // the record exists in the back stack.
@@ -521,13 +572,8 @@ private fun <R : Record> createRecordContent(onActive: () -> Unit, onDispose: ()
           }
         }
       }
-    }
-    // Track if the movableContent is still active to correctly reuse it and not create a new one.
-    DisposableEffect(Unit) {
-      onActive()
-      onDispose { onDispose() }
-    }
   }
+}
 
 /** The maximum radix available for conversion to and from strings. */
 private const val MaxSupportedRadix = 36

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStores.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStores.kt
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation.internal
+
+import androidx.compose.runtime.retain.RetainObserver
+import androidx.compose.runtime.retain.RetainedValuesStore
+
+/**
+ * A registry of per-record [RetainedValuesStore]s backing first-party `retain {}` calls inside
+ * navigation record content.
+ *
+ * This intentionally does not use `RetainedValuesStoreRegistry`/`ManagedRetainedValuesStore`.
+ * Those gate saving exited values on the content-presence indicator having already flipped the
+ * store out of its composed state, and that ordering inverts when record content leaves
+ * composition through an animated decorator's `AnimatedContent` pane: the record's retained value
+ * holders are forgotten before the indicator runs, so values are retired instead of saved.
+ *
+ * A record store instead keeps every exiting value unconditionally. Record content only leaves
+ * composition when the record goes off-screen or the composition is torn down, and both cases
+ * want retention. Unclaimed values are retired when the record's content next settles back into
+ * composition, and everything is retired when the record leaves the nav stack ([clear]) or the
+ * registry itself is retired ([dispose]).
+ */
+/** Retainable holder that disposes the registry when the retain system retires it. */
+internal class RecordRetainedValuesStoresHolder : RetainObserver {
+  val stores = RecordRetainedValuesStores()
+
+  override fun onRetained() {}
+
+  override fun onEnteredComposition() {}
+
+  override fun onExitedComposition() {}
+
+  override fun onRetired() = stores.dispose()
+
+  override fun onUnused() = stores.dispose()
+}
+
+internal class RecordRetainedValuesStores {
+  private val stores = mutableMapOf<String, RecordRetainedValuesStore>()
+
+  fun storeFor(key: String): RetainedValuesStore = stores.getOrPut(key) { RecordRetainedValuesStore() }
+
+  fun clear(key: String) {
+    stores.remove(key)?.retireAll()
+  }
+
+  fun dispose() {
+    stores.values.forEach { it.retireAll() }
+    stores.clear()
+  }
+}
+
+private class RecordRetainedValuesStore : RetainedValuesStore {
+  // Multiple values can be saved under one key (like movable content copies); restored LIFO to
+  // mirror ManagedRetainedValuesStore's SafeMultiValueMap semantics.
+  private val exitedValues = mutableMapOf<Any, MutableList<Any?>>()
+  // Tolerates transient double-installation during interrupted transitions, where a record's
+  // content can briefly compose in two decorator panes.
+  private var compositionCount = 0
+
+  override fun consumeExitedValueOrDefault(key: Any, defaultValue: Any?): Any? {
+    val values = exitedValues[key] ?: return defaultValue
+    val value = values.removeAt(values.lastIndex)
+    if (values.isEmpty()) exitedValues.remove(key)
+    return value
+  }
+
+  override fun saveExitingValue(key: Any, value: Any?) {
+    exitedValues.getOrPut(key) { mutableListOf() }.add(value)
+  }
+
+  override fun onContentEnteredComposition() {
+    // Fires at frame end, after re-entering content has already consumed the values it claims.
+    // Anything left is no longer referenced by the record's content.
+    if (compositionCount++ == 0) {
+      retireAll()
+    }
+  }
+
+  override fun onContentExitComposition() {
+    if (compositionCount > 0) compositionCount--
+  }
+
+  fun retireAll() {
+    if (exitedValues.isEmpty()) return
+    val values = exitedValues.values.flatten()
+    exitedValues.clear()
+    values.forEach { (it as? RetainObserver)?.onRetired() }
+  }
+}

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStores.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStores.kt
@@ -6,22 +6,6 @@ import androidx.compose.runtime.retain.ForgetfulRetainedValuesStore
 import androidx.compose.runtime.retain.RetainObserver
 import androidx.compose.runtime.retain.RetainedValuesStore
 
-/**
- * A registry of per-record [RetainedValuesStore]s backing first-party `retain {}` calls inside
- * navigation record content.
- *
- * This intentionally does not use `RetainedValuesStoreRegistry`/`ManagedRetainedValuesStore`. Those
- * gate saving exited values on the content-presence indicator having already flipped the store out
- * of its composed state, and that ordering inverts when record content leaves composition through
- * an animated decorator's `AnimatedContent` pane: the record's retained value holders are forgotten
- * before the indicator runs, so values are retired instead of saved.
- *
- * A record store instead keeps every exiting value unconditionally. Record content only leaves
- * composition when the record goes off-screen or the composition is torn down, and both cases want
- * retention. Unclaimed values are retired when the record's content next settles back into
- * composition, and everything is retired when the record leaves the nav stack ([clear]) or the
- * registry itself is retired ([dispose]).
- */
 /** Retainable holder that disposes the registry when the retain system retires it. */
 internal class RecordRetainedValuesStoresHolder : RetainObserver {
   val stores = RecordRetainedValuesStores()
@@ -37,6 +21,23 @@ internal class RecordRetainedValuesStoresHolder : RetainObserver {
   override fun onUnused() = stores.dispose()
 }
 
+/**
+ * A registry of per-record [RetainedValuesStore]s backing first-party `retain {}` calls inside
+ * navigation record content.
+ *
+ * This intentionally does not use `RetainedValuesStoreRegistry`/`ManagedRetainedValuesStore`. Those
+ * gate saving exited values on the content-presence indicator having already flipped the store out
+ * of its composed state, and that ordering inverts when record content leaves composition through
+ * an animated decorator's `AnimatedContent` pane: the record's retained value holders are forgotten
+ * before the indicator runs, so values are retired instead of saved. See
+ * [Compose issue 533778695](https://issuetracker.google.com/issues/533778695).
+ *
+ * A record store instead keeps every exiting value unconditionally. Record content only leaves
+ * composition when the record goes off-screen or the composition is torn down, and both cases want
+ * retention. Unclaimed values are retired when the record's content next settles back into
+ * composition, and everything is retired when the record leaves the nav stack ([clear]) or the
+ * registry itself is retired ([dispose]).
+ */
 internal class RecordRetainedValuesStores {
   private val stores = mutableMapOf<String, RecordRetainedValuesStore>()
   private var isDisposed = false

--- a/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStores.kt
+++ b/circuit-foundation/src/commonMain/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStores.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.slack.circuit.foundation.internal
 
+import androidx.compose.runtime.retain.ForgetfulRetainedValuesStore
 import androidx.compose.runtime.retain.RetainObserver
 import androidx.compose.runtime.retain.RetainedValuesStore
 
@@ -9,15 +10,15 @@ import androidx.compose.runtime.retain.RetainedValuesStore
  * A registry of per-record [RetainedValuesStore]s backing first-party `retain {}` calls inside
  * navigation record content.
  *
- * This intentionally does not use `RetainedValuesStoreRegistry`/`ManagedRetainedValuesStore`.
- * Those gate saving exited values on the content-presence indicator having already flipped the
- * store out of its composed state, and that ordering inverts when record content leaves
- * composition through an animated decorator's `AnimatedContent` pane: the record's retained value
- * holders are forgotten before the indicator runs, so values are retired instead of saved.
+ * This intentionally does not use `RetainedValuesStoreRegistry`/`ManagedRetainedValuesStore`. Those
+ * gate saving exited values on the content-presence indicator having already flipped the store out
+ * of its composed state, and that ordering inverts when record content leaves composition through
+ * an animated decorator's `AnimatedContent` pane: the record's retained value holders are forgotten
+ * before the indicator runs, so values are retired instead of saved.
  *
  * A record store instead keeps every exiting value unconditionally. Record content only leaves
- * composition when the record goes off-screen or the composition is torn down, and both cases
- * want retention. Unclaimed values are retired when the record's content next settles back into
+ * composition when the record goes off-screen or the composition is torn down, and both cases want
+ * retention. Unclaimed values are retired when the record's content next settles back into
  * composition, and everything is retired when the record leaves the nav stack ([clear]) or the
  * registry itself is retired ([dispose]).
  */
@@ -38,16 +39,26 @@ internal class RecordRetainedValuesStoresHolder : RetainObserver {
 
 internal class RecordRetainedValuesStores {
   private val stores = mutableMapOf<String, RecordRetainedValuesStore>()
+  private var isDisposed = false
 
-  fun storeFor(key: String): RetainedValuesStore = stores.getOrPut(key) { RecordRetainedValuesStore() }
+  fun storeFor(key: String): RetainedValuesStore =
+    if (isDisposed) {
+      // Content can still request its store while the retained holder and its children tear down.
+      ForgetfulRetainedValuesStore
+    } else {
+      stores.getOrPut(key) { RecordRetainedValuesStore() }
+    }
 
   fun clear(key: String) {
-    stores.remove(key)?.retireAll()
+    stores.remove(key)?.dispose()
   }
 
   fun dispose() {
-    stores.values.forEach { it.retireAll() }
+    if (isDisposed) return
+    isDisposed = true
+    val storesToDispose = stores.values.toList()
     stores.clear()
+    storesToDispose.forEach { it.dispose() }
   }
 }
 
@@ -58,8 +69,10 @@ private class RecordRetainedValuesStore : RetainedValuesStore {
   // Tolerates transient double-installation during interrupted transitions, where a record's
   // content can briefly compose in two decorator panes.
   private var compositionCount = 0
+  private var isDisposed = false
 
   override fun consumeExitedValueOrDefault(key: Any, defaultValue: Any?): Any? {
+    if (isDisposed) return defaultValue
     val values = exitedValues[key] ?: return defaultValue
     val value = values.removeAt(values.lastIndex)
     if (values.isEmpty()) exitedValues.remove(key)
@@ -67,22 +80,35 @@ private class RecordRetainedValuesStore : RetainedValuesStore {
   }
 
   override fun saveExitingValue(key: Any, value: Any?) {
-    exitedValues.getOrPut(key) { mutableListOf() }.add(value)
+    if (isDisposed) {
+      (value as? RetainObserver)?.onRetired()
+    } else {
+      exitedValues.getOrPut(key) { mutableListOf() }.add(value)
+    }
   }
 
   override fun onContentEnteredComposition() {
+    if (isDisposed) return
     // Fires at frame end, after re-entering content has already consumed the values it claims.
     // Anything left is no longer referenced by the record's content.
     if (compositionCount++ == 0) {
-      retireAll()
+      retireExitedValues()
     }
   }
 
   override fun onContentExitComposition() {
+    if (isDisposed) return
     if (compositionCount > 0) compositionCount--
   }
 
-  fun retireAll() {
+  fun dispose() {
+    if (isDisposed) return
+    isDisposed = true
+    compositionCount = 0
+    retireExitedValues()
+  }
+
+  private fun retireExitedValues() {
     if (exitedValues.isEmpty()) return
     val values = exitedValues.values.flatten()
     exitedValues.clear()

--- a/circuit-foundation/src/commonTest/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStoresTest.kt
+++ b/circuit-foundation/src/commonTest/kotlin/com/slack/circuit/foundation/internal/RecordRetainedValuesStoresTest.kt
@@ -1,0 +1,163 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package com.slack.circuit.foundation.internal
+
+import androidx.compose.runtime.retain.RetainObserver
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+class RecordRetainedValuesStoresTest {
+
+  @Test
+  fun duplicateKeysAreConsumedInLifoOrder() {
+    val store = RecordRetainedValuesStores().storeFor("record")
+    val first = Any()
+    val second = Any()
+
+    store.saveExitingValue("value", first)
+    store.saveExitingValue("value", second)
+
+    assertSame(second, store.consumeExitedValueOrDefault("value", null))
+    assertSame(first, store.consumeExitedValueOrDefault("value", null))
+    assertSame(Missing, store.consumeExitedValueOrDefault("value", Missing))
+  }
+
+  @Test
+  fun enteringCompositionRetiresUnclaimedValues() {
+    val store = RecordRetainedValuesStores().storeFor("record")
+    val claimed = TrackingRetainObserver()
+    val unclaimed = TrackingRetainObserver()
+    store.saveExitingValue("claimed", claimed)
+    store.saveExitingValue("unclaimed", unclaimed)
+
+    assertSame(claimed, store.consumeExitedValueOrDefault("claimed", null))
+    store.onContentEnteredComposition()
+
+    assertEquals(0, claimed.retiredCount)
+    assertEquals(1, unclaimed.retiredCount)
+  }
+
+  @Test
+  fun additionalCompositionDefersCleanupUntilAllInstallationsExit() {
+    val store = RecordRetainedValuesStores().storeFor("record")
+    store.onContentEnteredComposition()
+    store.onContentEnteredComposition()
+    store.onContentExitComposition()
+    val value = TrackingRetainObserver()
+    store.saveExitingValue("value", value)
+
+    store.onContentEnteredComposition()
+
+    assertEquals(0, value.retiredCount)
+    store.onContentExitComposition()
+    store.onContentExitComposition()
+    store.onContentEnteredComposition()
+    assertEquals(1, value.retiredCount)
+  }
+
+  @Test
+  fun clearRetiresSavedValuesExactlyOnce() {
+    val stores = RecordRetainedValuesStores()
+    val store = stores.storeFor("record")
+    val value = TrackingRetainObserver()
+    store.saveExitingValue("value", value)
+
+    stores.clear("record")
+    stores.clear("record")
+
+    assertEquals(1, value.retiredCount)
+    assertSame(Missing, store.consumeExitedValueOrDefault("value", Missing))
+  }
+
+  @Test
+  fun saveAfterClearRetiresValueInsteadOfKeepingIt() {
+    val stores = RecordRetainedValuesStores()
+    val store = stores.storeFor("record")
+    stores.clear("record")
+    val value = TrackingRetainObserver()
+
+    store.onContentExitComposition()
+    store.onContentEnteredComposition()
+    store.saveExitingValue("value", value)
+
+    assertEquals(1, value.retiredCount)
+    assertSame(Missing, store.consumeExitedValueOrDefault("value", Missing))
+  }
+
+  @Test
+  fun clearAllowsFreshStoreForSameRecord() {
+    val stores = RecordRetainedValuesStores()
+    val oldStore = stores.storeFor("record")
+    stores.clear("record")
+
+    val newStore = stores.storeFor("record")
+    val value = Any()
+    newStore.saveExitingValue("value", value)
+
+    assertNotSame(oldStore, newStore)
+    assertSame(value, newStore.consumeExitedValueOrDefault("value", null))
+  }
+
+  @Test
+  fun disposeRetiresValuesAcrossRecordsExactlyOnce() {
+    val stores = RecordRetainedValuesStores()
+    val first = TrackingRetainObserver()
+    val second = TrackingRetainObserver()
+    stores.storeFor("first").saveExitingValue("value", first)
+    stores.storeFor("second").saveExitingValue("value", second)
+
+    stores.dispose()
+    stores.dispose()
+
+    assertEquals(1, first.retiredCount)
+    assertEquals(1, second.retiredCount)
+  }
+
+  @Test
+  fun saveAfterDisposeRetiresValueInsteadOfKeepingIt() {
+    val stores = RecordRetainedValuesStores()
+    val store = stores.storeFor("record")
+    stores.dispose()
+    val value = TrackingRetainObserver()
+
+    store.saveExitingValue("value", value)
+
+    assertEquals(1, value.retiredCount)
+    assertSame(Missing, store.consumeExitedValueOrDefault("value", Missing))
+  }
+
+  @Test
+  fun storeRequestedAfterDisposeIsForgetful() {
+    val stores = RecordRetainedValuesStores()
+    stores.dispose()
+    val store = stores.storeFor("record")
+    val value = TrackingRetainObserver()
+
+    store.saveExitingValue("value", value)
+
+    assertEquals(1, value.retiredCount)
+    assertSame(Missing, store.consumeExitedValueOrDefault("value", Missing))
+  }
+
+  private class TrackingRetainObserver : RetainObserver {
+    var retiredCount = 0
+
+    override fun onRetained() {}
+
+    override fun onEnteredComposition() {}
+
+    override fun onExitedComposition() {}
+
+    override fun onRetired() {
+      retiredCount++
+    }
+
+    override fun onUnused() {}
+  }
+
+  private companion object {
+    val Missing = Any()
+  }
+}

--- a/circuit-retained/README.md
+++ b/circuit-retained/README.md
@@ -39,11 +39,11 @@ With the flag enabled, `lifecycleRetainedStateRegistry()` is backed by a single 
 
 The flag is experimental (`@ExperimentalCircuitRetainedApi`) and currently affects the targets that have the ViewModel-backed registry (Android, JVM, iOS, macOS, web).
 
-First-party `retain {}` calls also work correctly inside Circuit content today and can be used side by side with `rememberRetained`.
+With the flag enabled, `NavigableCircuitContent` also scopes a `RetainedValuesStore` to each nav record, so first-party `retain {}` calls inside presenters and UIs get per-record lifetimes side by side with `rememberRetained`: values survive while their record is in the nav stack (including across configuration changes) and are retired when the record is popped.
 
 ### Migration Plan
 
-The opt-in backing above is the current phase and swaps only the retention transport, with no API changes. The next phase scopes first-party stores per record in `NavigableCircuitContent` so `retain {}` gets correct per-record lifetimes, and steers new unkeyed, non-saveable usages toward `retain {}`.
+The opt-in flag above swaps the retention transport and scopes `retain {}` per record, with no API changes. From here, new unkeyed, non-saveable usages can prefer `retain {}` directly.
 
 Once the backing has soaked, APIs with direct first-party equivalents will be deprecated with replacements, like plain `rememberRetained {}` → `retain {}` and `rememberRetainedStateRegistry` → `retainManagedRetainedValuesStore`.
 
@@ -65,3 +65,5 @@ A reference implementation with retention-lifecycle forwarding and composition-r
 val store = retain { RetainedStore<ChatId, ChatController>() }
 val controller = store.rememberRetainedEntry(chatId) { ChatController(it) }
 ```
+
+Despite the similar name, this is unrelated to the per-record `RetainedValuesStore` scoping in `NavigableCircuitContent`. That is an internal implementation of the retain runtime's store interface for scoping, while `RetainedStore` is a user-facing container for keying your own values within whatever scope you retain it in.

--- a/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CircuitRetainedSettings.kt
+++ b/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/CircuitRetainedSettings.kt
@@ -13,6 +13,11 @@ public object CircuitRetainedSettings {
    * Circuit-managed `ViewModel`. Retention is then driven by the `RetainedValuesStore` installed in
    * the composition, such as the lifecycle-aware store Compose UI installs on Android.
    *
+   * This also enables per-record scoping of first-party `retain {}` calls inside
+   * `NavigableCircuitContent`: values retained by a record's content survive while the record is in
+   * the nav stack (including across configuration changes) and are retired when the record is
+   * popped.
+   *
    * Set this before the first composition. It is not a runtime toggle, registries created under one
    * backing do not migrate their state to the other.
    *

--- a/internal-test-utils/src/commonMain/kotlin/com/slack/circuit/internal/test/TestContent.kt
+++ b/internal-test-utils/src/commonMain/kotlin/com/slack/circuit/internal/test/TestContent.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -158,6 +159,9 @@ class TestCountPresenter(
         RememberType.ViewModel -> {
           rememberViewModel("count".takeIf { useKeys })
         }
+        RememberType.FirstPartyRetain -> {
+          retain { mutableIntStateOf(0) }
+        }
       }
 
     return TestState(count, screen.label) { event ->
@@ -202,6 +206,7 @@ class TestCountPresenter(
     Retained,
     Saveable,
     ViewModel,
+    FirstPartyRetain,
   }
 }
 


### PR DESCRIPTION
This is mostly just a few followups from the first PR with fixes for per-record scoping and better tests, plus filed an issue upstream issue for the original movablecontent + animatedcontent issue I saw before: https://issuetracker.google.com/issues/533778695

Our workaround works for now at least so I think we're good to continue with this move