### PR TITLE
Fix code gen docs render of supported DI framework list

### DIFF
--- a/docs/docs/code-gen.md
+++ b/docs/docs/code-gen.md
@@ -17,6 +17,7 @@ dependencies {
 ```
 
 Currently supported types are:
+
 - [Anvil](https://github.com/square/anvil) and [Anvil KSP](https://github.com/zacsweers/anvil)
 - [Dagger/Hilt](https://dagger.dev/hilt/)
 - [kotlin-inject](https://github.com/evant/kotlin-inject) + [kotlin-inject-anvil](https://github.com/amzn/kotlin-inject-anvil)


### PR DESCRIPTION
The supported DI frameworks list in the docs is a bit hard to read (see image). Seems there is a new line that's missing in the markdown. 

<img width="1138" height="585" alt="image" src="https://github.com/user-attachments/assets/61dfe83f-1da4-44da-aba1-fd9e0f6b226c" />

